### PR TITLE
fix: unify button action format to A2UI ActionSchema

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -550,3 +550,4 @@ These capture foundational auth setup, monorepo structure, and Phase 1 architect
 - **Validation:** 30 B-25 contract tests pass, all 423 tests green, lint/build clean.
 - **Key files:** `packages/web/api/src/lib/response-processor.ts`, `packages/core/src/catalog/index.ts` (ButtonAction type), `packages/core/src/__tests__/action-schema.test.ts` (B-25 tests)
 - **PR:** #78
+- **Review fix (2026-04-10):** Copilot reviewer caught `data`/`context` mismatch in docs vs code. The web surface's A2UI v0.9 ActionSchema uses `event.context`, while `@kickstart/core`'s `ButtonAction` uses `event.data`. Added inline comment to `btn()` and fixed history entry + PR description. Always verify doc/code schema alignment when two type systems describe the same payload.

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -545,7 +545,7 @@ These capture foundational auth setup, monorepo structure, and Phase 1 architect
 ### 2026-04-10: Unified Button Action Format (B-25 / Issue #24)
 
 - **Problem:** The `btn()` helper in `packages/web/api/src/lib/response-processor.ts` used a custom flat format (`action: "reply", data: { text }`) that bypassed the A2UI ActionSchema.
-- **Fix:** Updated `btn()` to emit `action: { event: { name: "reply", data: { text } } }` — the canonical A2UI v0.9 ActionSchema shape.
+- **Fix:** Updated `btn()` to emit `action: { event: { name: "reply", context: { text } } }` — the canonical A2UI v0.9 ActionSchema shape (uses `event.context`, not `event.data`).
 - **Scope:** Only the web API response-processor needed fixing. The core catalog (`ButtonAction` type), action dispatch hooks, and MCP server action handler already used the correct format.
 - **Validation:** 30 B-25 contract tests pass, all 423 tests green, lint/build clean.
 - **Key files:** `packages/web/api/src/lib/response-processor.ts`, `packages/core/src/catalog/index.ts` (ButtonAction type), `packages/core/src/__tests__/action-schema.test.ts` (B-25 tests)

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -542,3 +542,11 @@ These capture foundational auth setup, monorepo structure, and Phase 1 architect
 - **SWA route ordering matters:** Anonymous routes for specific endpoints MUST appear before the catch-all `/api/*` authenticated rule. Otherwise the endpoint requires login.
 - **Protocol tests:** 22 tests in `packages/mcp-server/src/__tests__/action-endpoint.test.ts` validate `parseAppMessage`/`handleAppMessage` for the action protocol layer.
 - **PR:** #77 (draft), closes #23.
+### 2026-04-10: Unified Button Action Format (B-25 / Issue #24)
+
+- **Problem:** The `btn()` helper in `packages/web/api/src/lib/response-processor.ts` used a custom flat format (`action: "reply", data: { text }`) that bypassed the A2UI ActionSchema.
+- **Fix:** Updated `btn()` to emit `action: { event: { name: "reply", data: { text } } }` — the canonical A2UI v0.9 ActionSchema shape.
+- **Scope:** Only the web API response-processor needed fixing. The core catalog (`ButtonAction` type), action dispatch hooks, and MCP server action handler already used the correct format.
+- **Validation:** 30 B-25 contract tests pass, all 423 tests green, lint/build clean.
+- **Key files:** `packages/web/api/src/lib/response-processor.ts`, `packages/core/src/catalog/index.ts` (ButtonAction type), `packages/core/src/__tests__/action-schema.test.ts` (B-25 tests)
+- **PR:** #78

--- a/packages/web/api/src/lib/response-processor.ts
+++ b/packages/web/api/src/lib/response-processor.ts
@@ -206,7 +206,7 @@ function inferDesignComponents(
   return [];
 }
 
-// Helper: create a suggestion button component
+// Helper: create a suggestion button using A2UI ActionSchema format
 function btn(
   label: string,
   replyText: string,
@@ -214,7 +214,11 @@ function btn(
   return {
     type: "Button",
     label,
-    action: "reply",
-    data: { text: replyText },
+    action: {
+      event: {
+        name: "reply",
+        data: { text: replyText },
+      },
+    },
   };
 }

--- a/packages/web/api/src/lib/response-processor.ts
+++ b/packages/web/api/src/lib/response-processor.ts
@@ -206,7 +206,10 @@ function inferDesignComponents(
   return [];
 }
 
-// Helper: create a suggestion button using A2UI ActionSchema format
+// Helper: create a suggestion button using A2UI v0.9 ActionSchema format.
+// Note: This targets the web surface's ActionSchema (event.context), not
+// @kickstart/core's ButtonAction type (event.data). Keep in sync with
+// packages/web/src/vendor/a2ui/web_core/schema/common-types.ts.
 function btn(
   label: string,
   replyText: string,

--- a/packages/web/api/src/lib/response-processor.ts
+++ b/packages/web/api/src/lib/response-processor.ts
@@ -217,7 +217,7 @@ function btn(
     action: {
       event: {
         name: "reply",
-        data: { text: replyText },
+        context: { text: replyText },
       },
     },
   };


### PR DESCRIPTION
Closes #24

## Summary
The `btn()` helper in `packages/web/api/src/lib/response-processor.ts` used a custom flat format (`action: "reply", data: { text }`) that did not conform to the A2UI v0.9 ActionSchema. Updated to use the canonical `{ event: { name, context } }` shape.

## Changes
- Updated `btn()` helper to emit `action: { event: { name: "reply", context: { text } } }` instead of `action: "reply", data: { text }`
- This aligns with the A2UI v0.9 `ActionSchema` in `common-types.ts` (which uses `event.context`)
- Note: `@kickstart/core`'s `ButtonAction` type uses `event.data` — the web surface's ActionSchema uses `event.context`. An inline comment clarifies the distinction.

## Testing
- All 30 B-25 contract tests pass
- All 423 tests green (`npx vitest run`)
- Lint clean (`npm run lint`)
- Build clean (`npm run build`)
- TypeScript check clean (`npx tsc --noEmit`)