### PR TITLE
feat: add anonymous route for /api/action endpoint

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -534,3 +534,11 @@ These capture foundational auth setup, monorepo structure, and Phase 1 architect
 - **CI:** Non-blocking `changeset status` step added to `.github/workflows/ci.yml` (warns if changeset missing, doesn't fail build)
 - **Docs:** `RELEASING.md` has the full workflow; `CONTRIBUTING.md` links to it
 - **Key files:** `.changeset/config.json`, `RELEASING.md`, `.github/workflows/ci.yml`, `package.json`
+
+### 2025-07-26: /api/action Anonymous Access Route (Issue #23)
+
+- **Gap found:** `POST /api/action` endpoint existed on main (commit `4bbf64c`, B-24) with full implementation — action routing (reply/navigate/api), session handling, LLM re-prompting — but lacked its anonymous access route in `staticwebapp.config.json`.
+- **Fix:** Added `/api/action` route with `allowedRoles: ["anonymous"]` to `packages/web/public/staticwebapp.config.json`, matching the pattern used by `/api/converse` and `/api/playground`.
+- **SWA route ordering matters:** Anonymous routes for specific endpoints MUST appear before the catch-all `/api/*` authenticated rule. Otherwise the endpoint requires login.
+- **Protocol tests:** 22 tests in `packages/mcp-server/src/__tests__/action-endpoint.test.ts` validate `parseAppMessage`/`handleAppMessage` for the action protocol layer.
+- **PR:** #77 (draft), closes #23.

--- a/packages/web/public/staticwebapp.config.json
+++ b/packages/web/public/staticwebapp.config.json
@@ -28,6 +28,10 @@
       "allowedRoles": ["anonymous"]
     },
     {
+      "route": "/api/action",
+      "allowedRoles": ["anonymous"]
+    },
+    {
       "route": "/api/inspirations",
       "allowedRoles": ["anonymous"]
     },


### PR DESCRIPTION
Closes #23

## Summary

The `POST /api/action` endpoint was already implemented on main (commit `4bbf64c`) but was missing its anonymous access route in `staticwebapp.config.json`. Without this route, the endpoint falls through to the `/api/*` catch-all which requires `authenticated` — blocking unauthenticated A2UI component action dispatch from the frontend.

## Changes

- Added `/api/action` route with `anonymous` access in `packages/web/public/staticwebapp.config.json`, matching the pattern used by `/api/converse` and `/api/playground`

## Verification

- ✅ API build passes (`cd packages/web/api && npm run build`)
- ✅ All 22 protocol-level tests pass (`parseAppMessage`/`handleAppMessage`)
- ✅ TypeScript check passes (`npx tsc --noEmit`)
- ✅ Lint passes (`npm run lint`)

## Context

The endpoint implementation (commit `4bbf64c`, B-24) already handles:
- `{ sessionId, action, context }` request shape
- Action routing: reply (default) → LLM re-prompt, navigate → phase navigation, api → stubbed
- Session lookup, LLM call, A2UI phase indicator generation
- Error handling (400/404/500)