### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.changeset/configure-changesets-releases.md
+++ b/.changeset/configure-changesets-releases.md
@@ -1,7 +1,0 @@
----
-"@kickstart/core": patch
-"@kickstart/web": patch
-"@kickstart/mcp-server": patch
----
-
-Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.

--- a/.changeset/session-2-polish.md
+++ b/.changeset/session-2-polish.md
@@ -1,7 +1,0 @@
----
-"@kickstart/core": patch
-"@kickstart/web": patch
-"@kickstart/mcp-server": patch
----
-
-UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 This project uses [@changesets/cli](https://github.com/changesets/changesets) for versioning.
 
+## 0.2.0
+
+### @kickstart/web
+
+- **Sidebar layout** — Playground restructured with A2UI Composer sidebar navigation (#59)
+- **Action system** — End-to-end button→API→handler pipeline: wire action handler (#22), /api/action endpoint (#23), unified ActionSchema format (#24)
+- **Questionnaire + Markdown components** — New A2UI catalog components for guided flows (#2)
+- **Playwright E2E tests stabilized** — 15 tests updated to match current UI (#69)
+- **TypeScript CI errors resolved** — ~50 pre-existing errors fixed, CI pipeline now green (#67)
+- **Playground link fix** — README uses full URL for playground (#71)
+
+### @kickstart/core
+
+- **Prompt knowledge updates** — KAITO/RAGEngine/Fine-Tuning knowledge ported to azureKit (#27), OIDC pipeline protocol added to githubKit (#28), false secrets claim fixed (#29), component props documented (#3)
+
+### Tooling
+
+- **Changesets & releases strategy** — Configured @changesets/cli with GitHub changelog integration (#53)
+- **PR workflow skill** — Consolidated issue→branch→PR→review→merge lifecycle into a single reference document
+
 ## 0.1.0 — Initial Scaffold
 
 ### @kickstart/core

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Kickstart helps developers go from "I have an app" to "it's running on Azure" th
 
 - **AI-guided landing page** — Track cards, framework pills, and an ✨ inspiration button that generates app ideas via AI
 - **A2UI component system** — 16 custom components + Fluent UI 2 styled vendor catalog, rendered from structured JSON returned by the LLM
-- **Component playground** — Interactive demo surface (https://kickstart.aks.azure.sabbour.me/?playground) for exploring A2UI components and scenarios
+- **Component playground** — Interactive sidebar-navigated demo surface (https://kickstart.aks.azure.sabbour.me/?playground) for exploring A2UI components, scenarios, and questionnaire flows
+- **Action system** — Unified button action pipeline with `/api/action` endpoint for component-driven interactions
 - **Azure Functions API** — Streaming conversation proxy, code generation (Codex), CORS proxies for ARM/GitHub/Pricing APIs
 - **MCP server** — IDE integration for VS Code Copilot and Claude Code via `@kickstart/mcp-server`
 - **Monorepo** — `packages/core` (engine), `packages/web` (React 19 + Vite 6), `packages/mcp-server` (MCP tools)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,25 @@
+# @kickstart/core
+
+## 0.2.0
+
+### Minor Changes
+
+- v0.2.0 release: Sidebar layout, action system, questionnaire components, prompt knowledge, and CI stabilization.
+
+### Patch Changes
+
+- [#70](https://github.com/sabbour/kickstart/pull/70) [`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba) Thanks [@sabbour](https://github.com/sabbour)! - Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.
+
+- [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd) Thanks [@sabbour](https://github.com/sabbour)! - UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).
+
+## 0.2.0
+
+### Minor Changes
+
+- v0.2.0 release: Sidebar layout, action system, questionnaire components, prompt knowledge, and CI stabilization.
+
+### Patch Changes
+
+- [#70](https://github.com/sabbour/kickstart/pull/70) [`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba) Thanks [@sabbour](https://github.com/sabbour)! - Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.
+
+- [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd) Thanks [@sabbour](https://github.com/sabbour)! - UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Kickstart conversation engine, A2UI catalog, and code generators",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,0 +1,31 @@
+# @kickstart/mcp-server
+
+## 0.2.0
+
+### Minor Changes
+
+- v0.2.0 release: Sidebar layout, action system, questionnaire components, prompt knowledge, and CI stabilization.
+
+### Patch Changes
+
+- [#70](https://github.com/sabbour/kickstart/pull/70) [`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba) Thanks [@sabbour](https://github.com/sabbour)! - Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.
+
+- [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd) Thanks [@sabbour](https://github.com/sabbour)! - UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).
+
+- Updated dependencies [[`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba), [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd)]:
+  - @kickstart/core@0.2.0
+
+## 0.2.0
+
+### Minor Changes
+
+- v0.2.0 release: Sidebar layout, action system, questionnaire components, prompt knowledge, and CI stabilization.
+
+### Patch Changes
+
+- [#70](https://github.com/sabbour/kickstart/pull/70) [`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba) Thanks [@sabbour](https://github.com/sabbour)! - Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.
+
+- [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd) Thanks [@sabbour](https://github.com/sabbour)! - UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).
+
+- Updated dependencies [[`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba), [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd)]:
+  - @kickstart/core@0.2.0

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for AKS Kickstart — exposes conversation tools and A2UI responses",
   "type": "module",
   "main": "dist/index.js",
@@ -22,5 +22,10 @@
   "devDependencies": {
     "vitest": "^4.1.3"
   },
-  "keywords": ["mcp", "kickstart", "aks", "a2ui"]
+  "keywords": [
+    "mcp",
+    "kickstart",
+    "aks",
+    "a2ui"
+  ]
 }

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,0 +1,25 @@
+# @kickstart/web
+
+## 0.2.0
+
+### Minor Changes
+
+- v0.2.0 release: Sidebar layout, action system, questionnaire components, prompt knowledge, and CI stabilization.
+
+### Patch Changes
+
+- [#70](https://github.com/sabbour/kickstart/pull/70) [`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba) Thanks [@sabbour](https://github.com/sabbour)! - Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.
+
+- [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd) Thanks [@sabbour](https://github.com/sabbour)! - UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).
+
+## 0.2.0
+
+### Minor Changes
+
+- v0.2.0 release: Sidebar layout, action system, questionnaire components, prompt knowledge, and CI stabilization.
+
+### Patch Changes
+
+- [#70](https://github.com/sabbour/kickstart/pull/70) [`c83f5cd`](https://github.com/sabbour/kickstart/commit/c83f5cd2c98a86c7ff3d7778ecace6326f3889ba) Thanks [@sabbour](https://github.com/sabbour)! - Configure changesets release workflow with GitHub changelog integration, CI validation, and release documentation.
+
+- [`ea890de`](https://github.com/sabbour/kickstart/commit/ea890de4d898302ad542e3c5d6dba7479d1333bd) Thanks [@sabbour](https://github.com/sabbour)! - UX polish and fixes: chat icon refactor, inspiration progress bar, playground StrictMode fix, SWA config alignment, Griffel shorthand improvements, and general backlog cleanup (B-46 through B-59).

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Kickstart web frontend — Azure Portal-style UX for AI-guided AKS deployment",


### PR DESCRIPTION
## Release v0.2.0

Bumps all packages to 0.2.0. Consumes changesets and updates changelogs.

### What shipped (12 issues closed)

**Features:**
- #59 — Sidebar layout for Playground
- #24 — Unified button action format
- #23 — /api/action endpoint
- #22 — Wire action handler for A2UI components
- #2 — Questionnaire + Markdown components

**Knowledge:**
- #28 — OIDC pipeline protocol for githubKit
- #27 — KAITO/RAGEngine/Fine-Tuning knowledge for azureKit
- #3 — Kit component props documented

**Fixes:**
- #29 — Fix false secrets claim in githubKit
- #67 — Fix ~50 TypeScript CI errors
- #71 — Playground link URL fix

**Tooling:**
- #53 — Changesets & releases strategy

### Changes in this PR
- Package versions bumped 0.1.0 → 0.2.0 (core, web, mcp-server)
- Changesets consumed, per-package CHANGELOGs generated
- Root CHANGELOG.md updated with v0.2.0 section
- README.md features list updated (sidebar, action system)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>