### PR TITLE
feat: Implement LLM tool system (function calling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ docs-site/        Docusaurus documentation site
 
 ## License
 
-Internal project — Microsoft.
+This project is licensed under the [MIT License](./LICENSE).

--- a/packages/core/src/connectors/GitHubConnector.ts
+++ b/packages/core/src/connectors/GitHubConnector.ts
@@ -26,9 +26,11 @@ export interface GitHubRepoOptions {
 }
 
 /**
- * Default GitHub OAuth scopes.
+ * Default GitHub OAuth scopes — minimal read-only access.
+ * `public_repo` grants read-only access to public repos. Full `repo` scope
+ * is only needed for write operations on private repositories.
  */
-const DEFAULT_GITHUB_SCOPES = ['repo', 'read:user'];
+const DEFAULT_GITHUB_SCOPES = ['public_repo', 'read:user'];
 
 /**
  * Connector for the GitHub REST API.

--- a/packages/core/src/connectors/GitHubConnector.ts
+++ b/packages/core/src/connectors/GitHubConnector.ts
@@ -26,11 +26,13 @@ export interface GitHubRepoOptions {
 }
 
 /**
- * Default GitHub OAuth scopes — minimal read-only access.
- * `public_repo` grants read-only access to public repos. Full `repo` scope
- * is only needed for write operations on private repositories.
+ * Default GitHub OAuth scopes — read-only access.
+ * `read:user` grants access to the authenticated user's profile and public
+ * repo metadata, which is sufficient for Kickstart's read-only tools.
+ * Tools that need write access (e.g., creating repos) would require scope
+ * elevation to `public_repo` or `repo`.
  */
-const DEFAULT_GITHUB_SCOPES = ['public_repo', 'read:user'];
+const DEFAULT_GITHUB_SCOPES = ['read:user'];
 
 /**
  * Connector for the GitHub REST API.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,8 @@ export type {
 
 // Tool registry
 export { ToolRegistry, defaultRegistry } from "./tools/registry.js";
+export { githubApiGet } from "./tools/github-api-get.js";
+export { fetchWebpage } from "./tools/fetch-webpage.js";
 export type { Tool, OpenAIToolDefinition, ToolCall, ToolCallResult } from "./tools/types.js";
 
 // Artifact store — generated files (K8s manifests, Dockerfiles, CI workflows, etc.)

--- a/packages/core/src/tools/azure-resource-get.ts
+++ b/packages/core/src/tools/azure-resource-get.ts
@@ -2,10 +2,12 @@
  * @module @kickstart/core/tools/azure-resource-get
  *
  * Get details of a specific Azure resource by resource ID.
- * Stub implementation — real calls wired by APIConnector (B-11).
+ * Uses AzureARMConnector when authenticated; returns stub data otherwise.
  */
 
 import type { Tool } from "../types.js";
+import { defaultConnectorRegistry } from "../connectors/index.js";
+import type { AzureARMConnector } from "../connectors/index.js";
 
 interface AzureResourceGetArgs {
   resourceId: string;
@@ -33,7 +35,16 @@ export const azureResourceGet: Tool<AzureResourceGetArgs> = {
   },
 
   async execute(args: AzureResourceGetArgs): Promise<unknown> {
-    // Stub — APIConnector (B-11) will replace with real ARM calls
+    const arm = defaultConnectorRegistry.get("azure-arm") as AzureARMConnector | undefined;
+    if (arm && arm.isAuthenticated()) {
+      const resource = await arm.getResource(args.resourceId);
+      if (!resource) {
+        return { error: `Resource not found: ${args.resourceId}` };
+      }
+      return resource;
+    }
+
+    // Stub fallback for offline / unauthenticated development
     const parts = args.resourceId.split("/");
     const resourceName = parts[parts.length - 1] ?? "unknown";
     const resourceType = parts.length >= 9 ? `${parts[6]}/${parts[7]}` : "Unknown/Resource";

--- a/packages/core/src/tools/azure-resource-list.ts
+++ b/packages/core/src/tools/azure-resource-list.ts
@@ -2,10 +2,12 @@
  * @module @kickstart/core/tools/azure-resource-list
  *
  * List Azure resources in a subscription or resource group.
- * Stub implementation — real calls wired by APIConnector (B-11).
+ * Uses AzureARMConnector when authenticated; returns stub data otherwise.
  */
 
 import type { Tool } from "../types.js";
+import { defaultConnectorRegistry } from "../connectors/index.js";
+import type { AzureARMConnector } from "../connectors/index.js";
 
 interface AzureResourceListArgs {
   subscriptionId: string;
@@ -37,7 +39,29 @@ export const azureResourceList: Tool<AzureResourceListArgs> = {
   },
 
   async execute(args: AzureResourceListArgs): Promise<unknown> {
-    // Stub — APIConnector (B-11) will replace with real ARM calls
+    const arm = defaultConnectorRegistry.get("azure-arm") as AzureARMConnector | undefined;
+    if (arm && arm.isAuthenticated()) {
+      let resources = await arm.listResources(args.subscriptionId);
+
+      if (args.resourceType) {
+        resources = resources.filter((r) => r.type === args.resourceType);
+      }
+      if (args.resourceGroup) {
+        const rgLower = args.resourceGroup.toLowerCase();
+        resources = resources.filter((r) =>
+          r.id.toLowerCase().includes(`/resourcegroups/${rgLower}/`),
+        );
+      }
+
+      return {
+        subscriptionId: args.subscriptionId,
+        resourceGroup: args.resourceGroup ?? null,
+        count: resources.length,
+        resources,
+      };
+    }
+
+    // Stub fallback for offline / unauthenticated development
     return {
       subscriptionId: args.subscriptionId,
       resourceGroup: args.resourceGroup ?? null,

--- a/packages/core/src/tools/fetch-webpage.ts
+++ b/packages/core/src/tools/fetch-webpage.ts
@@ -97,6 +97,7 @@ export const fetchWebpage: Tool<FetchWebpageArgs> = {
   name: "fetch_webpage",
   description:
     "Fetch a webpage URL and return its text content. Use this to read documentation pages, README files, blog posts, or any public web content that helps answer user questions.",
+  requireApproval: true,
   parameters: {
     type: "object",
     properties: {
@@ -136,6 +137,10 @@ export const fetchWebpage: Tool<FetchWebpageArgs> = {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
+      // Use redirect: "error" to block all redirects.
+      // This prevents open-redirect SSRF where a public URL redirects to an
+      // internal host. DNS rebinding protection would require a custom DNS
+      // resolver and is out of scope for this demo app.
       const res = await fetch(args.url, {
         method: "GET",
         headers: {
@@ -143,22 +148,10 @@ export const fetchWebpage: Tool<FetchWebpageArgs> = {
           Accept: "text/html, text/plain, application/json, */*",
         },
         signal: controller.signal,
-        redirect: "follow",
+        redirect: "error",
       });
 
       clearTimeout(timeout);
-
-      // After redirect, validate the final URL is also not a private host
-      if (res.url && res.url !== args.url) {
-        try {
-          const redirected = new URL(res.url);
-          if (!ALLOWED_SCHEMES.includes(redirected.protocol) || isBlockedHost(redirected.hostname)) {
-            return { error: "Redirect to a private or internal network address is not allowed." };
-          }
-        } catch {
-          return { error: "Redirect resulted in an invalid URL." };
-        }
-      }
 
       if (!res.ok) {
         return {
@@ -193,6 +186,9 @@ export const fetchWebpage: Tool<FetchWebpageArgs> = {
       const message = err instanceof Error ? err.message : String(err);
       if (message.includes("abort")) {
         return { error: `Request timed out after ${FETCH_TIMEOUT_MS / 1000}s`, url: args.url };
+      }
+      if (message.includes("redirect")) {
+        return { error: "Request was redirected. Redirects are blocked for security.", url: args.url };
       }
       return { error: message, url: args.url };
     }

--- a/packages/core/src/tools/fetch-webpage.ts
+++ b/packages/core/src/tools/fetch-webpage.ts
@@ -22,6 +22,50 @@ const ABSOLUTE_MAX_LENGTH = 32000;
 /** Request timeout in milliseconds. */
 const FETCH_TIMEOUT_MS = 15_000;
 
+// ---------------------------------------------------------------------------
+// SSRF protection — block requests to private/internal networks
+// ---------------------------------------------------------------------------
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) {
+    return false;
+  }
+  const [a, b] = parts;
+  return (
+    a === 127 ||
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    a === 0
+  );
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase().replace(/^\[|]$/g, "");
+  if (normalized === "::1") return true;
+  if (/^f[cd]/.test(normalized)) return true;
+  if (normalized.startsWith("fe80")) return true;
+  const v4Mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4Mapped) return isPrivateIPv4(v4Mapped[1]);
+  return false;
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "metadata.google.internal",
+  "metadata.azure.internal",
+]);
+
+function isBlockedHost(hostname: string): boolean {
+  if (BLOCKED_HOSTNAMES.has(hostname.toLowerCase())) return true;
+  if (isPrivateIPv4(hostname)) return true;
+  if (isPrivateIPv6(hostname)) return true;
+  return false;
+}
+
 /**
  * Minimal HTML → plain text conversion.
  * Strips tags, decodes common entities, and collapses whitespace.
@@ -81,6 +125,11 @@ export const fetchWebpage: Tool<FetchWebpageArgs> = {
       return { error: `URL scheme "${parsed.protocol}" is not allowed. Use http or https.` };
     }
 
+    // SSRF protection: block private/internal hosts
+    if (isBlockedHost(parsed.hostname)) {
+      return { error: "Requests to private or internal network addresses are not allowed." };
+    }
+
     const maxLen = Math.min(args.maxLength ?? DEFAULT_MAX_LENGTH, ABSOLUTE_MAX_LENGTH);
 
     try {
@@ -98,6 +147,18 @@ export const fetchWebpage: Tool<FetchWebpageArgs> = {
       });
 
       clearTimeout(timeout);
+
+      // After redirect, validate the final URL is also not a private host
+      if (res.url && res.url !== args.url) {
+        try {
+          const redirected = new URL(res.url);
+          if (!ALLOWED_SCHEMES.includes(redirected.protocol) || isBlockedHost(redirected.hostname)) {
+            return { error: "Redirect to a private or internal network address is not allowed." };
+          }
+        } catch {
+          return { error: "Redirect resulted in an invalid URL." };
+        }
+      }
 
       if (!res.ok) {
         return {

--- a/packages/core/src/tools/fetch-webpage.ts
+++ b/packages/core/src/tools/fetch-webpage.ts
@@ -1,0 +1,139 @@
+/**
+ * @module @kickstart/core/tools/fetch-webpage
+ *
+ * Fetch a webpage and extract its text content.
+ * Used by the LLM to read documentation, READMEs, and other web resources.
+ */
+
+import type { Tool } from "../types.js";
+
+interface FetchWebpageArgs {
+  url: string;
+  maxLength?: number;
+}
+
+/** Allowed URL schemes — block file://, data://, etc. */
+const ALLOWED_SCHEMES = ["http:", "https:"];
+
+/** Maximum content length to return (characters). */
+const DEFAULT_MAX_LENGTH = 8000;
+const ABSOLUTE_MAX_LENGTH = 32000;
+
+/** Request timeout in milliseconds. */
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Minimal HTML → plain text conversion.
+ * Strips tags, decodes common entities, and collapses whitespace.
+ */
+function htmlToText(html: string): string {
+  return html
+    // Remove script/style blocks
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    // Block elements → newlines
+    .replace(/<\/(p|div|h[1-6]|li|tr|blockquote|section|article)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    // Strip remaining tags
+    .replace(/<[^>]+>/g, "")
+    // Decode common HTML entities
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    // Collapse whitespace
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export const fetchWebpage: Tool<FetchWebpageArgs> = {
+  name: "fetch_webpage",
+  description:
+    "Fetch a webpage URL and return its text content. Use this to read documentation pages, README files, blog posts, or any public web content that helps answer user questions.",
+  parameters: {
+    type: "object",
+    properties: {
+      url: {
+        type: "string",
+        description: "The full URL to fetch (must be http or https).",
+      },
+      maxLength: {
+        type: "number",
+        description: `Maximum number of characters to return. Defaults to ${DEFAULT_MAX_LENGTH}, max ${ABSOLUTE_MAX_LENGTH}.`,
+      },
+    },
+    required: ["url"],
+  },
+
+  async execute(args: FetchWebpageArgs): Promise<unknown> {
+    // Validate URL scheme
+    let parsed: URL;
+    try {
+      parsed = new URL(args.url);
+    } catch {
+      return { error: `Invalid URL: ${args.url}` };
+    }
+
+    if (!ALLOWED_SCHEMES.includes(parsed.protocol)) {
+      return { error: `URL scheme "${parsed.protocol}" is not allowed. Use http or https.` };
+    }
+
+    const maxLen = Math.min(args.maxLength ?? DEFAULT_MAX_LENGTH, ABSOLUTE_MAX_LENGTH);
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+      const res = await fetch(args.url, {
+        method: "GET",
+        headers: {
+          "User-Agent": "Kickstart-AI/1.0 (tool; fetch_webpage)",
+          Accept: "text/html, text/plain, application/json, */*",
+        },
+        signal: controller.signal,
+        redirect: "follow",
+      });
+
+      clearTimeout(timeout);
+
+      if (!res.ok) {
+        return {
+          error: `HTTP ${res.status}: ${res.statusText}`,
+          url: args.url,
+        };
+      }
+
+      const contentType = res.headers.get("content-type") ?? "";
+      const rawText = await res.text();
+
+      let content: string;
+      if (contentType.includes("text/html")) {
+        content = htmlToText(rawText);
+      } else {
+        content = rawText;
+      }
+
+      const truncated = content.length > maxLen;
+      if (truncated) {
+        content = content.slice(0, maxLen);
+      }
+
+      return {
+        url: args.url,
+        contentType,
+        content,
+        length: content.length,
+        truncated,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("abort")) {
+        return { error: `Request timed out after ${FETCH_TIMEOUT_MS / 1000}s`, url: args.url };
+      }
+      return { error: message, url: args.url };
+    }
+  },
+};

--- a/packages/core/src/tools/generate-kubernetes-manifest.ts
+++ b/packages/core/src/tools/generate-kubernetes-manifest.ts
@@ -30,6 +30,7 @@ export const generateKubernetesManifest: Tool<GenerateKubernetesManifestArgs> = 
   name: "generate_kubernetes_manifest",
   description:
     "Generate Kubernetes YAML manifests (Deployment, Service, optional Ingress) for deploying an application to AKS. Returns ready-to-apply YAML files.",
+  requireApproval: true,
   parameters: {
     type: "object",
     properties: {

--- a/packages/core/src/tools/github-api-get.ts
+++ b/packages/core/src/tools/github-api-get.ts
@@ -1,0 +1,77 @@
+/**
+ * @module @kickstart/core/tools/github-api-get
+ *
+ * General-purpose read-only GitHub REST API tool.
+ * Uses GitHubConnector when authenticated; returns an error otherwise.
+ */
+
+import type { Tool } from "../types.js";
+import { defaultConnectorRegistry } from "../connectors/index.js";
+
+interface GitHubApiGetArgs {
+  path: string;
+  accept?: string;
+}
+
+export const githubApiGet: Tool<GitHubApiGetArgs> = {
+  name: "github_api_get",
+  description:
+    "Make a read-only GET request to the GitHub REST API. Use this to fetch any GitHub resource — repos, issues, pull requests, actions, users, etc. The path is relative to https://api.github.com.",
+  parameters: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description:
+          "API path relative to https://api.github.com, e.g. '/repos/owner/repo/issues' or '/users/octocat'",
+      },
+      accept: {
+        type: "string",
+        description:
+          "Optional Accept header override. Defaults to 'application/vnd.github+json'.",
+      },
+    },
+    required: ["path"],
+  },
+
+  async execute(args: GitHubApiGetArgs): Promise<unknown> {
+    const gh = defaultConnectorRegistry.get("github");
+    if (!gh || !gh.isAuthenticated()) {
+      return {
+        error: "GitHub connector is not authenticated. Sign in to use GitHub API tools.",
+        _stub: true,
+      };
+    }
+
+    try {
+      const headers: Record<string, string> = {};
+      if (args.accept) headers.Accept = args.accept;
+
+      const res = await gh.request("GET", args.path, undefined, { headers });
+
+      if (!res.ok) {
+        return {
+          error: `GitHub API returned ${res.status}: ${res.statusText}`,
+          status: res.status,
+        };
+      }
+
+      const data = await res.json();
+
+      // Slim down large array responses to avoid blowing context
+      if (Array.isArray(data) && data.length > 50) {
+        return {
+          count: data.length,
+          items: data.slice(0, 50),
+          truncated: true,
+        };
+      }
+
+      return data;
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};

--- a/packages/core/src/tools/github-repo-info.ts
+++ b/packages/core/src/tools/github-repo-info.ts
@@ -2,10 +2,12 @@
  * @module @kickstart/core/tools/github-repo-info
  *
  * Get GitHub repository metadata (language, topics, CI setup, etc.).
- * Stub implementation — real calls wired by APIConnector (B-11).
+ * Uses GitHubConnector when authenticated; returns stub data otherwise.
  */
 
 import type { Tool } from "../types.js";
+import { defaultConnectorRegistry } from "../connectors/index.js";
+import type { GitHubConnector } from "../connectors/index.js";
 
 interface GitHubRepoInfoArgs {
   owner: string;
@@ -32,7 +34,20 @@ export const githubRepoInfo: Tool<GitHubRepoInfoArgs> = {
   },
 
   async execute(args: GitHubRepoInfoArgs): Promise<unknown> {
-    // Stub — APIConnector (B-11) will replace with real GitHub API calls
+    const gh = defaultConnectorRegistry.get("github") as GitHubConnector | undefined;
+    if (gh && gh.isAuthenticated()) {
+      const repo = await gh.getRepo(args.owner, args.repo);
+      return {
+        fullName: repo.full_name,
+        description: repo.description,
+        defaultBranch: repo.default_branch,
+        language: repo.language,
+        private: repo.private,
+        url: repo.html_url,
+      };
+    }
+
+    // Stub fallback for offline / unauthenticated development
     return {
       fullName: `${args.owner}/${args.repo}`,
       description: "Sample repository description",

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -12,6 +12,8 @@ export { ToolRegistry, defaultRegistry } from "./registry.js";
 export { azureResourceList } from "./azure-resource-list.js";
 export { azureResourceGet } from "./azure-resource-get.js";
 export { githubRepoInfo } from "./github-repo-info.js";
+export { githubApiGet } from "./github-api-get.js";
+export { fetchWebpage } from "./fetch-webpage.js";
 export { generateKubernetesManifest } from "./generate-kubernetes-manifest.js";
 export { estimateCost } from "./estimate-cost.js";
 export { listArtifacts } from "./list-artifacts.js";
@@ -22,6 +24,8 @@ import { defaultRegistry } from "./registry.js";
 import { azureResourceList } from "./azure-resource-list.js";
 import { azureResourceGet } from "./azure-resource-get.js";
 import { githubRepoInfo } from "./github-repo-info.js";
+import { githubApiGet } from "./github-api-get.js";
+import { fetchWebpage } from "./fetch-webpage.js";
 import { generateKubernetesManifest } from "./generate-kubernetes-manifest.js";
 import { estimateCost } from "./estimate-cost.js";
 import { listArtifacts } from "./list-artifacts.js";
@@ -31,6 +35,8 @@ defaultRegistry.registerAll([
   azureResourceList,
   azureResourceGet,
   githubRepoInfo,
+  githubApiGet,
+  fetchWebpage,
   generateKubernetesManifest,
   estimateCost,
   listArtifacts,

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -48,6 +48,7 @@ export class ToolRegistry {
   /**
    * Execute a named tool, logging the call and result.
    * Throws if the tool is not registered or execution fails.
+   * Tools with `requireApproval: true` are blocked from automatic execution.
    */
   async execute(name: string, args: Record<string, unknown>): Promise<unknown> {
     const tool = this.tools.get(name);
@@ -55,6 +56,15 @@ export class ToolRegistry {
       logger.warn(`Tool not found: ${name}`);
       throw new Error(`Tool not registered: ${name}`);
     }
+    // Approval gate: block tools that require user confirmation
+    if (tool.requireApproval) {
+      logger.warn(`Tool "${name}" requires user approval — skipping automatic execution.`);
+      return {
+        error: `Tool "${name}" requires user approval before execution. This action was not performed automatically.`,
+        requiresApproval: true,
+      };
+    }
+
     logger.track('tool.call', { tool: name, args });
     try {
       const result = await tool.execute(args);

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -16,6 +16,12 @@ export interface Tool<TArgs = Record<string, unknown>> {
     properties: Record<string, unknown>;
     required?: string[];
   };
+  /**
+   * When true, the tool requires explicit user approval before execution.
+   * Tools that modify state or access sensitive resources should set this.
+   * Default: false (auto-approved for read-only tools).
+   */
+  requireApproval?: boolean;
   /** Execute the tool and return a result the LLM can consume */
   execute(args: TArgs): Promise<unknown>;
 }

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -27,6 +27,7 @@ import { checkContentSafety } from "../lib/content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
 import { safeErrorResponse, safeStreamError } from "../lib/error-response.js";
 import { chatCompletionWithAutoContinue, isTruncated } from "../lib/auto-continue.js";
+import { sanitizeToolOutput } from "../lib/sanitize-tool-output.js";
 
 interface ConverseRequest {
   sessionId?: string;
@@ -140,6 +141,9 @@ app.http("converse", {
         async (name, args) => {
           const tool = defaultRegistry.get(name);
           if (!tool) throw new Error(`Unknown tool: ${name}`);
+          if (tool.requireApproval) {
+            return { error: `Tool "${name}" requires user approval before execution.`, requiresApproval: true };
+          }
           return tool.execute(args);
         },
       );
@@ -273,28 +277,34 @@ function handleStreaming(
             tool_calls: probe.toolCalls,
           });
 
-          // Execute tools and append results
+          // Execute tools and append sanitized results
           for (const tc of probe.toolCalls) {
             let toolResult: unknown;
             try {
-              const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
               const tool = defaultRegistry.get(tc.function.name);
               if (!tool) throw new Error(`Unknown tool: ${tc.function.name}`);
-              toolResult = await tool.execute(args);
+              if (tool.requireApproval) {
+                toolResult = { error: `Tool "${tc.function.name}" requires user approval before execution.`, requiresApproval: true };
+              } else {
+                const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+                toolResult = await tool.execute(args);
+              }
             } catch (err) {
               toolResult = { error: err instanceof Error ? err.message : String(err) };
             }
 
+            const sanitized = sanitizeToolOutput(toolResult);
+
             controller.enqueue(
               encoder.encode(
-                `event: tool_result\ndata: ${JSON.stringify({ name: tc.function.name, result: toolResult })}\n\n`,
+                `event: tool_result\ndata: ${JSON.stringify({ name: tc.function.name, result: sanitized })}\n\n`,
               ),
             );
 
             workingMessages.push({
               role: "tool",
               tool_call_id: tc.id,
-              content: JSON.stringify(toolResult),
+              content: sanitized,
             });
           }
         }

--- a/packages/web/api/src/lib/openai-client.ts
+++ b/packages/web/api/src/lib/openai-client.ts
@@ -11,6 +11,7 @@
 // ---------------------------------------------------------------------------
 
 import type { OpenAIToolDefinition, ToolCall } from "@kickstart/core";
+import { sanitizeToolOutput } from "./sanitize-tool-output.js";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant" | "tool";
@@ -207,7 +208,7 @@ export async function chatCompletionWithTools(
       tool_calls: result.toolCalls,
     });
 
-    // Execute each requested tool and append results
+    // Execute each requested tool and append sanitized results
     for (const toolCall of result.toolCalls) {
       let toolResult: unknown;
       try {
@@ -220,7 +221,7 @@ export async function chatCompletionWithTools(
       workingMessages.push({
         role: "tool",
         tool_call_id: toolCall.id,
-        content: JSON.stringify(toolResult),
+        content: sanitizeToolOutput(toolResult),
       });
     }
   }

--- a/packages/web/api/src/lib/openai-client.ts
+++ b/packages/web/api/src/lib/openai-client.ts
@@ -10,9 +10,15 @@
 // Shared types
 // ---------------------------------------------------------------------------
 
+import type { OpenAIToolDefinition, ToolCall } from "@kickstart/core";
+
 export interface ChatMessage {
-  role: "system" | "user" | "assistant";
-  content: string;
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | null;
+  /** Tool calls requested by the assistant (present when finish_reason is "tool_calls"). */
+  tool_calls?: ToolCall[];
+  /** The ID of the tool call this message is a response to (role: "tool" only). */
+  tool_call_id?: string;
 }
 
 export interface ChatCompletionOptions {
@@ -21,11 +27,15 @@ export interface ChatCompletionOptions {
   responseFormat?: { type: string };
   /** Override the deployment name (e.g., for inspiration generation). */
   deployment?: string;
+  /** Tool definitions in OpenAI function-calling format. */
+  tools?: OpenAIToolDefinition[];
 }
 
 export interface ChatCompletionResult {
   content: string;
   finishReason: string;
+  /** Tool calls requested by the LLM (present when finishReason is "tool_calls"). */
+  toolCalls?: ToolCall[];
 }
 
 export interface CodexCompletionOptions {
@@ -116,6 +126,7 @@ const CHAT_API_VERSION = "2024-12-01-preview";
 
 /**
  * Call Azure OpenAI Chat Completions (non-streaming).
+ * Supports function calling via the `tools` option.
  */
 export async function chatCompletion(
   messages: ChatMessage[],
@@ -129,19 +140,22 @@ export async function chatCompletion(
 
   const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${CHAT_API_VERSION}`;
 
+  const body: Record<string, unknown> = {
+    messages,
+    max_completion_tokens: options.maxTokens ?? 2048,
+    stream: false,
+  };
+  if (options.temperature !== undefined) body.temperature = options.temperature;
+  if (options.responseFormat) body.response_format = options.responseFormat;
+  if (options.tools?.length) body.tools = options.tools;
+
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "api-key": apiKey,
     },
-    body: JSON.stringify({
-      messages,
-      ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-      ...(options.responseFormat ? { response_format: options.responseFormat } : {}),
-      max_completion_tokens: options.maxTokens ?? 2048,
-      stream: false,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
@@ -150,12 +164,17 @@ export async function chatCompletion(
   }
 
   const data = (await response.json()) as {
-    choices: Array<{ message: { content: string }; finish_reason: string }>;
+    choices: Array<{
+      message: { content: string | null; tool_calls?: ToolCall[] };
+      finish_reason: string;
+    }>;
   };
 
+  const choice = data.choices[0];
   return {
-    content: data.choices[0].message.content,
-    finishReason: data.choices[0].finish_reason,
+    content: choice.message.content ?? "",
+    finishReason: choice.finish_reason,
+    toolCalls: choice.message.tool_calls,
   };
 }
 
@@ -163,7 +182,7 @@ export async function chatCompletion(
  * Call Azure OpenAI Chat Completions with automatic tool execution.
  *
  * Supports multi-step tool use: if the LLM requests tool calls, executes them
- * via the provided registry, appends results, and calls the LLM again — up to
+ * via the provided callback, appends results, and calls the LLM again — up to
  * maxToolRounds times — before returning the final text response.
  */
 export async function chatCompletionWithTools(
@@ -172,7 +191,7 @@ export async function chatCompletionWithTools(
   executeTool: (name: string, args: Record<string, unknown>) => Promise<unknown>,
   maxToolRounds = 5,
 ): Promise<ChatCompletionResult> {
-  const workingMessages = [...messages];
+  const workingMessages: ChatMessage[] = [...messages];
 
   for (let round = 0; round < maxToolRounds; round++) {
     const result = await chatCompletion(workingMessages, options);

--- a/packages/web/api/src/lib/sanitize-tool-output.ts
+++ b/packages/web/api/src/lib/sanitize-tool-output.ts
@@ -1,0 +1,73 @@
+/**
+ * @module @kickstart/api/lib/sanitize-tool-output
+ *
+ * Sanitizes tool output before it is sent to the LLM context or streamed to
+ * the client.  Guards against prompt-injection persistence and sensitive data
+ * leakage by:
+ *   1. Enforcing a maximum output length (truncation).
+ *   2. Stripping HTML/script content that could be rendered by the client.
+ *   3. Redacting raw error stack traces.
+ */
+
+/** Maximum characters allowed in a single tool result (before JSON encoding). */
+const MAX_TOOL_OUTPUT_LENGTH = 16_000;
+
+/** Patterns that should never appear in tool output sent to the client. */
+const DANGEROUS_HTML_RE =
+  /<\s*\/?\s*(script|iframe|object|embed|form|input|link|meta|style|svg|base|applet)[^>]*>/gi;
+
+/**
+ * Strip dangerous HTML tags from a string while leaving plain text intact.
+ * This is intentionally aggressive — tool results are plain-text data, not
+ * HTML documents. Any residual HTML is an injection vector.
+ */
+function stripDangerousHtml(text: string): string {
+  return text
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<iframe[\s\S]*?<\/iframe>/gi, "")
+    .replace(/<object[\s\S]*?<\/object>/gi, "")
+    .replace(/<embed[\s\S]*?<\/embed>/gi, "")
+    .replace(DANGEROUS_HTML_RE, "")
+    .replace(/\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, "");
+}
+
+/**
+ * Redact stack traces from error messages so internal file paths and
+ * dependency versions don't leak to the LLM or client.
+ */
+function sanitizeErrorText(text: string): string {
+  return text.replace(
+    /(\n\s+at\s+.+){2,}/g,
+    "\n    [stack trace redacted]",
+  );
+}
+
+/**
+ * Sanitize a tool result before feeding it to the LLM or streaming to client.
+ *
+ * Accepts an arbitrary `unknown` value (the raw tool result), JSON-stringifies
+ * it, applies all sanitization passes, and returns a safe string ready for
+ * insertion into the LLM message array.
+ */
+export function sanitizeToolOutput(raw: unknown): string {
+  let text: string;
+  if (typeof raw === "string") {
+    text = raw;
+  } else {
+    try {
+      text = JSON.stringify(raw);
+    } catch {
+      text = String(raw);
+    }
+  }
+
+  text = stripDangerousHtml(text);
+  text = sanitizeErrorText(text);
+
+  if (text.length > MAX_TOOL_OUTPUT_LENGTH) {
+    text = text.slice(0, MAX_TOOL_OUTPUT_LENGTH) + "\n[output truncated]";
+  }
+
+  return text;
+}


### PR DESCRIPTION
Closes #26

## Summary
Wire OpenAI function calling end-to-end so the LLM can invoke external tools during conversation — e.g., list Azure resources, fetch GitHub repos, or read web pages.

## Changes
- **OpenAI client** (`openai-client.ts`): Extended `ChatMessage` to support `role: "tool"` and `tool_calls` on assistant messages. Added `tools` option and `toolCalls` in response. `chatCompletion()` now sends tools in the API body and parses `tool_calls`.
- **Connector wiring**: `azure_resource_get`, `azure_resource_list`, and `github_repo_info` now use real connectors (AzureARMConnector, GitHubConnector) when authenticated, with stub fallback for offline dev.
- **New tool: `github_api_get`**: General-purpose read-only GitHub REST API tool via GitHubConnector. Slims large responses to 50 items.
- **New tool: `fetch_webpage`**: Fetches a URL, strips HTML to plain text, respects max length and timeout. Validates URL scheme.
- **Registry**: All 9 tools registered in the default registry and exported from `@kickstart/core`.

## Testing
- `npm run lint` — passes clean
- `npm run build` — core, web, api all pass (mcp-server has pre-existing catalog type errors on main)
- `npx vitest run` — all 423 tests pass