### PR TITLE
feat: batch prompt knowledge updates

### DIFF
--- a/.squad/decisions/inbox/bender-oidc-secrets-convention.md
+++ b/.squad/decisions/inbox/bender-oidc-secrets-convention.md
@@ -1,0 +1,23 @@
+# Decision: OIDC credentials use `secrets.*` not `vars.*`
+
+**Date:** 2026-04-10
+**Author:** Bender
+**Context:** PR #65 review by @copilot
+
+## Decision
+
+All references to AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID
+in prompt knowledge, workflow generators, and documentation MUST use
+`${{ secrets.* }}` — NOT `${{ vars.* }}`.
+
+## Rationale
+
+The existing codebase (deploy-infra.yml, github-actions.ts generator,
+demo-scenarios.ts, docs/deployment.md) uniformly uses `secrets.*` for these
+values. While GitHub supports both `vars` and `secrets`, mixing them causes
+inconsistent generated workflows and confuses the LLM. One convention, enforced
+everywhere.
+
+## Scope
+
+Prompt knowledge (kits), workflow generators, documentation, demo scenarios.

--- a/packages/core/src/kits/azure-kit.ts
+++ b/packages/core/src/kits/azure-kit.ts
@@ -58,6 +58,24 @@ export const azureKit: IntegrationKit = {
     // Deployment safeguards
     'Never expose Kubernetes YAML or kubectl commands directly to the user. Translate all infrastructure ' +
     'operations into plain-language deployment steps. K8s complexity is hidden behind AKS Automatic.',
+
+    // KAITO (Kubernetes AI Toolchain Operator)
+    'When the user wants to run AI/ML workloads (open-source LLMs, inference, fine-tuning), recommend the ' +
+    'KAITO add-on for AKS. KAITO automates GPU node provisioning, downloads model images from the KAITO model ' +
+    'registry, and deploys inference endpoints — users only write a Workspace CRD specifying the model name ' +
+    '(e.g. falcon-7b, llama-2-13b, mistral-7b, phi-3). KAITO supports preset models and custom model imports.',
+
+    // RAGEngine
+    'For retrieval-augmented generation (RAG) scenarios, recommend RAGEngine — an AKS add-on that pairs with KAITO. ' +
+    'RAGEngine manages the end-to-end RAG pipeline: document ingestion, embedding generation, vector store indexing ' +
+    '(Azure AI Search or in-cluster FAISS), and query-time retrieval + LLM completion. Users define a RAGEngine CRD ' +
+    'referencing their KAITO Workspace and a document source (Azure Blob, Git repo, or inline).',
+
+    // Fine-tuning
+    'KAITO supports fine-tuning open-source models on AKS GPU nodes. Users specify a Workspace CRD with ' +
+    'tuning.method (LoRA or QLoRA), a training dataset (Azure Blob or HuggingFace), and hyperparameters. ' +
+    'KAITO handles checkpoint management, GPU scheduling, and model export. Fine-tuned models can be served ' +
+    'immediately as a KAITO inference Workspace or pushed to ACR as a custom model image.',
   ],
 
   phasePrompts: {
@@ -72,6 +90,9 @@ export const azureKit: IntegrationKit = {
       'Recommend managed Azure services: Azure Database for PostgreSQL, Azure Cache for Redis, Azure Service Bus, Azure AI Search. ' +
       'Use azure_resource_list to discover existing resources before proposing new ones. ' +
       'Present the architecture with ArchitectureDiagram + CostEstimate using estimate_cost tool output.',
+      'For AI/ML workloads: recommend KAITO add-on for model inference (GPU node provisioning is automatic), ' +
+      'RAGEngine for RAG pipelines, and KAITO fine-tuning for custom model training. ' +
+      'Include GPU node pool costs in the estimate_cost breakdown when KAITO is part of the architecture.',
     ],
 
     [Phase.Generate]: [
@@ -81,7 +102,12 @@ export const azureKit: IntegrationKit = {
       '  • ACR integration: AcrPull role binding for kubelet (never imagePullSecrets)\n' +
       '  • HPA: min 2 replicas, max 10, CPU threshold 70%\n' +
       '  • PDB: minAvailable 1\n' +
-      'Do NOT set dnsPrefix, networkProfile, or nodeResourceGroup on the AKS Automatic cluster resource.',
+      'Do NOT set dnsPrefix, networkProfile, or nodeResourceGroup on the AKS Automatic cluster resource.\n' +
+      'For AI/ML workloads with KAITO:\n' +
+      '  • Generate a Workspace CRD (apiVersion: kaito.sh/v1alpha1, kind: Workspace) with the model preset name\n' +
+      '  • Set resource.instanceType to the appropriate GPU VM size (e.g. Standard_NC12s_v3 for 7B models)\n' +
+      '  • For RAG: generate a RAGEngine CRD referencing the KAITO Workspace and document source\n' +
+      '  • For fine-tuning: set tuning.method (lora/qlora), tuning.input (dataset source), and tuning.output',
     ],
 
     [Phase.Review]: [
@@ -92,8 +118,11 @@ export const azureKit: IntegrationKit = {
 
     [Phase.Handoff]: [
       'After code is pushed to GitHub, remind the user that the GitHub Actions workflow will deploy ' +
-      'automatically on every push to the default branch. No manual Azure steps needed. ' +
-      'The workflow uses OIDC Workload Identity — no secrets to configure.',
+      'automatically on every push to the default branch. No manual Azure steps needed beyond initial OIDC setup. ' +
+      'The workflow uses OIDC Workload Identity Federation — this eliminates long-lived secrets but still requires ' +
+      'one-time setup: an Entra app registration (or User-Assigned Managed Identity) with a federated credential ' +
+      'for the GitHub repo, and three GitHub repository variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID). ' +
+      'Guide the user through this setup if it has not been done yet.',
     ],
 
     [Phase.Deploy]: [
@@ -106,11 +135,21 @@ export const azureKit: IntegrationKit = {
   components: [
     {
       type: 'azureLoginCard',
-      description: 'MSAL sign-in card with automatic subscription selection',
+      description:
+        'MSAL sign-in card with automatic subscription selection.\n' +
+        'Props:\n' +
+        '  - displayName (optional string): Display name shown on the avatar and user info. Defaults to "Azure User".\n' +
+        '  - onSignIn (optional action): Callback fired after successful MSAL sign-in.\n' +
+        '  - onSignOut (optional action): Callback fired when the user signs out.',
     },
     {
       type: 'azureResourcePicker',
-      description: 'Dropdown populated from ARM API at render time (regions, resource groups, SKUs)',
+      description:
+        'Dropdown populated from ARM API at render time (regions, resource groups, SKUs).\n' +
+        'Props:\n' +
+        '  - subscriptionId (optional string): Azure subscription ID to list resources from. Falls back to a stub if omitted.\n' +
+        '  - label (optional string): Header text above the resource list. Defaults to "Select an Azure resource".\n' +
+        '  - onSelect (optional action): Callback fired when the user selects a resource.',
     },
   ],
 };

--- a/packages/core/src/kits/azure-kit.ts
+++ b/packages/core/src/kits/azure-kit.ts
@@ -15,7 +15,7 @@
  *
  * Component registrations (rendered by packages/web):
  *   - azureLoginCard       (MSAL sign-in card with subscription auto-select)
- *   - azureResourcePicker  (dropdown populated from ARM at render time)
+ *   - azureResourcePicker  (selectable card list populated from ARM at render time)
  */
 
 import type { IntegrationKit } from './types.js';
@@ -121,7 +121,7 @@ export const azureKit: IntegrationKit = {
       'automatically on every push to the default branch. No manual Azure steps needed beyond initial OIDC setup. ' +
       'The workflow uses OIDC Workload Identity Federation — this eliminates long-lived secrets but still requires ' +
       'one-time setup: an Entra app registration (or User-Assigned Managed Identity) with a federated credential ' +
-      'for the GitHub repo, and three GitHub repository variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID). ' +
+      'for the GitHub repo, and three GitHub repository secrets (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID). ' +
       'Guide the user through this setup if it has not been done yet.',
     ],
 
@@ -145,7 +145,7 @@ export const azureKit: IntegrationKit = {
     {
       type: 'azureResourcePicker',
       description:
-        'Dropdown populated from ARM API at render time (regions, resource groups, SKUs).\n' +
+        'Selectable card list populated from ARM API at render time (resource names, types, groups, locations).\n' +
         'Props:\n' +
         '  - subscriptionId (optional string): Azure subscription ID to list resources from. Falls back to a stub if omitted.\n' +
         '  - label (optional string): Header text above the resource list. Defaults to "Select an Azure resource".\n' +

--- a/packages/core/src/kits/github-kit.ts
+++ b/packages/core/src/kits/github-kit.ts
@@ -42,11 +42,23 @@ export const githubKit: IntegrationKit = {
     // CI/CD wiring
     'When generating deployment artifacts, always include a GitHub Actions workflow (.github/workflows/deploy.yml) ' +
     'that builds the container image, pushes to ACR, and triggers a rolling update on AKS. ' +
-    'The workflow should use OIDC Workload Identity — never hardcode credentials.',
+    'The workflow should use OIDC Workload Identity Federation — never hardcode credentials. ' +
+    'OIDC eliminates secret rotation but requires one-time setup of Azure credentials as GitHub repository variables.',
 
     // Branch strategy
     'Recommend a trunk-based deployment strategy: pushes to the default branch trigger production deploys. ' +
     'Pull requests trigger preview environment deploys on a separate AKS namespace.',
+
+    // OIDC pipeline setup protocol
+    'When setting up the CI/CD pipeline for the first time, guide the user through OIDC federation setup:\n' +
+    '  1. Create an Entra app registration (or User-Assigned Managed Identity) in the target Azure tenant.\n' +
+    '  2. Add a federated credential: issuer "https://token.actions.githubusercontent.com", ' +
+    'subject "repo:{owner}/{repo}:ref:refs/heads/{default_branch}" (and optionally for pull_request).\n' +
+    '  3. Grant the app/identity the required Azure RBAC roles (Contributor on the resource group, AcrPush on the ACR).\n' +
+    '  4. Set three GitHub repository variables: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID.\n' +
+    '  5. The deploy.yml workflow uses `azure/login@v2` with `client-id`, `tenant-id`, `subscription-id` from those variables.\n' +
+    'This replaces service principal client secrets with short-lived, scope-limited OIDC tokens. ' +
+    'No secret rotation is needed. The federated credential is scoped to the specific repo and branch.',
   ],
 
   phasePrompts: {
@@ -65,18 +77,23 @@ export const githubKit: IntegrationKit = {
     [Phase.Generate]: [
       'Generate a GitHub Actions workflow at .github/workflows/deploy.yml. It must:\n' +
       '  • Trigger on push to the default branch and on pull_request\n' +
-      '  • Build and push the container image to ACR using OIDC (azure/login@v2 + workload identity)\n' +
+      '  • Use `azure/login@v2` with OIDC: read client-id, tenant-id, subscription-id from GitHub vars\n' +
+      '  • Set `permissions: { id-token: write, contents: read }` for OIDC token issuance\n' +
+      '  • Build and push the container image to ACR\n' +
       '  • Run `az aks get-credentials` then apply deployment files\n' +
       '  • Never hardcode Azure credentials, subscription IDs, or tokens in the workflow file\n' +
-      'Use github_repo_info to confirm the default branch name before generating.',
+      'Use github_repo_info to confirm the default branch name before generating.\n' +
+      'If OIDC is not yet configured, prompt the user to set up federated credentials (see OIDC setup protocol).',
     ],
 
     [Phase.Handoff]: [
       'Walk the user through getting their generated files into GitHub:\n' +
       '  1. Ask: new repo or push to existing? Use ChoicePicker.\n' +
       '  2. Show AuthCard for GitHub sign-in if needed.\n' +
-      '  3. After push: "Your workflow will deploy automatically on every push to {branch}."\n' +
-      '  4. Offer a Codespaces link so they can edit and iterate in the browser.',
+      '  3. Verify OIDC federation is set up — check that AZURE_CLIENT_ID, AZURE_TENANT_ID, and ' +
+      'AZURE_SUBSCRIPTION_ID are configured as repository variables. If not, walk the user through the setup.\n' +
+      '  4. After push: "Your workflow will deploy automatically on every push to {branch}."\n' +
+      '  5. Offer a Codespaces link so they can edit and iterate in the browser.',
     ],
 
     [Phase.Deploy]: [
@@ -90,11 +107,22 @@ export const githubKit: IntegrationKit = {
   components: [
     {
       type: 'githubLoginCard',
-      description: 'OAuth Device Flow sign-in card with token confirmation',
+      description:
+        'OAuth Device Flow sign-in card with token confirmation.\n' +
+        'Props:\n' +
+        '  - username (optional string): GitHub username shown on the avatar and user info when signed in.\n' +
+        '  - avatarUrl (optional string): URL of the user\'s GitHub avatar image.\n' +
+        '  - onSignIn (optional action): Callback fired after successful GitHub OAuth sign-in.\n' +
+        '  - onSignOut (optional action): Callback fired when the user signs out.',
     },
     {
       type: 'githubRepoPicker',
-      description: 'Repository picker with search, pagination, and org/personal account support',
+      description:
+        'Repository picker with search, pagination, and org/personal account support.\n' +
+        'Props:\n' +
+        '  - placeholder (optional string): Placeholder text for the search input. Defaults to "Search repositories…".\n' +
+        '  - selectedRepo (optional string): Full name (owner/repo) of the pre-selected repository.\n' +
+        '  - onSelect (optional action): Callback fired when the user selects a repository.',
     },
   ],
 };

--- a/packages/core/src/kits/github-kit.ts
+++ b/packages/core/src/kits/github-kit.ts
@@ -12,7 +12,7 @@
  *
  * Component registrations (rendered by packages/web):
  *   - githubLoginCard    (OAuth Device Flow sign-in card)
- *   - githubRepoPicker   (repository picker with search and pagination)
+ *   - githubRepoPicker   (repository picker with search and client-side filtering)
  */
 
 import type { IntegrationKit } from './types.js';
@@ -43,7 +43,7 @@ export const githubKit: IntegrationKit = {
     'When generating deployment artifacts, always include a GitHub Actions workflow (.github/workflows/deploy.yml) ' +
     'that builds the container image, pushes to ACR, and triggers a rolling update on AKS. ' +
     'The workflow should use OIDC Workload Identity Federation — never hardcode credentials. ' +
-    'OIDC eliminates secret rotation but requires one-time setup of Azure credentials as GitHub repository variables.',
+    'OIDC eliminates secret rotation but requires one-time setup of Azure credentials as GitHub repository secrets.',
 
     // Branch strategy
     'Recommend a trunk-based deployment strategy: pushes to the default branch trigger production deploys. ' +
@@ -55,8 +55,8 @@ export const githubKit: IntegrationKit = {
     '  2. Add a federated credential: issuer "https://token.actions.githubusercontent.com", ' +
     'subject "repo:{owner}/{repo}:ref:refs/heads/{default_branch}" (and optionally for pull_request).\n' +
     '  3. Grant the app/identity the required Azure RBAC roles (Contributor on the resource group, AcrPush on the ACR).\n' +
-    '  4. Set three GitHub repository variables: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID.\n' +
-    '  5. The deploy.yml workflow uses `azure/login@v2` with `client-id`, `tenant-id`, `subscription-id` from those variables.\n' +
+    '  4. Set three GitHub repository secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID.\n' +
+    '  5. The deploy.yml workflow uses `azure/login@v2` with `client-id`, `tenant-id`, `subscription-id` from those secrets.\n' +
     'This replaces service principal client secrets with short-lived, scope-limited OIDC tokens. ' +
     'No secret rotation is needed. The federated credential is scoped to the specific repo and branch.',
   ],
@@ -77,7 +77,7 @@ export const githubKit: IntegrationKit = {
     [Phase.Generate]: [
       'Generate a GitHub Actions workflow at .github/workflows/deploy.yml. It must:\n' +
       '  • Trigger on push to the default branch and on pull_request\n' +
-      '  • Use `azure/login@v2` with OIDC: read client-id, tenant-id, subscription-id from GitHub vars\n' +
+      '  • Use `azure/login@v2` with OIDC: read client-id, tenant-id, subscription-id from GitHub secrets\n' +
       '  • Set `permissions: { id-token: write, contents: read }` for OIDC token issuance\n' +
       '  • Build and push the container image to ACR\n' +
       '  • Run `az aks get-credentials` then apply deployment files\n' +
@@ -90,8 +90,8 @@ export const githubKit: IntegrationKit = {
       'Walk the user through getting their generated files into GitHub:\n' +
       '  1. Ask: new repo or push to existing? Use ChoicePicker.\n' +
       '  2. Show AuthCard for GitHub sign-in if needed.\n' +
-      '  3. Verify OIDC federation is set up — check that AZURE_CLIENT_ID, AZURE_TENANT_ID, and ' +
-      'AZURE_SUBSCRIPTION_ID are configured as repository variables. If not, walk the user through the setup.\n' +
+      '  3. Verify OIDC federation is set up — ask the user to confirm that AZURE_CLIENT_ID, AZURE_TENANT_ID, and ' +
+      'AZURE_SUBSCRIPTION_ID are configured as repository secrets. If not, walk the user through the setup.\n' +
       '  4. After push: "Your workflow will deploy automatically on every push to {branch}."\n' +
       '  5. Offer a Codespaces link so they can edit and iterate in the browser.',
     ],
@@ -118,7 +118,7 @@ export const githubKit: IntegrationKit = {
     {
       type: 'githubRepoPicker',
       description:
-        'Repository picker with search, pagination, and org/personal account support.\n' +
+        'Repository picker with search and client-side filtering.\n' +
         'Props:\n' +
         '  - placeholder (optional string): Placeholder text for the search input. Defaults to "Search repositories…".\n' +
         '  - selectedRepo (optional string): Full name (owner/repo) of the pre-selected repository.\n' +


### PR DESCRIPTION
Fixes #3
Fixes #27
Fixes #28
Fixes #29

- Document kit component props in azureKit/githubKit (AzureLoginCard, AzureResourcePicker, GitHubLoginCard, GitHubRepoPicker) so the LLM knows what props each component accepts
- Port KAITO/RAGEngine/Fine-Tuning knowledge to azureKit prompts with Design and Generate phase-specific guidance
- Add OIDC pipeline setup protocol to githubKit with step-by-step federated credential setup instructions
- Fix false 'no secrets to configure' claim — OIDC eliminates long-lived secrets but still requires one-time setup of federated credentials and three GitHub repository variables