### PR TITLE
feat: add Questionnaire + Markdown components (#2)

### DIFF
--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -230,3 +230,12 @@ Core decisions preserved in `.squad/decisions.md` supersede archived entries. Th
 - **Release flow:** changeset per PR → `npx changeset version` → `git tag vX.Y.Z` → push tag → auto deploy.
 - **Infra + docs deploys unchanged:** Still trigger on push to main (path-scoped). Lower risk, no tag gate needed yet.
 - **Full decision:** `.squad/decisions/inbox/leela-pr-release-workflow.md`
+
+### 2025-07-27: Sprint Planning — Release Roadmap v0.2.0–v0.5.0
+- **4 milestones created:** v0.2.0 (34pt, 10 issues), v0.3.0 (40pt, 8 issues), v0.4.0 (17pt, 12 issues), v0.5.0 (68pt, 18 issues). Total: 159 story points across 48 issues.
+- **All 48 issues assigned to milestones.** No unassigned work remains.
+- **v0.2.0 P0 items moved to Ready** on the project board (#22, #23, #24, #53, #59). Items already in-progress (#2, #3, #27, #28, #29) left as-is.
+- **Two active PRs:** PR #65 (prompt knowledge batch → #3/#27/#28/#29) and PR #66 (questionnaire → #2) — both mergeable, both v0.2.0 scope.
+- **Key dependency chain:** #22→#23→#24 (action handler), #34→#25→#30→#31/#32 (ServiceConnector→ServicePack→fat components).
+- **Capacity balance:** v0.2.0 is Bender-heavy (core loop), v0.3.0 is balanced, v0.4.0 is light (prompt batch), v0.5.0 is stretch.
+- **Full decision:** `.squad/decisions/inbox/leela-sprint-planning-roadmap.md`

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -39,3 +39,48 @@
 2. Root cause analysis
 3. What should change?
 4. Action items for next iteration
+
+---
+
+## Sprint Planning
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | manual |
+| **When** | before |
+| **Condition** | user requests sprint planning, or at the start of a new milestone |
+| **Facilitator** | lead |
+| **Participants** | all-active |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. Review completed work from previous sprint/milestone
+2. Assess open issues by priority (P0 → P1 → P2) and estimate
+3. Group issues into milestones aligned with semver releases
+4. Set milestone on each issue via GitHub API
+5. Identify dependencies and blockers
+6. Assign sprint capacity per agent based on estimates
+7. Output: milestone roadmap with release targets
+
+---
+
+## Sprint Retro
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | manual |
+| **When** | after |
+| **Condition** | user requests sprint retro, or after a release is tagged |
+| **Facilitator** | lead |
+| **Participants** | all-involved |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. What shipped? (milestone summary)
+2. What slipped? (issues that moved between milestones)
+3. Velocity check: estimated vs actual story points
+4. What went well?
+5. What should change?
+6. Action items for next sprint

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2977,6 +2977,25 @@ Public-facing LLM endpoints (inspirations, converse) could generate or respond t
 **Status:** Accepted
 
 Playground Create tab was calling `/api/converse`, which uses the full Kickstart onboarding engine (phases, kit skills, phase indicators). Wrong context — the playground needs free-form A2UI component generation, not an AKS deployment guide.
+## Merged from Inbox
+
+### 2026-04-10: A2UI Message Protocol for Dynamic Surfaces (Bender)
+
+When creating A2UI surfaces dynamically (e.g. from LLM responses), always use the two-message pattern:
+1. `{ version: 'v0.9', createSurface: { surfaceId, catalogId } }` — creates an empty surface
+2. `{ version: 'v0.9', updateComponents: { surfaceId, components: [...] } }` — adds components
+
+Never put a `body` field on `createSurface` — it is silently ignored. One component in the `updateComponents` array must have `id: "root"` — this is the renderer's entry point.
+
+### 2026-04-10: Content Safety Guardrails for LLM-Generated Content (Bender)
+
+Public-facing LLM endpoints (inspirations, converse) include two layers of defense:
+1. System prompt hardening — All inspiration generation prompts include a safety clause forbidding weapons, violence, illegal activities, adult content, gambling, and harmful/offensive ideas.
+2. User input pre-flight check — `content-safety.ts` performs lightweight LLM classification (`safe`/`unsafe`) on user messages before they reach the main converse flow.
+
+All agents adding new LLM prompts should include the safety clause.
+
+### 2026-04-10: Dedicated /api/playground Endpoint for A2UI Playground (Bender)
 
 Created a dedicated `POST /api/playground` endpoint with:
 - Its own system prompt focused on A2UI component design
@@ -2999,6 +3018,9 @@ Frontend `Playground.tsx` updated to call `/api/playground` with direct fetch in
 **Status:** Implemented
 
 Widget inspiration system (Ideas tab in Playground) was generating generic "chat-based AI assistant UX" component ideas. Too vague for one-shot component generation and not aligned with Kickstart's focus on Kubernetes/AKS deployment operations.
+Frontend `Playground.tsx` updated to call `/api/playground` with direct fetch instead of the SSE-based `useStreaming` hook.
+
+### 2026-04-10: Widget Inspiration Prompts — Dev/Deploy/Ops Focus (Bender)
 
 All widget inspiration prompts are now scoped exclusively to:
 1. Kubernetes deployment and operations (rollouts, scaling, pod health, events, logs)
@@ -3155,3 +3177,58 @@ PR preview environments still work — `pull_request` trigger is preserved for s
 **What:** When agent picks up work in Ralph loop, assign GitHub issue to @sabbour since AI agents have no GitHub accounts. Use `gh issue edit <number> --add-assignee sabbour`.
 **Why:** User request — agents can't be assigned issues directly, so use human owner's account.
 
+Prompts now include explicit instructions to specify A2UI component types, realistic sample data, interactions, and layout.
+
+### 2026-04-10: ArchitectureDiagram Fluent 2 Theme & Auto-sizing (Fry)
+
+ArchitectureDiagram now uses:
+1. Mermaid `base` theme with Fluent 2 `themeVariables` (hardcoded hex values, not runtime tokens)
+2. SVG post-processing for icon injection via keyword matching, rounded corners, thin strokes, flat styling
+3. Auto-sizing viewport (300–800px range based on SVG natural dimensions)
+4. Fit-and-center logic — diagram scales to fit container width and centers on render; reset button re-fits
+
+### 2026-04-10: SteppedCarousel component pattern (Fry)
+
+Created `SteppedCarousel` as a custom A2UI component using the `createReactComponent` pattern:
+- Client-side state only via `useState` — no server round-trip for step changes
+- Child-based content — each step references a `child` ComponentId for composable step content
+- No animation — simple content swap keeps it lightweight
+
+### 2026-04-10: PR + Tagged Release Workflow (Leela, Ahmed directive)
+
+All work flows through PRs:
+```
+squad/{issue}-{slug} → PR to main → merge → tag release → deploy to SWA
+```
+
+CI runs on every PR (lint, TypeScript check, build, unit tests, Playwright e2e). Production deploys trigger on version tags `v*` or manual dispatch. Each PR includes a changeset; release tags are created with `git tag v0.X.Y && git push --tags`.
+
+### 2026-04-10: Sprint Planning — Release Roadmap v0.2.0–v0.5.0 (Leela)
+
+Four milestones created mapping to tagged releases, grouping by Priority order, dependency chains, and agent capacity balance:
+
+- **v0.2.0 — Core Loop** (34 story points, 10 issues): End-to-end app functionality + release infra
+- **v0.3.0 — Feature Enrichment** (40 story points, 8 issues): API integrations + rich components
+- **v0.4.0 — Polish & Prompt Tuning** (17 story points, 12 issues): Prompt accuracy + UI polish
+- **v0.5.0 — Stretch** (68 story points, 18 issues): All P2 nice-to-have items
+
+### 2026-04-10: Project Board Fields Required on All Issues (Ralph directive)
+
+All GitHub issues must have:
+1. **Priority** — P0, P1, P2
+2. **Size** — XS, S, M, L, XL (story points)
+3. **Estimate** — Fibonacci points matching Size
+4. **Status** — Backlog → Ready → In progress → In review → Done
+
+Update Status as work progresses through lifecycle stages.
+
+### 2026-04-10: User directives (Ahmed Sabbour, Copilot captured)
+
+- **2026-04-10T06:03Z:** Use GitHub project board stages (Backlog → Ready → In progress → In review → Done) as agents work on items.
+- **2026-04-10T06:03Z:** Deploy from tagged releases only. Use PRs for work, no direct pushes to main.
+- **2026-04-10T06:08Z:** Use GitHub milestones tied to releases to group work by version.
+- **2026-04-10T06:08Z:** Investigate SWA slots for pre-prod/prod deployment (main = pre-prod, tags = prod).
+- **2026-04-10T06:08Z:** Track ALL work on GitHub Issues — GitHub is the source of truth, not in-memory state.
+- **2026-04-10T06:08Z:** For complex/stuck work, hire a 3rd-party "consultant" agent using gpt-5.4 model.
+- **2026-04-10T06:28Z:** Always set Estimate (1/2/3/5/8) and Priority (Critical/Important/Nice-to-have) on all issues. Update Status as work moves.
+- **2026-04-10T06:34Z:** Milestones must be set on all issues. Use sprint planning and sprint retro ceremonies. Derive roadmap from work item details.

--- a/.squad/decisions/inbox/fry-questionnaire-schema-conventions.md
+++ b/.squad/decisions/inbox/fry-questionnaire-schema-conventions.md
@@ -1,0 +1,13 @@
+# Decision: Questionnaire schema conventions
+
+**Date:** 2026-04-10
+**Author:** Fry
+**Context:** PR #66 review feedback
+
+## Decision
+
+1. **IDs in component schemas must use `z.string()`, not `DynamicStringSchema`** — IDs are used as React keys and state-map keys and must be stable literals. `DynamicStringSchema` allows data-bindings/function calls that can produce unstable values.
+
+2. **All interactive components must expose `ActionSchema` callback props** (e.g., `onSubmit`, `onSelect`) instead of hard-coding event names. This is the established catalog convention (AzureLoginCard, RadioGroup, GitHubRepoPicker all follow it).
+
+3. **Required-field validation must gate submit** — visual `*` markers without actual validation is a UX bug. Submit buttons should be disabled until all required fields pass.

--- a/packages/web/src/catalog/components/Questionnaire.tsx
+++ b/packages/web/src/catalog/components/Questionnaire.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { createReactComponent } from '../../vendor/a2ui/react/adapter';
 import { z } from 'zod';
-import { DynamicStringSchema } from '../../vendor/a2ui/web_core/schema/common-types';
+import { DynamicStringSchema, ActionSchema } from '../../vendor/a2ui/web_core/schema/common-types';
 import {
   Button,
   Checkbox,
@@ -19,13 +19,14 @@ const QuestionnaireApi = {
   name: 'Questionnaire',
   schema: z.object({
     questions: z.array(z.object({
-      id: DynamicStringSchema,
+      id: z.string(),
       label: DynamicStringSchema,
       type: z.enum(['text', 'choice', 'multiChoice']).optional(),
-      choices: z.array(z.object({ id: DynamicStringSchema, label: DynamicStringSchema })).optional(),
+      choices: z.array(z.object({ id: z.string(), label: DynamicStringSchema })).optional(),
       required: z.boolean().optional(),
     })),
     submitLabel: DynamicStringSchema.optional(),
+    onSubmit: ActionSchema.optional(),
   }).strict(),
 };
 
@@ -80,6 +81,18 @@ export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) 
     });
   };
 
+  const isComplete = (props.questions || [])
+    .filter((q) => q.required)
+    .every((q) => {
+      const val = answers[q.id];
+      if (Array.isArray(val)) return val.length > 0;
+      return typeof val === 'string' && val.trim().length > 0;
+    });
+
+  const handleSubmit = () => {
+    if (props.onSubmit) (props.onSubmit as () => void)();
+  };
+
   return (
     <Card className={classes.root}>
       <Subtitle2 style={{ marginBottom: tokens.spacingVerticalM }}>
@@ -88,7 +101,7 @@ export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) 
 
       {(props.questions || []).map((q) => {
         const qType = q.type || 'text';
-        const qId = q.id as string;
+        const qId = q.id;
         const qLabel = q.label as string;
 
         return (
@@ -113,8 +126,8 @@ export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) 
               >
                 {q.choices.map((c) => (
                   <Radio
-                    key={c.id as string}
-                    value={c.id as string}
+                    key={c.id}
+                    value={c.id}
                     label={c.label as string}
                   />
                 ))}
@@ -124,12 +137,12 @@ export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) 
             {qType === 'multiChoice' && q.choices && (
               <div className={classes.checkboxGroup}>
                 {q.choices.map((c) => {
-                  const selected = ((answers[qId] as string[]) || []).includes(c.id as string);
+                  const selected = ((answers[qId] as string[]) || []).includes(c.id);
                   return (
                     <Checkbox
-                      key={c.id as string}
+                      key={c.id}
                       checked={selected}
-                      onChange={() => toggleMultiChoice(qId, c.id as string)}
+                      onChange={() => toggleMultiChoice(qId, c.id)}
                       label={c.label as string}
                     />
                   );
@@ -141,7 +154,7 @@ export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) 
       })}
 
       <div className={classes.footer}>
-        <Button appearance="primary">
+        <Button appearance="primary" disabled={!isComplete} onClick={handleSubmit}>
           {(props.submitLabel as string) || 'Submit'}
         </Button>
       </div>

--- a/packages/web/src/catalog/components/Questionnaire.tsx
+++ b/packages/web/src/catalog/components/Questionnaire.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import { createReactComponent } from '../../vendor/a2ui/react/adapter';
+import { z } from 'zod';
+import { DynamicStringSchema } from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Button,
+  Checkbox,
+  Input,
+  Label,
+  RadioGroup as FluentRadioGroup,
+  Radio,
+  Card,
+  Subtitle2,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+
+const QuestionnaireApi = {
+  name: 'Questionnaire',
+  schema: z.object({
+    questions: z.array(z.object({
+      id: DynamicStringSchema,
+      label: DynamicStringSchema,
+      type: z.enum(['text', 'choice', 'multiChoice']).optional(),
+      choices: z.array(z.object({ id: DynamicStringSchema, label: DynamicStringSchema })).optional(),
+      required: z.boolean().optional(),
+    })),
+    submitLabel: DynamicStringSchema.optional(),
+  }).strict(),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalS,
+    width: '100%',
+    padding: tokens.spacingHorizontalL,
+  },
+  question: {
+    marginBottom: tokens.spacingVerticalL,
+  },
+  label: {
+    display: 'block',
+    marginBottom: tokens.spacingVerticalXS,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+    color: tokens.colorNeutralForeground1,
+  },
+  required: {
+    color: tokens.colorPaletteRedForeground1,
+    marginLeft: tokens.spacingHorizontalXXS,
+  },
+  checkboxGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXS,
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: tokens.spacingVerticalM,
+  },
+});
+
+export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) => {
+  const classes = useStyles();
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+
+  const updateAnswer = (questionId: string, value: string | string[]) => {
+    setAnswers(prev => ({ ...prev, [questionId]: value }));
+  };
+
+  const toggleMultiChoice = (questionId: string, choiceId: string) => {
+    setAnswers(prev => {
+      const current = (prev[questionId] as string[]) || [];
+      const next = current.includes(choiceId)
+        ? current.filter(c => c !== choiceId)
+        : [...current, choiceId];
+      return { ...prev, [questionId]: next };
+    });
+  };
+
+  return (
+    <Card className={classes.root}>
+      <Subtitle2 style={{ marginBottom: tokens.spacingVerticalM }}>
+        {props.submitLabel || 'Questionnaire'}
+      </Subtitle2>
+
+      {(props.questions || []).map((q) => {
+        const qType = q.type || 'text';
+        const qId = q.id as string;
+        const qLabel = q.label as string;
+
+        return (
+          <div key={qId} className={classes.question}>
+            <Label className={classes.label}>
+              {qLabel}
+              {q.required && <span className={classes.required}>*</span>}
+            </Label>
+
+            {qType === 'text' && (
+              <Input
+                style={{ width: '100%' }}
+                value={(answers[qId] as string) || ''}
+                onChange={(_e, data) => updateAnswer(qId, data.value)}
+              />
+            )}
+
+            {qType === 'choice' && q.choices && (
+              <FluentRadioGroup
+                value={(answers[qId] as string) || ''}
+                onChange={(_e, data) => updateAnswer(qId, data.value)}
+              >
+                {q.choices.map((c) => (
+                  <Radio
+                    key={c.id as string}
+                    value={c.id as string}
+                    label={c.label as string}
+                  />
+                ))}
+              </FluentRadioGroup>
+            )}
+
+            {qType === 'multiChoice' && q.choices && (
+              <div className={classes.checkboxGroup}>
+                {q.choices.map((c) => {
+                  const selected = ((answers[qId] as string[]) || []).includes(c.id as string);
+                  return (
+                    <Checkbox
+                      key={c.id as string}
+                      checked={selected}
+                      onChange={() => toggleMultiChoice(qId, c.id as string)}
+                      label={c.label as string}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <div className={classes.footer}>
+        <Button appearance="primary">
+          {(props.submitLabel as string) || 'Submit'}
+        </Button>
+      </div>
+    </Card>
+  );
+});

--- a/packages/web/src/catalog/kickstart-catalog.ts
+++ b/packages/web/src/catalog/kickstart-catalog.ts
@@ -19,6 +19,7 @@ import { FileEditor } from './components/FileEditor';
 import { CostEstimate } from './components/CostEstimate';
 import { DeploymentProgress } from './components/DeploymentProgress';
 import { SteppedCarousel } from './components/SteppedCarousel';
+import { Questionnaire } from './components/Questionnaire';
 
 const kickstartComponents: ReactComponentImplementation[] = [
   ...Array.from(basicCatalog.components.values()),
@@ -40,6 +41,7 @@ const kickstartComponents: ReactComponentImplementation[] = [
   CostEstimate,
   DeploymentProgress,
   SteppedCarousel,
+  Questionnaire,
 ];
 
 export const kickstartCatalog = new Catalog<ReactComponentImplementation>(

--- a/packages/web/src/pages/playground-scenarios.ts
+++ b/packages/web/src/pages/playground-scenarios.ts
@@ -385,6 +385,37 @@ const customArchitectureDiagram = (): A2uiMsg[] => {
   ] as A2uiComponent[]);
 };
 
+const customQuestionnaire = (): A2uiMsg[] => {
+  const sid = uid('questionnaire-demo');
+  return surface(sid, [
+    { id: 'root', component: 'Column', children: ['heading', 'q1'], gap: 'medium' },
+    { id: 'heading', component: 'Text', text: 'Questionnaire (Custom)', variant: 'h3' },
+    { id: 'q1', component: 'Questionnaire', questions: [
+      { id: 'app-name', label: 'What is your application name?', type: 'text', required: true },
+      { id: 'app-type', label: 'What type of application?', type: 'choice', required: true, choices: [
+        { id: 'web', label: 'Web Application' },
+        { id: 'api', label: 'REST API' },
+        { id: 'worker', label: 'Background Worker' },
+      ] },
+      { id: 'features', label: 'Which features do you need?', type: 'multiChoice', choices: [
+        { id: 'autoscale', label: 'Auto-scaling' },
+        { id: 'monitoring', label: 'Monitoring & Alerts' },
+        { id: 'ci-cd', label: 'CI/CD Pipeline' },
+        { id: 'secrets', label: 'Secret Management' },
+      ] },
+    ], submitLabel: 'Continue' },
+  ] as A2uiComponent[]);
+};
+
+const customMarkdown = (): A2uiMsg[] => {
+  const sid = uid('markdown-demo');
+  return surface(sid, [
+    { id: 'root', component: 'Column', children: ['heading', 'md1'], gap: 'medium' },
+    { id: 'heading', component: 'Text', text: 'Markdown (Custom)', variant: 'h3' },
+    { id: 'md1', component: 'Markdown', content: '## Deployment Summary\n\nYour application **web-app** is ready for deployment.\n\n### Resources Created\n\n| Resource | SKU | Region |\n|----------|-----|--------|\n| AKS Cluster | Standard | East US 2 |\n| Container Registry | Basic | East US 2 |\n| Key Vault | Standard | East US 2 |\n\n### Next Steps\n\n1. Review the generated manifests\n2. Configure environment variables\n3. Run `kubectl apply -f deployment.yaml`\n\n> **Note:** Auto-scaling is enabled with a minimum of 2 replicas.\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web-app\nspec:\n  replicas: 2\n```' },
+  ] as A2uiComponent[]);
+};
+
 // ---------------------------------------------------------------------------
 // Advanced Scenarios — Data Binding, Events, Lifecycle, Dynamic Patterns
 // ---------------------------------------------------------------------------
@@ -727,6 +758,8 @@ export const CONTROL_SCENARIOS: ScenarioDef[] = [
   { id: 'ctrl-code',     label: 'CodeBlock',      description: 'Syntax-highlighted code',          group: 'Custom Controls', catalog: 'kickstart', generate: customCodeBlock },
   { id: 'ctrl-progress', label: 'ProgressSteps',  description: 'Multi-step progress tracker',      group: 'Custom Controls', catalog: 'kickstart', generate: customProgressSteps },
   { id: 'ctrl-arch',     label: 'ArchitectureDiagram', description: 'Mermaid-powered architecture diagram', group: 'Custom Controls', catalog: 'kickstart', generate: customArchitectureDiagram },
+  { id: 'ctrl-questionnaire', label: 'Questionnaire', description: 'Multi-question form with text/choice/multiChoice', group: 'Custom Controls', catalog: 'kickstart', generate: customQuestionnaire },
+  { id: 'ctrl-markdown', label: 'Markdown', description: 'Rich markdown with tables and code blocks', group: 'Custom Controls', catalog: 'kickstart', generate: customMarkdown },
   // Data Binding
   { id: 'data-basic',    label: 'Basic Data Binding',     description: 'Text components bound to data paths',        group: 'Data Binding',    generate: dataBindingBasic },
   { id: 'data-form',     label: 'Data-Bound Form',        description: 'Form fields with path bindings',             group: 'Data Binding',    generate: dataBindingForm },


### PR DESCRIPTION
Fixes #2

- New **Questionnaire** component: multi-question form with text, choice, and multiChoice question types using Fluent UI (Input, RadioGroup, Checkbox, Button)
- Verified **Markdown** is already registered in kickstart catalog (line 9 import, line 30 in component array)
- Added playground demos for both Questionnaire and Markdown under **Custom Controls** group