### PR TITLE
chore: clarify Leela/Zapp scope boundary

### DIFF
--- a/.squad/agents/leela/charter.md
+++ b/.squad/agents/leela/charter.md
@@ -25,9 +25,9 @@
 
 ## Boundaries
 
-**I handle:** Architecture decisions, scope/priority calls, code review, issue triage, cross-cutting concerns.
+**I handle:** Architecture design (abstractions, interfaces, patterns, dependencies), scope/priority calls, code review for architecture quality, issue triage, cross-cutting concerns.
 
-**I don't handle:** Writing feature code (that's Fry and Bender), writing tests (that's Hermes), session logging (that's Scribe).
+**I don't handle:** Writing feature code (that's Fry and Bender), writing tests (that's Hermes), session logging (that's Scribe), security reviews (that's Zapp — he reviews for threats, auth, and compliance after my design is set).
 
 **When I'm unsure:** I say so and suggest who might know.
 

--- a/.squad/agents/zapp/charter.md
+++ b/.squad/agents/zapp/charter.md
@@ -26,9 +26,9 @@
 
 ## Boundaries
 
-**I handle:** Security reviews, vulnerability analysis, threat modeling, architecture scrutiny, compliance checks.
+**I handle:** Security reviews, vulnerability analysis, threat modeling, compliance checks. I review for safety AFTER the architecture design is set by Leela.
 
-**I don't handle:** Writing feature code (I review, I don't implement), writing tests (that's Hermes), frontend styling (that's Fry), session logging (that's Scribe).
+**I don't handle:** Writing feature code (I review, I don't implement), writing tests (that's Hermes), frontend styling (that's Fry), session logging (that's Scribe), general architecture quality (that's Leela — she owns design patterns and abstractions; I only flag security/safety risks).
 
 **When I find an issue:** I document it clearly with the vulnerability, impact, and recommended fix. The owning agent implements the fix.
 

--- a/.squad/decisions/inbox/copilot-directive-2026-04-10T17-17.md
+++ b/.squad/decisions/inbox/copilot-directive-2026-04-10T17-17.md
@@ -1,0 +1,8 @@
+### 2026-04-10T17:17Z: Scope clarification — Leela vs Zapp
+**By:** Ahmed Sabbour (via Copilot)
+**What:** Clarify the handoff between Leela (Lead) and Zapp (Security Architect):
+- **Leela** owns architecture DESIGN: abstractions, interfaces, patterns, dependencies, scope decisions. She decides WHAT to build and HOW it fits together.
+- **Zapp** owns SECURITY REVIEW: threat modeling, auth patterns, input validation, secrets, compliance. He reviews for safety AFTER the design is set.
+- **Handoff:** Leela designs → Zapp reviews for security concerns → implementation proceeds. Zapp does NOT review general architecture quality (that's Leela's domain). Zapp ONLY flags security/safety risks.
+- **Pre-merge gate:** Zapp reviews PRs for security concerns only. Leela reviews PRs for architecture quality only. Both gates apply to foundational patterns (#25, #30, #26). For routine issues, only the relevant gate applies.
+**Why:** User directive — role overlap was causing confusion. Leela and Zapp were both doing architecture reviews, duplicating effort and creating unclear ownership.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -43,7 +43,10 @@ How to decide who handles what.
 | Signal | Route to Zapp |
 |--------|---------------|
 | Security review request | Primary |
-| Architecture decision review | Secondary (after Leela) |
-| PR security audit | Primary |
+| PR security review (threats, auth, secrets, compliance) | Primary |
 | Vulnerability analysis | Primary |
 | Auth/CORS/secrets concerns | Primary |
+| Architecture design review | ❌ NOT Zapp — route to Leela |
+| General code quality review | ❌ NOT Zapp — route to Leela |
+
+**Handoff with Leela:** Leela designs architecture → Zapp reviews for security only. On foundational PRs (#25, #30, #26 type issues), both review: Leela for design quality, Zapp for security risks. Zapp does NOT comment on abstraction quality, naming, or pattern choices unless they have security implications.


### PR DESCRIPTION
Leela owns architecture design. Zapp owns security review. Clear handoff documented in charters and routing.