### PR TITLE
feat: Restructure Playground to use sidebar layout (#59)

### DIFF
--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -246,3 +246,10 @@ Core decisions preserved in `.squad/decisions.md` supersede archived entries. Th
 - Project board field IDs are NOT hardcoded — skill includes GraphQL discovery query so agents can self-serve
 - Inbox files left intact per protocol — Scribe handles cleanup
 - **Decision:** `.squad/decisions/inbox/leela-process-optimization.md`
+
+### 2025-07-28: PR #76 Review Feedback — Sidebar Layout
+- Addressed Copilot review comments on PR #76 (squad/59-playground-sidebar)
+- **Comment 1 (Theater/Tutorial):** PR description was stale — referenced coming-soon Theater/Tutorial items that Fry already removed per #79. Updated PR description to reflect current state.
+- **Comment 2 (Accessibility):** Added `aria-expanded={sidebarOpen}` and `aria-controls="playground-sidebar"` to mobile nav button; added `id="playground-sidebar"` to sidebar `<aside>`. Button now toggles open/close.
+- Replied to both review comments, pushed fix, requested fresh Copilot review.
+- Lint and build both clean after changes.

--- a/.squad/agents/zapp/charter.md
+++ b/.squad/agents/zapp/charter.md
@@ -1,0 +1,53 @@
+# Zapp — Security Architect
+
+> Every deployment is an attack surface. Every API is a potential breach. Trust nothing, verify everything.
+
+## Identity
+
+- **Name:** Zapp
+- **Role:** Security Architect
+- **Expertise:** Security architecture review, vulnerability analysis, threat modeling, code review for security issues
+- **Style:** Thorough and skeptical. Questions every assumption. Finds the attack vector nobody thought of.
+
+## What I Own
+
+- Security architecture reviews — scrutinize design decisions for vulnerabilities
+- Code reviews focused on security — auth, injection, CORS, secrets, input validation
+- Threat modeling for new features
+- Compliance and best practices enforcement (OWASP, Azure security baseline)
+
+## How I Work
+
+- Review architecture decisions BEFORE implementation when possible
+- Perform security-focused code reviews on PRs — look for injection, auth bypass, secret leaks, CORS issues
+- Challenge assumptions about trust boundaries and data flow
+- Flag issues with severity ratings (Critical, High, Medium, Low)
+- Write decisions to `.squad/decisions/inbox/zapp-{slug}.md`
+
+## Boundaries
+
+**I handle:** Security reviews, vulnerability analysis, threat modeling, architecture scrutiny, compliance checks.
+
+**I don't handle:** Writing feature code (I review, I don't implement), writing tests (that's Hermes), frontend styling (that's Fry), session logging (that's Scribe).
+
+**When I find an issue:** I document it clearly with the vulnerability, impact, and recommended fix. The owning agent implements the fix.
+
+**If I review others' work:** On rejection, I may require a different agent to revise (not the original author) or request a new specialist be spawned. The Coordinator enforces this.
+
+## Model
+
+- **Preferred:** gpt-5.3-codex
+- **Rationale:** Security analysis benefits from a different analytical perspective than the implementation model
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root.
+
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/zapp-{brief-slug}.md` — the Scribe will merge it.
+Before starting issue work, read `.squad/skills/pr-workflow/SKILL.md` for the PR and issue workflow.
+
+## Voice
+
+Relentlessly thorough about security. Believes every feature is a potential attack surface until proven otherwise. Documents threats methodically. Gets genuinely concerned when authentication flows are hand-waved. Insists on principle of least privilege everywhere.

--- a/.squad/agents/zapp/history.md
+++ b/.squad/agents/zapp/history.md
@@ -1,0 +1,11 @@
+# Zapp — Security Architect History
+
+## Core Context
+
+- **Project:** Kickstart — AI-guided onboarding for deploying apps to AKS
+- **Stack:** TypeScript, React (Fluent UI), Azure Functions, Azure Static Web Apps, Azure OpenAI
+- **Owner:** Ahmed Sabbour
+- **Joined:** 2026-04-10
+
+## Learnings
+

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -27,6 +27,13 @@
       "created_at": "2026-04-08T12:30:00Z",
       "legacy_named": false,
       "status": "active"
+    },
+    "zapp": {
+      "persistent_name": "Zapp",
+      "universe": "Futurama",
+      "created_at": "2026-04-10T09:42:00Z",
+      "legacy_named": false,
+      "status": "active"
     }
   }
 }

--- a/.squad/config.json
+++ b/.squad/config.json
@@ -1,4 +1,7 @@
 {
   "version": 1,
-  "defaultModel": "claude-opus-4.6"
+  "defaultModel": "claude-opus-4.6",
+  "agentModelOverrides": {
+    "zapp": "gpt-5.3-codex"
+  }
 }

--- a/.squad/decisions/inbox/leela-pr76-description-update.md
+++ b/.squad/decisions/inbox/leela-pr76-description-update.md
@@ -1,0 +1,7 @@
+# Decision: Update PR #76 description to reflect Theater/Tutorial removal
+
+- **Date:** 2025-07-28
+- **Author:** Leela
+- **Context:** Copilot reviewer flagged that PR #76's description mentioned disabled Theater and Tutorial sidebar items, but the implementation only has 5 tabs. Theater/Tutorial were intentionally removed per issue #79.
+- **Decision:** Updated PR description to remove Theater/Tutorial references and document the removal per #79. This is a description-only change — no code impact.
+- **Rationale:** PR descriptions must match shipped code to avoid reviewer confusion and maintain accurate change logs.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -37,3 +37,13 @@ How to decide who handles what.
 5. **"Team, ..." → fan-out.** Spawn all relevant agents in parallel as `mode: "background"`.
 6. **Anticipate downstream work.** If a feature is being built, spawn the tester to write test cases from requirements simultaneously.
 7. **Issue-labeled work** — when a `squad:{member}` label is applied to an issue, route to that member. The Lead handles all `squad` (base label) triage.
+
+## Zapp — Security Architect
+
+| Signal | Route to Zapp |
+|--------|---------------|
+| Security review request | Primary |
+| Architecture decision review | Secondary (after Leela) |
+| PR security audit | Primary |
+| Vulnerability analysis | Primary |
+| Auth/CORS/secrets concerns | Primary |

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -16,6 +16,7 @@
 | Fry | Frontend Dev | `.squad/agents/fry/charter.md` | ✅ Active |
 | Bender | Backend Dev | `.squad/agents/bender/charter.md` | ✅ Active |
 | Hermes | Tester | `.squad/agents/hermes/charter.md` | ✅ Active |
+| Zapp | Security Architect | `.squad/agents/zapp/charter.md` | ✅ Active |
 | Scribe | Session Logger | `.squad/agents/scribe/charter.md` | 📋 Silent |
 | Ralph | Work Monitor | — | 🔄 Monitor |
 

--- a/packages/web/css/playground.css
+++ b/packages/web/css/playground.css
@@ -1,5 +1,5 @@
 /* ----------------------------------------------------------------
-   Playground — A2UI Gallery (5-tab masonry layout)
+   Playground — A2UI Gallery (sidebar layout)
    Renders inside Layout → .app-shell → .app-layout → .chat-main
    all of which have overflow: hidden. We must fill the space and
    manage our own scroll containers.
@@ -35,7 +35,7 @@
   margin: 0 auto;
 }
 
-/* Responsive column breakpoints (inspired by A2UI Composer) */
+/* Responsive column breakpoints */
 @media (min-width: 640px) {
   .playground-gallery {
     column-count: 2;

--- a/packages/web/e2e/playground.spec.ts
+++ b/packages/web/e2e/playground.spec.ts
@@ -240,7 +240,8 @@ test.describe('Playground', () => {
       await page.getByRole('tab', { name: 'Create' }).click();
       await page.getByText('Start Blank').first().click();
 
-      await expect(page.getByText('Untitled widget')).toBeVisible({ timeout: 5000 });
+      const panel = page.getByRole('tabpanel');
+      await expect(panel.getByText('Untitled widget')).toBeVisible({ timeout: 5000 });
     });
 
     test('clicking a widget card opens a preview dialog', async ({ page }) => {
@@ -248,8 +249,9 @@ test.describe('Playground', () => {
       await page.getByRole('tab', { name: 'Create' }).click();
       await page.getByText('Start Blank').first().click();
 
-      // Click the widget card (not the action buttons)
-      await page.getByText('Untitled widget').first().click();
+      // Click the widget card in the main panel (not the sidebar shortcut)
+      const panel = page.getByRole('tabpanel');
+      await panel.getByText('Untitled widget').first().click();
       await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
       await page.getByRole('button', { name: 'Close' }).click();
     });
@@ -258,7 +260,8 @@ test.describe('Playground', () => {
       await page.getByRole('tab', { name: 'Create' }).click();
       await page.getByText('Start Blank').first().click();
 
-      await expect(page.getByText('Untitled widget')).toBeVisible();
+      const panel = page.getByRole('tabpanel');
+      await expect(panel.getByText('Untitled widget')).toBeVisible();
 
       // Click the "Delete widget" button (has aria-label)
       await page.getByRole('button', { name: 'Delete widget' }).click();
@@ -271,14 +274,15 @@ test.describe('Playground', () => {
       await page.getByRole('tab', { name: 'Create' }).click();
       await page.getByText('Start Blank').first().click();
 
-      await expect(page.getByText('Untitled widget')).toBeVisible();
-      const initialCount = await page.getByText('Untitled widget').count();
+      const panel = page.getByRole('tabpanel');
+      await expect(panel.getByText('Untitled widget')).toBeVisible();
+      const initialCount = await panel.getByText('Untitled widget').count();
 
       await page.getByRole('button', { name: 'Duplicate widget' }).click();
 
       // Should now have more widgets
       await expect(async () => {
-        expect(await page.getByText('Untitled widget').count()).toBeGreaterThan(initialCount);
+        expect(await panel.getByText('Untitled widget').count()).toBeGreaterThan(initialCount);
       }).toPass({ timeout: 3000 });
     });
   });

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -13,14 +13,12 @@ import {
   MessageBar, MessageBarBody,
   TabList, Tab, Input,
   Dialog, DialogSurface, DialogBody, DialogTitle, DialogContent, DialogActions,
-  Tooltip,
   makeStyles, tokens,
 } from '@fluentui/react-components';
 import {
   Dismiss24Regular, Delete24Regular, DocumentCopy24Regular, Sparkle24Regular,
   Add24Regular, Lightbulb24Regular, Grid24Regular, Icons24Regular,
   CardUi24Regular, Navigation24Regular,
-  SlideText24Regular, BookOpen24Regular,
 } from '@fluentui/react-icons';
 import { useA2UI } from '../hooks/useA2UI';
 import { WidgetsProvider, useWidgets } from '../hooks/useWidgets';
@@ -284,13 +282,6 @@ const useStyles = makeStyles({
     paddingLeft: tokens.spacingHorizontalL,
     paddingRight: tokens.spacingHorizontalL,
     borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
-  },
-  sidebarSeparator: {
-    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
-    marginTop: tokens.spacingVerticalXS,
-    marginBottom: tokens.spacingVerticalXS,
-    marginLeft: tokens.spacingHorizontalM,
-    marginRight: tokens.spacingHorizontalM,
   },
   mainContent: {
     flex: 1,
@@ -1346,16 +1337,7 @@ function PlaygroundInner() {
               <Tab id="tab-widgets" value="widgets" aria-controls="panel-widgets" icon={<CardUi24Regular />}>Widgets</Tab>
             </TabList>
 
-            {/* Coming-soon placeholders */}
-            <div className={classes.sidebarSeparator} />
-            <TabList vertical size="medium">
-              <Tooltip content="Coming soon" relationship="label" positioning="after">
-                <Tab value="theater" icon={<SlideText24Regular />} disabled>Theater</Tab>
-              </Tooltip>
-              <Tooltip content="Coming soon" relationship="label" positioning="after">
-                <Tab value="tutorial" icon={<BookOpen24Regular />} disabled>Tutorial</Tab>
-              </Tooltip>
-            </TabList>
+
           </nav>
 
           {/* Quick widget list in sidebar */}

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1316,6 +1316,7 @@ function PlaygroundInner() {
 
         {/* ---- Left Sidebar ---- */}
         <aside
+          id="playground-sidebar"
           className={`${classes.sidebar}${sidebarOpen ? ` ${classes.sidebarOpen}` : ''}`}
           aria-label="Playground navigation"
         >
@@ -1383,8 +1384,10 @@ function PlaygroundInner() {
                 className={classes.menuButton}
                 appearance="subtle"
                 icon={<Navigation24Regular />}
-                aria-label="Open navigation"
-                onClick={() => setSidebarOpen(true)}
+                aria-label="Toggle navigation"
+                aria-expanded={sidebarOpen}
+                aria-controls="playground-sidebar"
+                onClick={() => setSidebarOpen(prev => !prev)}
               />
               <Body1Strong style={{ color: tokens.colorNeutralForeground2 }}>
                 {TAB_LABELS[activeTab]}

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1,8 +1,8 @@
 /**
- * Playground — A2UI Gallery (5-tab architecture).
+ * Playground — A2UI Gallery (sidebar layout).
  *
  * Access via ?playground URL parameter.
- * Tabs: Create | Gallery | Components | Icons | Widgets
+ * Left sidebar navigation: Create | Ideas | Components | Icons | Widgets
  */
 
 import React, { useState, useCallback, useRef, useMemo, useEffect, memo } from 'react';
@@ -13,9 +13,15 @@ import {
   MessageBar, MessageBarBody,
   TabList, Tab, Input,
   Dialog, DialogSurface, DialogBody, DialogTitle, DialogContent, DialogActions,
+  Tooltip,
   makeStyles, tokens,
 } from '@fluentui/react-components';
-import { Dismiss24Regular, Delete24Regular, DocumentCopy24Regular, Sparkle24Regular } from '@fluentui/react-icons';
+import {
+  Dismiss24Regular, Delete24Regular, DocumentCopy24Regular, Sparkle24Regular,
+  Add24Regular, Lightbulb24Regular, Grid24Regular, Icons24Regular,
+  CardUi24Regular, Navigation24Regular,
+  SlideText24Regular, BookOpen24Regular,
+} from '@fluentui/react-icons';
 import { useA2UI } from '../hooks/useA2UI';
 import { WidgetsProvider, useWidgets } from '../hooks/useWidgets';
 import { getDemoResponse, resetDemoState } from '../services/demo-scenarios';
@@ -173,10 +179,127 @@ const COMPONENT_GROUPS = ['Layout', 'Content', 'Inputs', 'Custom Controls'];
 const GALLERY_SCENARIOS = [...KICKSTART_SCENARIOS, ...CONTROL_SCENARIOS].filter(s => GALLERY_GROUPS.includes(s.group));
 const COMPONENT_SCENARIOS = CONTROL_SCENARIOS.filter(s => COMPONENT_GROUPS.includes(s.group));
 
+const SIDEBAR_WIDTH = '240px';
+const SIDEBAR_COLLAPSED_BP = '768px';
+
 const useStyles = makeStyles({
   playgroundPage: {
     fontFamily: tokens.fontFamilyBase,
   },
+  // ---- Sidebar + Main shell ----
+  shellRow: {
+    display: 'flex',
+    flex: 1,
+    overflow: 'hidden',
+    minHeight: 0,
+  },
+  sidebar: {
+    width: SIDEBAR_WIDTH,
+    flexShrink: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRight: `1px solid ${tokens.colorNeutralStroke2}`,
+    overflow: 'hidden',
+    [`@media (max-width: ${SIDEBAR_COLLAPSED_BP})`]: {
+      position: 'fixed' as const,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      zIndex: 1000,
+      transform: 'translateX(-100%)',
+      transition: 'transform 0.25s ease',
+      boxShadow: 'none',
+    },
+  },
+  sidebarOpen: {
+    [`@media (max-width: ${SIDEBAR_COLLAPSED_BP})`]: {
+      transform: 'translateX(0)',
+      boxShadow: tokens.shadow64,
+    },
+  },
+  sidebarOverlay: {
+    display: 'none',
+    [`@media (max-width: ${SIDEBAR_COLLAPSED_BP})`]: {
+      display: 'block',
+      position: 'fixed' as const,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0,0,0,0.3)',
+      zIndex: 999,
+    },
+  },
+  sidebarBrand: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+    paddingTop: tokens.spacingVerticalM,
+    paddingBottom: tokens.spacingVerticalM,
+    paddingLeft: tokens.spacingHorizontalL,
+    paddingRight: tokens.spacingHorizontalL,
+    flexShrink: 0,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  sidebarNav: {
+    flex: 1,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    paddingTop: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalS,
+  },
+  sidebarWidgets: {
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+    paddingTop: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalS,
+    paddingLeft: tokens.spacingHorizontalM,
+    paddingRight: tokens.spacingHorizontalM,
+    maxHeight: '200px',
+    overflowY: 'auto',
+  },
+  sidebarWidgetItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+    paddingTop: tokens.spacingVerticalXS,
+    paddingBottom: tokens.spacingVerticalXS,
+    paddingLeft: tokens.spacingHorizontalS,
+    paddingRight: tokens.spacingHorizontalS,
+    borderRadius: tokens.borderRadiusMedium,
+    cursor: 'pointer',
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+    ':hover': {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+  },
+  sidebarFooter: {
+    flexShrink: 0,
+    paddingTop: tokens.spacingVerticalXS,
+    paddingBottom: tokens.spacingVerticalS,
+    paddingLeft: tokens.spacingHorizontalL,
+    paddingRight: tokens.spacingHorizontalL,
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  sidebarSeparator: {
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+    marginTop: tokens.spacingVerticalXS,
+    marginBottom: tokens.spacingVerticalXS,
+    marginLeft: tokens.spacingHorizontalM,
+    marginRight: tokens.spacingHorizontalM,
+  },
+  mainContent: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    minWidth: 0,
+  },
+  // ---- Top bar (now inside main content) ----
   topbar: {
     display: 'flex',
     alignItems: 'center',
@@ -188,6 +311,7 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorNeutralBackground1,
     flexShrink: 0,
     gap: tokens.spacingHorizontalM,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
   },
   topbarLeft: {
     display: 'flex',
@@ -204,21 +328,11 @@ const useStyles = makeStyles({
     gap: tokens.spacingHorizontalXS,
     flexShrink: 0,
   },
-  tabsContainer: {
-    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
-    backgroundColor: tokens.colorNeutralBackground1,
-    paddingLeft: tokens.spacingHorizontalL,
-    paddingRight: tokens.spacingHorizontalL,
-    flexShrink: 0,
-    display: 'flex',
-    flexDirection: 'column' as const,
-  },
-  tabHint: {
-    paddingLeft: tokens.spacingHorizontalXXS,
-    paddingBottom: tokens.spacingVerticalS,
-    color: tokens.colorNeutralForeground4,
-    fontSize: tokens.fontSizeBase200,
-    lineHeight: tokens.lineHeightBase200,
+  menuButton: {
+    display: 'none',
+    [`@media (max-width: ${SIDEBAR_COLLAPSED_BP})`]: {
+      display: 'inline-flex',
+    },
   },
   galleryCard: {
     backgroundColor: tokens.colorNeutralBackground1,
@@ -842,6 +956,7 @@ function PlaygroundInner() {
   const { widgets, addWidget, updateWidget: _updateWidget, deleteWidget, duplicateWidget } = useWidgets();
   const [inspireLoading, setInspireLoading] = useState(false);
   const inspireAbortRef = useRef<AbortController | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Abort in-flight inspiration stream on unmount
   useEffect(() => {
@@ -1175,71 +1290,160 @@ function PlaygroundInner() {
     }
   };
 
+  // Tab label map for topbar heading
+  const TAB_LABELS: Record<string, string> = {
+    create: 'Create',
+    gallery: 'Ideas',
+    components: 'Components',
+    icons: 'Icons',
+    widgets: 'Widgets',
+  };
+  const TAB_DESCRIPTIONS: Record<string, string> = {
+    create: 'Build A2UI components with AI',
+    gallery: 'Browse pre-built demo scenarios',
+    components: 'A2UI component reference',
+    icons: 'Fluent icon browser',
+    widgets: 'Your saved widget library',
+  };
+
+  const handleTabSelect = useCallback((_e: any, data: any) => {
+    setActiveTab(data.value as any);
+    setSidebarOpen(false);
+  }, []);
+
   return (
     <div className={`playground-page ${classes.playgroundPage}`}>
-      {/* ---- Top bar ---- */}
-      <div className={classes.topbar}>
-        <div className={classes.topbarLeft}>
-          <Body1Strong style={{ color: tokens.colorNeutralForeground2 }}>A2UI Playground</Body1Strong>
-          <CounterBadge
-            count={getCounter()}
-            appearance="filled"
-            color="brand"
-            overflowCount={999}
-            size="small"
+      <div className={classes.shellRow}>
+        {/* ---- Mobile overlay ---- */}
+        {sidebarOpen && (
+          <div
+            className={classes.sidebarOverlay}
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
           />
-        </div>
-        {(activeTab === 'gallery' || activeTab === 'components') && (
-          <div className={classes.topbarCenter} ref={searchBoxRef}>
-            <SearchBox
-              placeholder="Filter scenarios..."
-              value={filterQuery}
-              onChange={(_e, data) => setFilterQuery(data.value)}
-              size="small"
-            />
-          </div>
         )}
-        {activeTab === 'icons' && (
-          <div className={classes.topbarCenter} ref={iconSearchRef}>
-            <SearchBox
-              placeholder="Filter icons..."
-              value={iconFilter}
-              onChange={(_e, data) => setIconFilter(data.value)}
-              size="small"
-            />
-          </div>
-        )}
-        <div className={classes.topbarActions}>
-          {activeTab === 'create' && (
-            <Button appearance="outline" size="small" onClick={handleClearAll}>Clear All</Button>
-          )}
-          <Caption1 style={{ color: tokens.colorNeutralForeground3, marginLeft: '12px' }}>
-            v{(window as any).__BUILD_VERSION__ || '0.0.0'} · {(window as any).__BUILD_SHA__ || 'dev'}
-          </Caption1>
-        </div>
-      </div>
 
-      {/* ---- Tabs: Create | Gallery | Components | Icons | Widgets ---- */}
-      <div className={classes.tabsContainer}>
-        <TabList
-          selectedValue={activeTab}
-          onTabSelect={(_e, data) => setActiveTab(data.value as any)}
-          size="medium"
+        {/* ---- Left Sidebar ---- */}
+        <aside
+          className={`${classes.sidebar}${sidebarOpen ? ` ${classes.sidebarOpen}` : ''}`}
+          aria-label="Playground navigation"
         >
-          <Tab id="tab-create" value="create" aria-controls="panel-create">Create</Tab>
-          <Tab id="tab-gallery" value="gallery" aria-controls="panel-gallery">Ideas</Tab>
-          <Tab id="tab-components" value="components" aria-controls="panel-components">Components</Tab>
-          <Tab id="tab-icons" value="icons" aria-controls="panel-icons">Icons</Tab>
-          <Tab id="tab-widgets" value="widgets" aria-controls="panel-widgets">Widgets</Tab>
-        </TabList>
-        <Caption1 style={{ color: tokens.colorNeutralForeground3, paddingTop: tokens.spacingVerticalXS, paddingBottom: tokens.spacingVerticalXS }}>
-          {activeTab === 'create' && 'Build A2UI components with AI'}
-          {activeTab === 'gallery' && 'Browse pre-built demo scenarios'}
-          {activeTab === 'components' && 'A2UI component reference'}
-          {activeTab === 'icons' && 'Fluent icon browser'}
-          {activeTab === 'widgets' && 'Your saved widget library'}
-        </Caption1>
-      </div>
+          <div className={classes.sidebarBrand}>
+            <Body1Strong style={{ color: tokens.colorNeutralForeground2 }}>A2UI Playground</Body1Strong>
+          </div>
+
+          <nav className={classes.sidebarNav}>
+            <TabList
+              vertical
+              selectedValue={activeTab}
+              onTabSelect={handleTabSelect}
+              size="medium"
+            >
+              <Tab id="tab-create" value="create" aria-controls="panel-create" icon={<Add24Regular />}>Create</Tab>
+              <Tab id="tab-gallery" value="gallery" aria-controls="panel-gallery" icon={<Lightbulb24Regular />}>Ideas</Tab>
+              <Tab id="tab-components" value="components" aria-controls="panel-components" icon={<Grid24Regular />}>Components</Tab>
+              <Tab id="tab-icons" value="icons" aria-controls="panel-icons" icon={<Icons24Regular />}>Icons</Tab>
+              <Tab id="tab-widgets" value="widgets" aria-controls="panel-widgets" icon={<CardUi24Regular />}>Widgets</Tab>
+            </TabList>
+
+            {/* Coming-soon placeholders */}
+            <div className={classes.sidebarSeparator} />
+            <TabList vertical size="medium">
+              <Tooltip content="Coming soon" relationship="label" positioning="after">
+                <Tab value="theater" icon={<SlideText24Regular />} disabled>Theater</Tab>
+              </Tooltip>
+              <Tooltip content="Coming soon" relationship="label" positioning="after">
+                <Tab value="tutorial" icon={<BookOpen24Regular />} disabled>Tutorial</Tab>
+              </Tooltip>
+            </TabList>
+          </nav>
+
+          {/* Quick widget list in sidebar */}
+          {widgets.length > 0 && (
+            <div className={classes.sidebarWidgets}>
+              <Caption1 style={{ color: tokens.colorNeutralForeground3, display: 'block', marginBottom: tokens.spacingVerticalXS, fontWeight: tokens.fontWeightSemibold }}>
+                Widgets ({widgets.length})
+              </Caption1>
+              {widgets.slice(0, 8).map(w => (
+                <div
+                  key={w.id}
+                  className={classes.sidebarWidgetItem}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => { handleWidgetClick(w.id); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleWidgetClick(w.id); } }}
+                >
+                  <CardUi24Regular style={{ fontSize: '14px', flexShrink: 0 }} />
+                  {w.name}
+                </div>
+              ))}
+              {widgets.length > 8 && (
+                <Caption1 style={{ color: tokens.colorNeutralForeground3, paddingLeft: tokens.spacingHorizontalS }}>
+                  +{widgets.length - 8} more
+                </Caption1>
+              )}
+            </div>
+          )}
+
+          <div className={classes.sidebarFooter}>
+            <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
+              v{(window as any).__BUILD_VERSION__ || '0.0.0'} · {(window as any).__BUILD_SHA__ || 'dev'}
+            </Caption1>
+          </div>
+        </aside>
+
+        {/* ---- Main Content ---- */}
+        <div className={classes.mainContent}>
+          {/* ---- Top bar ---- */}
+          <div className={classes.topbar}>
+            <div className={classes.topbarLeft}>
+              <Button
+                className={classes.menuButton}
+                appearance="subtle"
+                icon={<Navigation24Regular />}
+                aria-label="Open navigation"
+                onClick={() => setSidebarOpen(true)}
+              />
+              <Body1Strong style={{ color: tokens.colorNeutralForeground2 }}>
+                {TAB_LABELS[activeTab]}
+              </Body1Strong>
+              <CounterBadge
+                count={getCounter()}
+                appearance="filled"
+                color="brand"
+                overflowCount={999}
+                size="small"
+              />
+            </div>
+            {(activeTab === 'gallery' || activeTab === 'components') && (
+              <div className={classes.topbarCenter} ref={searchBoxRef}>
+                <SearchBox
+                  placeholder="Filter scenarios..."
+                  value={filterQuery}
+                  onChange={(_e, data) => setFilterQuery(data.value)}
+                  size="small"
+                />
+              </div>
+            )}
+            {activeTab === 'icons' && (
+              <div className={classes.topbarCenter} ref={iconSearchRef}>
+                <SearchBox
+                  placeholder="Filter icons..."
+                  value={iconFilter}
+                  onChange={(_e, data) => setIconFilter(data.value)}
+                  size="small"
+                />
+              </div>
+            )}
+            <div className={classes.topbarActions}>
+              {activeTab === 'create' && (
+                <Button appearance="outline" size="small" onClick={handleClearAll}>Clear All</Button>
+              )}
+              <Caption1 style={{ color: tokens.colorNeutralForeground3, marginLeft: '12px' }}>
+                {TAB_DESCRIPTIONS[activeTab]}
+              </Caption1>
+            </div>
+          </div>
 
       {/* ---- Tab 1: Create (empty state — no messages yet) ---- */}
       {activeTab === 'create' && createMessages.length === 0 && (
@@ -1730,6 +1934,8 @@ function PlaygroundInner() {
           </DialogBody>
         </DialogSurface>
       </Dialog>
+        </div>{/* end mainContent */}
+      </div>{/* end shellRow */}
     </div>
   );
 }


### PR DESCRIPTION
Closes #59

## Summary
Restructures the Playground from horizontal top tabs to a left sidebar layout, matching the A2UI Composer pattern.

## Changes
- **Sidebar navigation:** Replaced horizontal `TabList` with vertical sidebar (240px) containing nav items with Fluent icons
- **Coming-soon items:** Added disabled Theater and Tutorial tabs in sidebar with tooltips
- **Widget quick-list:** Sidebar shows up to 8 saved widgets below nav for quick access
- **Responsive collapse:** Sidebar slides off-screen on mobile (<768px) with overlay backdrop and hamburger menu button
- **Topbar redesign:** Moved to main content area, shows active tab name + description + search/actions
- **Version info:** Moved from topbar to sidebar footer

## Preserved
- All 5 tab panels and their content (Create, Ideas, Components, Icons, Widgets)
- All tab IDs (`tab-create`, `tab-gallery`, `tab-components`, `tab-icons`, `tab-widgets`)
- All panel IDs (`panel-create`, `panel-gallery`, etc.)
- All ARIA attributes (`role=tabpanel`, `aria-labelledby`, `aria-controls`)
- All CSS class names used by Playwright tests (`.playground-page`, `.playground-gallery`, `.playground-gallery-scroll`, `.playground-create-scroll`, `.playground-surfaces`)
- All keyboard shortcuts (Ctrl+K, /, arrow navigation)

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx vite build` — clean
- Playwright tests: all selectors preserved (tab IDs, panel IDs, CSS classes, ARIA roles)