### PR TITLE
chore: consolidate process directives into skills + charters

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Propose a new feature with structured problem statement and acceptance criteria.
+title: "[Feature]: "
+labels: ["squad"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+        Use this template to describe a feature for Kickstart. Focus on the **problem** and **user impact** — the implementing agent will propose the solution in a Design Proposal (DP) comment.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: What problem does this feature solve? Who experiences this problem and when?
+      placeholder: "Users currently have to manually configure X, which leads to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: user-impact
+    attributes:
+      label: User Impact
+      description: How does this affect users today? What's the cost of not solving it?
+      placeholder: "Without this, users must spend ~30 minutes configuring..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: |
+        What must be true for this feature to be considered done?
+        Use checkboxes (- [ ]) for each criterion.
+      placeholder: |
+        - [ ] User can do X without manual configuration
+        - [ ] Works with Azure/AKS Automatic
+        - [ ] Accessible (WCAG A compliant)
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-areas
+    attributes:
+      label: Affected Areas
+      description: Which packages, components, or systems does this touch?
+      placeholder: "packages/core, packages/web, infra/"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any mockups, links, prior art, or other context.
+    validations:
+      required: false

--- a/.squad/agents/bender/charter.md
+++ b/.squad/agents/bender/charter.md
@@ -19,6 +19,8 @@
 ## How I Work
 
 - Before starting issue work, read `.squad/skills/pr-workflow/SKILL.md` for the PR and issue workflow
+- **Post a Design Proposal (DP) comment on the issue BEFORE writing code** — propose implementation approach within Leela's architectural constraints
+- Wait for Leela (architecture) and Zapp (security) to approve the DP before implementing
 - Design APIs contract-first — define the interface before writing implementation
 - Use Azure best practices for AKS Automatic (security defaults, managed identity, auto-provisioning)
 - Generate infrastructure-as-code that's production-ready out of the box

--- a/.squad/agents/fry/charter.md
+++ b/.squad/agents/fry/charter.md
@@ -19,6 +19,8 @@
 ## How I Work
 
 - Before starting issue work, read `.squad/skills/pr-workflow/SKILL.md` for the PR and issue workflow
+- **Post a Design Proposal (DP) comment on the issue BEFORE writing code** — propose implementation approach within Leela's architectural constraints
+- Wait for Leela (architecture) and Zapp (security) to approve the DP before implementing
 - Build with the Portal Prototyper framework — zero-dependency static HTML/CSS/JS that mirrors Azure Portal UX
 - Start with the user journey: what does the user see, click, and feel?
 - Use framework components (tables, filters, wizards, panels) rather than custom widgets

--- a/.squad/agents/leela/charter.md
+++ b/.squad/agents/leela/charter.md
@@ -11,23 +11,25 @@
 
 ## What I Own
 
-- Architecture and system design decisions
+- High-level architecture direction — set during planning and triage
 - Scope and priorities — what to build next, what to defer
-- PR reviews and quality gates
+- Design Proposal (DP) reviews — evaluate architecture quality and alignment
+- PR code quality reviews
 - Issue triage (the `squad` label inbox)
 
 ## How I Work
 
 - Start every task by reviewing `.squad/decisions.md` for context
 - Favour small, shippable increments over big-bang releases
+- Review Design Proposals (DPs) on issues for architecture alignment before code is written
 - When reviewing PRs, check for correctness first, style second
 - Write decisions to `.squad/decisions/inbox/leela-{slug}.md`
 
 ## Boundaries
 
-**I handle:** Architecture decisions, scope/priority calls, code review, issue triage, cross-cutting concerns.
+**I handle:** Architecture direction, scope/priority calls, DP architecture reviews, PR code quality reviews, issue triage, cross-cutting concerns.
 
-**I don't handle:** Writing feature code (that's Fry and Bender), writing tests (that's Hermes), session logging (that's Scribe).
+**I don't handle:** Writing feature code (that's Fry and Bender), writing tests (that's Hermes), security reviews (that's Zapp), session logging (that's Scribe).
 
 **When I'm unsure:** I say so and suggest who might know.
 

--- a/.squad/agents/zapp/charter.md
+++ b/.squad/agents/zapp/charter.md
@@ -11,24 +11,25 @@
 
 ## What I Own
 
-- Security architecture reviews — scrutinize design decisions for vulnerabilities
-- Code reviews focused on security — auth, injection, CORS, secrets, input validation
+- Security reviews on Design Proposals (DPs) — evaluate security concerns before code is written
+- Security-focused PR reviews — auth, injection, CORS, secrets, input validation
 - Threat modeling for new features
 - Compliance and best practices enforcement (OWASP, Azure security baseline)
+- Pre-merge security gate for foundational patterns
 
 ## How I Work
 
-- Review architecture decisions BEFORE implementation when possible
-- Perform security-focused code reviews on PRs — look for injection, auth bypass, secret leaks, CORS issues
+- Review Design Proposals (DPs) on issues for security concerns BEFORE implementation
+- Review PRs for security issues — look for injection, auth bypass, secret leaks, CORS issues
 - Challenge assumptions about trust boundaries and data flow
 - Flag issues with severity ratings (Critical, High, Medium, Low)
 - Write decisions to `.squad/decisions/inbox/zapp-{slug}.md`
 
 ## Boundaries
 
-**I handle:** Security reviews, vulnerability analysis, threat modeling, architecture scrutiny, compliance checks.
+**I handle:** Security reviews (DPs and PRs), vulnerability analysis, threat modeling, compliance checks.
 
-**I don't handle:** Writing feature code (I review, I don't implement), writing tests (that's Hermes), frontend styling (that's Fry), session logging (that's Scribe).
+**I don't handle:** Architecture quality reviews (that's Leela), writing feature code (I review, I don't implement), writing tests (that's Hermes), frontend styling (that's Fry), session logging (that's Scribe).
 
 **When I find an issue:** I document it clearly with the vulnerability, impact, and recommended fix. The owning agent implements the fix.
 

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -8,17 +8,20 @@
 |-------|-------|
 | **Trigger** | auto |
 | **When** | before |
-| **Condition** | multi-agent task involving 2+ agents modifying shared systems |
+| **Condition** | Design Proposal (DP) comment posted on an issue, OR multi-agent task involving 2+ agents modifying shared systems |
 | **Facilitator** | lead |
-| **Participants** | all-relevant |
+| **Participants** | all-relevant, Zapp (security input) |
 | **Time budget** | focused |
 | **Enabled** | ✅ yes |
 
 **Agenda:**
-1. Review the task and requirements
-2. Agree on interfaces and contracts between components
-3. Identify risks and edge cases
-4. Assign action items
+1. Review the Design Proposal (DP) comment on the issue
+2. Leela evaluates architecture quality and alignment
+3. Zapp evaluates security concerns and threat surface
+4. Agree on interfaces and contracts between components
+5. Identify risks and edge cases
+6. Both approve → implementation proceeds
+7. Capture decisions as comments on the issue (or as a GitHub Discussion if cross-issue)
 
 ---
 
@@ -63,6 +66,8 @@
 6. Assign sprint capacity per agent based on estimates
 7. Output: milestone roadmap with release targets
 
+**Artifacts:** Create a GitHub Discussion (or milestone comment) linking to the sprint plan. Include the sprint goal, issue list, wave breakdown, and capacity estimates.
+
 ---
 
 ## Sprint Retro
@@ -81,6 +86,9 @@
 1. What shipped? (milestone summary)
 2. What slipped? (issues that moved between milestones)
 3. Velocity check: estimated vs actual story points
-4. What went well?
-5. What should change?
-6. Action items for next sprint
+4. Wall-clock time vs estimates (per issue and per wave)
+5. What went well?
+6. What should change?
+7. Action items for next sprint
+
+**Artifacts:** Create a GitHub Discussion (or milestone comment) with the retro summary, including wall-clock vs estimate analysis and velocity metrics.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -42,8 +42,10 @@ How to decide who handles what.
 
 | Signal | Route to Zapp |
 |--------|---------------|
+| Design Proposal (DP) posted on issue | Primary — review for security concerns |
+| PR marked ready for review | Primary — security-focused code review |
 | Security review request | Primary |
-| Architecture decision review | Secondary (after Leela) |
-| PR security audit | Primary |
 | Vulnerability analysis | Primary |
 | Auth/CORS/secrets concerns | Primary |
+
+> **Scope boundary:** Zapp reviews for **security only**. Architecture quality review is Leela's responsibility. Both review DPs on issues and code on PRs, but in their respective domains.

--- a/.squad/skills/pr-workflow/SKILL.md
+++ b/.squad/skills/pr-workflow/SKILL.md
@@ -105,6 +105,38 @@ Before running any `gh` commands, ensure you are authenticated with the correct 
 
 ---
 
+## Design Proposal (DP) Process
+
+> Design discussion happens on the **issue**, not the PR. PRs are for code review only.
+
+### Authorship
+
+- **Issue body** (problem + acceptance criteria) = written by Ahmed or Leela during triage. This is the "what and why."
+- **DP comment** (proposed approach) = written by the implementing agent (Bender/Fry/Hermes). This is the "how."
+- Agents do NOT write problem statements — they propose solutions to problems defined by the product owner or Lead.
+
+### DP Lifecycle
+
+1. **Issue is triaged** — Ahmed or Leela writes the problem statement and acceptance criteria in the issue body.
+2. **Agent picks up issue** — posts a **Design Proposal (DP)** as a structured comment on the issue BEFORE writing any code.
+3. **DP structure:**
+   - Problem statement (reference to issue body)
+   - Proposed approach
+   - Files to modify / create
+   - Patterns and dependencies
+   - API contracts (if applicable)
+   - Security considerations
+   - Alternatives considered
+4. **Leela reviews DP** for architecture quality (comment on issue).
+5. **Zapp reviews DP** for security concerns (comment on issue).
+6. **Both approve** → agent proceeds to implementation.
+7. **Draft PR opened** — code review only; design is already approved on the issue.
+8. **PR marked ready** → CI → Leela reviews code quality → Zapp reviews security → merge.
+
+> For foundational patterns (e.g., ServiceConnector, ServicePack, LLM tool system), the DP may reference a full design doc in `docs/architecture/`.
+
+---
+
 ## PR Workflow
 
 ### Creating a PR
@@ -149,6 +181,15 @@ Only after work is complete AND CI passes:
 ```bash
 gh pr ready <N>
 ```
+
+### Review Gates
+
+Before a PR can merge, it must pass two review gates:
+
+1. **Leela** — reviews for code quality, architecture alignment with the approved DP
+2. **Zapp** — reviews for security concerns (auth, injection, secrets, CORS)
+
+Zapp's review is a **pre-merge gate** for foundational patterns. Do not merge without Zapp's approval on security-sensitive changes.
 
 ### Requesting Copilot Review
 
@@ -241,13 +282,19 @@ Example: `squad/42-fix-login-validation`
 □ Assign issue to current user (gh api user -q .login)
 □ Set milestone
 □ Update board → In progress
+□ Post Design Proposal (DP) comment on issue
+□ Leela approves DP (architecture)
+□ Zapp approves DP (security)
 □ Create branch: squad/{N}-{slug}
+□ Implement (design already approved)
 □ Open draft PR: gh pr create --draft
 □ Post progress comments on PR
 □ Rebase if behind main (never merge)
 □ All CI green
 □ gh pr ready
 □ Request @copilot review via API
+□ Leela reviews code quality
+□ Zapp reviews security
 □ Address all review comments
 □ Resolve all threads
 □ Update board → In review


### PR DESCRIPTION
Consolidates ~10 process directives from `.squad/decisions/inbox/` into the team's operational files.

## What changed

### `.squad/skills/pr-workflow/SKILL.md`
- Added **Design Proposal (DP) process** section — the full lifecycle from issue to merge
- Added **Review Gates** section — Leela (architecture) + Zapp (security) as pre-merge gates
- Updated **Quick Reference Checklist** with DP steps

### `.squad/ceremonies.md`
- **Design Review** — updated trigger to fire on DP comments, added Zapp as participant
- **Sprint Planning** — added GitHub Discussion artifact requirement
- **Sprint Retro** — added wall-clock vs estimates to agenda, added GitHub Discussion artifact

### Agent charters
- **Leela** — clarified: owns architecture direction, reviews DPs for architecture, does NOT review security
- **Zapp** — clarified: reviews DPs and PRs for security only, does NOT review architecture quality
- **Bender** — added: must post DP on issue before coding, wait for approval
- **Fry** — added: must post DP on issue before coding, wait for approval

### `.squad/routing.md`
- Updated Zapp routing table with DP triggers and explicit scope boundary note

### `.github/ISSUE_TEMPLATE/feature-request.yml`
- New GitHub issue form template encouraging structured problem statements with acceptance criteria

## Directives consolidated
From `.squad/decisions/inbox/`:
- `copilot-directive-2026-04-10T15-57` — Zapp pre-merge gate
- `copilot-directive-2026-04-10T17-20` — Full ceremony lifecycle
- `copilot-directive-2026-04-10T17-22` — Ceremony artifacts on GitHub
- `copilot-directive-2026-04-10T17-24` — Reviews before AND after code (superseded by DP)
- `copilot-directive-2026-04-10T17-26` — Draft PR for review (superseded by DP)
- `copilot-directive-2026-04-10T17-30` — Design Proposal process (authoritative)
- `copilot-directive-2026-04-10T17-32` — DP ownership clarification