### PR TITLE
fix(security): add Content-Security-Policy and security headers (fixes #86)

### DIFF
--- a/packages/web/public/staticwebapp.config.json
+++ b/packages/web/public/staticwebapp.config.json
@@ -68,6 +68,7 @@
     ]
   },
   "globalHeaders": {
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.openai.azure.com; font-src 'self' data:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "X-XSS-Protection": "1; mode=block",


### PR DESCRIPTION
Closes #86

## Summary
Adds a `Content-Security-Policy` header to `staticwebapp.config.json` to mitigate XSS and script injection attacks (OWASP A05:2021).

## Changes
- Added restrictive CSP header to `globalHeaders` in `staticwebapp.config.json`:
  - `default-src 'self'` — same-origin by default
  - `script-src 'self'` — no inline scripts
  - `style-src 'self' 'unsafe-inline'` — required for Fluent UI runtime styles
  - `img-src 'self' data: https:` — data URIs and HTTPS images
  - `connect-src 'self' https://*.openai.azure.com` — Azure OpenAI API calls
  - `font-src 'self' data:` — embedded fonts
  - `object-src 'none'` — block plugins
  - `frame-ancestors 'none'` — prevent clickjacking
  - `base-uri 'self'` / `form-action 'self'` — additional hardening
- `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` were already present ✅

## Testing
- JSON validated with `python3 -m json.tool`
- `npm run lint` passes
- `npm run build` succeeds (config-only change, no code impact)