### PR TITLE
fix(security): API security hardening

### DIFF
--- a/packages/web/api/src/functions/action.ts
+++ b/packages/web/api/src/functions/action.ts
@@ -26,6 +26,8 @@ import type { Phase, PhaseItem } from "@kickstart/core";
 import type { A2UIMessage } from "@kickstart/core";
 import { getSession, addMessage } from "../lib/session-store.js";
 import { chatCompletion, getChatDeploymentName } from "../lib/openai-client.js";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse } from "../lib/error-response.js";
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -178,6 +180,12 @@ app.http("action", {
     request: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> => {
+    // Rate limit check
+    const rateCheck = checkRateLimit(request);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
     try {
       // --- Parse & validate request ---
       let body: ActionRequest;
@@ -268,9 +276,7 @@ app.http("action", {
       };
       return { status: 200, jsonBody: response };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      context.error(`[action] error: ${message}`);
-      return { status: 500, jsonBody: { error: message } };
+      return safeErrorResponse(err, context, "[action] error");
     }
   },
 });

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -24,6 +24,8 @@ import type { PhaseItem } from "@kickstart/core";
 import { getSession, createSession, addMessage } from "../lib/session-store.js";
 import { chatCompletion, chatCompletionWithTools, getChatDeploymentName } from "../lib/openai-client.js";
 import { checkContentSafety } from "../lib/content-safety.js";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse, safeStreamError } from "../lib/error-response.js";
 
 interface ConverseRequest {
   sessionId?: string;
@@ -36,7 +38,6 @@ interface ConverseResponse {
   message: string;
   model?: string;
   a2ui?: object[];
-  systemPrompt?: string;
 }
 
 app.http("converse", {
@@ -47,6 +48,12 @@ app.http("converse", {
     request: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> => {
+    // Rate limit check
+    const rateCheck = checkRateLimit(request);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
     try {
       const body = (await request.json()) as ConverseRequest;
 
@@ -64,7 +71,6 @@ app.http("converse", {
       let session = body.sessionId
         ? getSession(body.sessionId)
         : undefined;
-      const isNewSession = !session;
       if (!session) {
         session = createSession();
       }
@@ -148,19 +154,11 @@ app.http("converse", {
         message: processed.message,
         model: getChatDeploymentName(),
         a2ui: [...phaseA2ui, ...processed.a2uiMessages],
-        ...(isNewSession
-          ? {
-              systemPrompt: state.messages.find((m) => m.role === "system")
-                ?.content,
-            }
-          : {}),
       };
 
       return { status: 200, jsonBody: responseBody };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      context.error(`Converse error: ${message}`);
-      return { status: 500, jsonBody: { error: message } };
+      return safeErrorResponse(err, context, "Converse error");
     }
   },
 });
@@ -275,10 +273,9 @@ function handleStreaming(
 
         controller.close();
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        context.error(`Stream error: ${msg}`);
+        const safeMsg = safeStreamError(err, context, "Stream error");
         controller.enqueue(
-          encoder.encode(`event: error\ndata: ${JSON.stringify({ error: msg })}\n\n`),
+          encoder.encode(`event: error\ndata: ${JSON.stringify({ error: safeMsg })}\n\n`),
         );
         controller.close();
       }

--- a/packages/web/api/src/functions/generate.ts
+++ b/packages/web/api/src/functions/generate.ts
@@ -19,6 +19,8 @@ import {
   codexCompletionStream,
   isConfigured,
 } from "../lib/openai-client.js";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse, safeStreamError } from "../lib/error-response.js";
 import type { ChatMessage } from "../lib/openai-client.js";
 
 type GenerateType =
@@ -61,6 +63,12 @@ app.http("generate", {
     request: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> => {
+    // Rate limit check
+    const rateCheck = checkRateLimit(request);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
     try {
       if (!isConfigured()) {
         return {
@@ -112,9 +120,7 @@ app.http("generate", {
 
       return { status: 200, jsonBody: responseBody };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      context.error(`Generate error: ${message}`);
-      return { status: 500, jsonBody: { error: message } };
+      return safeErrorResponse(err, context, "Generate error");
     }
   },
 });
@@ -150,10 +156,9 @@ function handleCodexStreaming(
         );
         controller.close();
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        context.error(`Codex stream error: ${msg}`);
+        const safeMsg = safeStreamError(err, context, "Codex stream error");
         controller.enqueue(
-          encoder.encode(`data: ${JSON.stringify({ error: msg })}\n\n`),
+          encoder.encode(`data: ${JSON.stringify({ error: safeMsg })}\n\n`),
         );
         controller.close();
       }

--- a/packages/web/api/src/functions/inspirations.ts
+++ b/packages/web/api/src/functions/inspirations.ts
@@ -19,6 +19,8 @@ import type {
   HttpResponseInit,
   InvocationContext,
 } from "@azure/functions";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse, safeStreamError } from "../lib/error-response.js";
 
 interface InspirationIdea {
   title: string;
@@ -206,6 +208,12 @@ app.http("inspirations", {
     request: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> => {
+    // Rate limit check
+    const rateCheck = checkRateLimit(request);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
     const url = new URL(request.url);
     const isStreaming = url.searchParams.get("stream") === "true";
 
@@ -252,9 +260,8 @@ app.http("inspirations", {
               controller.enqueue(encoder.encode(sseData("[DONE]")));
               controller.close();
             } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              context.log(`Streaming error: ${msg}`);
-              controller.enqueue(encoder.encode(sseData(`[ERROR] ${msg}`)));
+              const safeMsg = safeStreamError(err, context, "Inspiration stream error");
+              controller.enqueue(encoder.encode(sseData(`[ERROR] ${safeMsg}`)));
               controller.close();
             }
           },
@@ -284,12 +291,12 @@ app.http("inspirations", {
       try {
         ideas = await generateIdeas();
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        context.log(`OpenAI generation failed: ${msg}`);
+        const detail = err instanceof Error ? err.message : String(err);
+        context.error(`OpenAI generation failed: ${detail}`);
         return {
           status: 502,
           headers: { "Content-Type": "application/json" },
-          jsonBody: { error: `Inspiration generation failed: ${msg}` },
+          jsonBody: { error: "Inspiration generation is temporarily unavailable." },
         };
       }
 
@@ -299,9 +306,7 @@ app.http("inspirations", {
         jsonBody: ideas,
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      context.log(`Inspirations error: ${message}`);
-      return { status: 500, jsonBody: { error: message } };
+      return safeErrorResponse(err, context, "Inspirations error");
     }
   },
 });

--- a/packages/web/api/src/functions/playground.ts
+++ b/packages/web/api/src/functions/playground.ts
@@ -14,6 +14,8 @@ import type { HttpRequest, HttpResponseInit, InvocationContext } from "@azure/fu
 import { randomUUID } from "node:crypto";
 import { chatCompletion, getChatDeploymentName } from "../lib/openai-client.js";
 import { checkContentSafety } from "../lib/content-safety.js";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse } from "../lib/error-response.js";
 import type { ChatMessage } from "../lib/openai-client.js";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -166,6 +168,12 @@ app.http("playground", {
     request: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> => {
+    // Rate limit check
+    const rateCheck = checkRateLimit(request);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
     try {
       const body = (await request.json()) as PlaygroundRequest;
 
@@ -234,9 +242,7 @@ app.http("playground", {
 
       return { status: 200, jsonBody: responseBody };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      context.error(`Playground error: ${message}`);
-      return { status: 500, jsonBody: { error: message } };
+      return safeErrorResponse(err, context, "Playground error");
     }
   },
 });

--- a/packages/web/api/src/lib/error-response.ts
+++ b/packages/web/api/src/lib/error-response.ts
@@ -1,0 +1,44 @@
+/**
+ * @module @kickstart/api/lib/error-response
+ *
+ * Shared error handling utilities for API functions.
+ * Logs full error details server-side and returns a generic message to clients.
+ */
+
+import type { InvocationContext } from "@azure/functions";
+
+const GENERIC_ERROR_MESSAGE = "An error occurred processing your request.";
+
+/**
+ * Build a safe 500 error response. Logs full error details server-side,
+ * returns only a generic message to the client.
+ */
+export function safeErrorResponse(
+  err: unknown,
+  context: InvocationContext,
+  label: string,
+): { status: 500; jsonBody: { error: string } } {
+  const detail = err instanceof Error ? err.message : String(err);
+  context.error(`${label}: ${detail}`);
+  if (err instanceof Error && err.stack) {
+    context.error(`${label} stack: ${err.stack}`);
+  }
+  return { status: 500, jsonBody: { error: GENERIC_ERROR_MESSAGE } };
+}
+
+/**
+ * Format a safe error message for SSE streaming responses.
+ * Returns only a generic error — never internal details.
+ */
+export function safeStreamError(
+  err: unknown,
+  context: InvocationContext,
+  label: string,
+): string {
+  const detail = err instanceof Error ? err.message : String(err);
+  context.error(`${label}: ${detail}`);
+  if (err instanceof Error && err.stack) {
+    context.error(`${label} stack: ${err.stack}`);
+  }
+  return GENERIC_ERROR_MESSAGE;
+}

--- a/packages/web/api/src/lib/rate-limiter.ts
+++ b/packages/web/api/src/lib/rate-limiter.ts
@@ -1,9 +1,12 @@
 /**
  * @module @kickstart/api/lib/rate-limiter
  *
- * Simple in-memory per-IP rate limiter for API endpoints.
- * Tracks request counts in a sliding window and rejects requests
- * that exceed the configured limit.
+ * In-memory sliding-window rate limiter for API endpoints.
+ *
+ * Key resolution order:
+ *   1. SWA authenticated principal ID (x-ms-client-principal-id) — trusted
+ *   2. IP from proxy headers (x-forwarded-for, x-client-ip, x-real-ip) — fallback
+ *   3. Global backstop bucket — always enforced regardless of per-client key
  */
 
 interface RateLimitEntry {
@@ -15,6 +18,11 @@ const store = new Map<string, RateLimitEntry>();
 
 const DEFAULT_WINDOW_MS = 60_000; // 1 minute
 const DEFAULT_MAX_REQUESTS = 30;
+
+// Global backstop: shared bucket for all requests (prevents aggregate abuse)
+const GLOBAL_KEY = "__global__";
+const GLOBAL_MAX_REQUESTS = 300;
+const GLOBAL_WINDOW_MS = 60_000;
 
 // Periodically clean up expired entries to prevent unbounded memory growth
 const cleanupInterval = setInterval(() => {
@@ -28,16 +36,22 @@ const cleanupInterval = setInterval(() => {
 cleanupInterval.unref();
 
 /**
- * Extract the client IP from an Azure Functions HTTP request.
- * Falls back to "unknown" if no IP can be determined.
+ * Extract a client identifier from the request.
+ * Prefers SWA authenticated principal ID (trusted, not spoofable),
+ * falls back to IP-based headers only when auth is unavailable.
  */
-function getClientIp(request: { headers: { get(name: string): string | undefined | null } }): string {
-  return (
+function getClientId(request: { headers: { get(name: string): string | undefined | null } }): string {
+  // SWA injects x-ms-client-principal-id after auth — trusted, not spoofable
+  const principalId = request.headers.get("x-ms-client-principal-id");
+  if (principalId) return `principal:${principalId}`;
+
+  // Fallback to IP headers (spoofable, but better than nothing)
+  return `ip:${
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
     request.headers.get("x-client-ip") ||
     request.headers.get("x-real-ip") ||
     "unknown"
-  );
+  }`;
 }
 
 export interface RateLimitResult {
@@ -46,24 +60,18 @@ export interface RateLimitResult {
   retryAfterMs?: number;
 }
 
-/**
- * Check whether a request from the given IP is within the rate limit.
- * Returns { allowed, remaining, retryAfterMs }.
- */
-export function checkRateLimit(
-  request: { headers: { get(name: string): string | undefined | null } },
-  maxRequests = DEFAULT_MAX_REQUESTS,
-  windowMs = DEFAULT_WINDOW_MS,
+/** Check a single bucket. Returns { allowed, remaining, retryAfterMs }. */
+function checkBucket(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
 ): RateLimitResult {
-  const ip = getClientIp(request);
   const now = Date.now();
+  let entry = store.get(key);
 
-  let entry = store.get(ip);
-
-  // Start a new window if none exists or the current one has expired
   if (!entry || now - entry.windowStart >= windowMs) {
     entry = { count: 0, windowStart: now };
-    store.set(ip, entry);
+    store.set(key, entry);
   }
 
   entry.count++;
@@ -74,6 +82,24 @@ export function checkRateLimit(
   }
 
   return { allowed: true, remaining: maxRequests - entry.count };
+}
+
+/**
+ * Check whether a request is within rate limits.
+ * Enforces both a per-client limit and a global backstop.
+ */
+export function checkRateLimit(
+  request: { headers: { get(name: string): string | undefined | null } },
+  maxRequests = DEFAULT_MAX_REQUESTS,
+  windowMs = DEFAULT_WINDOW_MS,
+): RateLimitResult {
+  // Global backstop — always checked regardless of per-client key
+  const globalResult = checkBucket(GLOBAL_KEY, GLOBAL_MAX_REQUESTS, GLOBAL_WINDOW_MS);
+  if (!globalResult.allowed) return globalResult;
+
+  // Per-client limit
+  const clientId = getClientId(request);
+  return checkBucket(clientId, maxRequests, windowMs);
 }
 
 /**

--- a/packages/web/api/src/lib/rate-limiter.ts
+++ b/packages/web/api/src/lib/rate-limiter.ts
@@ -1,0 +1,94 @@
+/**
+ * @module @kickstart/api/lib/rate-limiter
+ *
+ * Simple in-memory per-IP rate limiter for API endpoints.
+ * Tracks request counts in a sliding window and rejects requests
+ * that exceed the configured limit.
+ */
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+const DEFAULT_MAX_REQUESTS = 30;
+
+// Periodically clean up expired entries to prevent unbounded memory growth
+const cleanupInterval = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    if (now - entry.windowStart > DEFAULT_WINDOW_MS * 2) {
+      store.delete(key);
+    }
+  }
+}, 5 * 60_000);
+cleanupInterval.unref();
+
+/**
+ * Extract the client IP from an Azure Functions HTTP request.
+ * Falls back to "unknown" if no IP can be determined.
+ */
+function getClientIp(request: { headers: { get(name: string): string | undefined | null } }): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-client-ip") ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfterMs?: number;
+}
+
+/**
+ * Check whether a request from the given IP is within the rate limit.
+ * Returns { allowed, remaining, retryAfterMs }.
+ */
+export function checkRateLimit(
+  request: { headers: { get(name: string): string | undefined | null } },
+  maxRequests = DEFAULT_MAX_REQUESTS,
+  windowMs = DEFAULT_WINDOW_MS,
+): RateLimitResult {
+  const ip = getClientIp(request);
+  const now = Date.now();
+
+  let entry = store.get(ip);
+
+  // Start a new window if none exists or the current one has expired
+  if (!entry || now - entry.windowStart >= windowMs) {
+    entry = { count: 0, windowStart: now };
+    store.set(ip, entry);
+  }
+
+  entry.count++;
+
+  if (entry.count > maxRequests) {
+    const retryAfterMs = windowMs - (now - entry.windowStart);
+    return { allowed: false, remaining: 0, retryAfterMs };
+  }
+
+  return { allowed: true, remaining: maxRequests - entry.count };
+}
+
+/**
+ * Build a 429 Too Many Requests response with appropriate headers.
+ */
+export function rateLimitResponse(retryAfterMs: number): {
+  status: 429;
+  headers: Record<string, string>;
+  jsonBody: { error: string };
+} {
+  return {
+    status: 429,
+    headers: {
+      "Retry-After": String(Math.ceil(retryAfterMs / 1000)),
+    },
+    jsonBody: { error: "Too many requests. Please try again later." },
+  };
+}

--- a/packages/web/public/staticwebapp.config.json
+++ b/packages/web/public/staticwebapp.config.json
@@ -21,11 +21,11 @@
     },
     {
       "route": "/api/inspirations",
-      "allowedRoles": ["anonymous"]
+      "allowedRoles": ["authenticated"]
     },
     {
       "route": "/api/inspirations/*",
-      "allowedRoles": ["anonymous"]
+      "allowedRoles": ["authenticated"]
     },
     {
       "route": "/api/playground",

--- a/packages/web/public/staticwebapp.config.json
+++ b/packages/web/public/staticwebapp.config.json
@@ -20,24 +20,28 @@
       "allowedRoles": ["anonymous"]
     },
     {
-      "route": "/api/playground",
-      "allowedRoles": ["anonymous"]
-    },
-    {
-      "route": "/api/converse",
-      "allowedRoles": ["anonymous"]
-    },
-    {
-      "route": "/api/action",
-      "allowedRoles": ["anonymous"]
-    },
-    {
       "route": "/api/inspirations",
       "allowedRoles": ["anonymous"]
     },
     {
       "route": "/api/inspirations/*",
       "allowedRoles": ["anonymous"]
+    },
+    {
+      "route": "/api/playground",
+      "allowedRoles": ["authenticated"]
+    },
+    {
+      "route": "/api/converse",
+      "allowedRoles": ["authenticated"]
+    },
+    {
+      "route": "/api/action",
+      "allowedRoles": ["authenticated"]
+    },
+    {
+      "route": "/api/generate",
+      "allowedRoles": ["authenticated"]
     },
     {
       "route": "/api/*",


### PR DESCRIPTION
Fixes #83, fixes #84, fixes #85

## Changes
- Add in-memory rate limiter for AI endpoints (30 req/min per IP) with shared utility
- Require SWA authentication on /api/converse, /api/playground, /api/action, /api/generate
- Strip system messages from /api/converse responses (was exposed on new sessions)
- Sanitize error responses - generic messages to client, full details logged server-side
- Add shared error-response.ts and rate-limiter.ts utilities

## Security
Addresses critical and medium API vulnerabilities from Zapp v0.2.0 security audit:
- #83 (CRITICAL): Rate limiting + SWA auth on AI endpoints
- #84 (MEDIUM): System prompt no longer returned in API responses
- #85 (MEDIUM): Internal error details replaced with generic messages