### PR TITLE
docs: Update README and architecture docs for v0.3.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Kickstart helps developers go from "I have an app" to "it's running on Azure" th
 - **AI-guided landing page** — Track cards, framework pills, and an ✨ inspiration button that generates app ideas via AI
 - **A2UI component system** — 16 custom components + Fluent UI 2 styled vendor catalog, rendered from structured JSON returned by the LLM
 - **Component playground** — Interactive sidebar-navigated demo surface (https://kickstart.aks.azure.sabbour.me/?playground) for exploring A2UI components, scenarios, and questionnaire flows
+- **Fat A2UI components** — Azure and GitHub login cards, resource pickers, and action buttons with real API integration, in-memory token storage, and operation allowlisting
+- **LLM function calling** — Tool system enables the LLM to directly query Azure resources, GitHub repos, and web content
+- **ServiceConnector & ServicePack patterns** — Declarative auth requirements, kit lifecycle hooks, and dependency validation for seamless Azure/GitHub integration
+- **CORS proxy security** — Private IP filtering, redirect validation, and hostname allowlisting for safe cross-origin API calls
 - **Action system** — Unified button action pipeline with `/api/action` endpoint for component-driven interactions
 - **Azure Functions API** — Streaming conversation proxy, code generation (Codex), CORS proxies for ARM/GitHub/Pricing APIs
 - **MCP server** — IDE integration for VS Code Copilot and Claude Code via `@kickstart/mcp-server`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,36 @@
 # Kickstart Documentation
 
-Welcome to the Kickstart docs — the AI-guided onboarding experience for deploying apps to AKS Automatic.
+Welcome to the Kickstart docs — the AI-guided onboarding experience for deploying apps to AKS Automatic. Learn about architecture, APIs, components, and deployment.
 
 ## Contents
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](./architecture.md) | System diagrams — surfaces, flows, prompts, deployment |
+| [Architecture](./architecture.md) | System overview, conversation phases, IntegrationKit/ServicePack pattern, tool system, fat components, CORS proxy security |
+| [API Reference](./api-reference.md) | REST API endpoints, request/response schemas, streaming, error handling |
+| [A2UI Catalog](./a2ui-catalog.md) | Kickstart custom components, fat A2UI components, vendor basics, adding new components |
+| [MCP Server](./mcp-server.md) | IDE integration for VS Code Copilot and Claude Code |
+| [Prompt Architecture](./prompt-architecture.md) | 3-layer system prompt, skill resolver, phase-specific augmentations |
+| [Deployment Guide](./deployment.md) | Azure resource setup, Bicep templates, CI/CD workflows |
+| [Development](./development.md) | Local development, testing, debugging |
 | [Contributing](../CONTRIBUTING.md) | Dev setup, project structure, code style |
 | [Infrastructure](../infra/README.md) | Azure deployment (Bicep templates, Entra setup) |
+
+## Key Concepts
+
+### v0.3.0 Architecture Highlights
+
+- **ServicePack Pattern** — Declarative auth requirements, kit lifecycle hooks, transactional registration with rollback
+- **Fat A2UI Components** — Self-managing Azure login, GitHub login, resource pickers with built-in security (in-memory tokens, operation allowlisting)
+- **LLM Function Calling** — 9 built-in tools enable the LLM to query Azure/GitHub and fetch web pages
+- **CORS Proxy Security** — Private IP filtering, redirect validation, hostname allowlisting for safe cross-origin calls
+- **Service Pattern** — ServiceConnectors handle API authentication and provide domain-specific methods
 
 ## Quick Links
 
 - **Monorepo packages:** [`packages/core`](../packages/core), [`packages/web`](../packages/web), [`packages/mcp-server`](../packages/mcp-server)
-- **A2UI Catalog:** [`packages/core/src/catalog/`](../packages/core/src/catalog/)
+- **IntegrationKits:** [`packages/core/src/kits/`](../packages/core/src/kits/)
+- **A2UI Components:** [`packages/web/src/catalog/`](../packages/web/src/catalog/)
 - **Prompt system:** [`packages/core/src/prompts/`](../packages/core/src/prompts/)
+- **Tool Registry:** [`packages/core/src/engine/tool-registry.ts`](../packages/core/src/engine/tool-registry.ts)
 - **MCP tools:** [`packages/mcp-server/src/tools/`](../packages/mcp-server/src/tools/)

--- a/docs/a2ui-catalog.md
+++ b/docs/a2ui-catalog.md
@@ -349,6 +349,35 @@ Multi-step deployment progress tracker with per-step status. Used during the Dep
 
 ---
 
+## Fat A2UI Components
+
+Starting in v0.3.0, Kickstart includes **fat components** — opinionated, self-managing implementations of common workflows with built-in authentication, validation, and security controls. These are registered as part of the `azure` and `github` IntegrationKits.
+
+### Azure Fat Components
+
+| Component | Purpose | Auth | Security |
+|-----------|---------|------|----------|
+| **AzureLoginCard** | Device code auth flow for Azure MSAL | MSAL | Token in memory; logout clears session |
+| **AzureResourcePicker** | Browse subscriptions and list resources | AzureARMConnector | Rate-limit handling; stub fallback |
+| **AzureResourceForm** | Collect deployment parameters and estimate cost | AzureARMConnector | Input validation; cost preview before submit |
+
+### GitHub Fat Components
+
+| Component | Purpose | Auth | Security |
+|-----------|---------|------|----------|
+| **GitHubLoginCard** | Device code auth flow for GitHub OAuth | GitHub OAuth | Token in memory; no localStorage |
+| **GitHubRepoPicker** | Search and select from user's repositories | GitHubConnector | Debounced search; pagination; rate-limit warnings |
+| **GitHubAction** | Execute allowlisted GitHub API operations | GitHubConnector | Operation allowlisting; typed confirmation for DELETE |
+| **GitHubCommit** | Create pull request with artifact selection | GitHubConnector | Branch validation; protected-branch guards; diff preview |
+
+**Key Security Features:**
+- **In-memory token storage** — No localStorage; tokens cleared on logout
+- **Operation allowlisting** — Write operations must be explicitly approved
+- **Typed confirmation** — DELETE and merge operations require developer confirmation
+- **Protected-branch blocking** — Cannot push to main/master/production
+
+---
+
 ## Vendor A2UI Basic Catalog (Fluent-Styled)
 
 The vendor A2UI v0.9 basic catalog provides standard primitives. Kickstart overrides all of these with Fluent 2 styled implementations in `packages/web/src/catalog/fluent-components/`:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,9 +196,57 @@ flowchart LR
     ConnReg -->|request()| Connectors["AzureARMConnector\nGitHubConnector\nPricingConnector"]
 ```
 
+### ServicePack Pattern
+
+**ServicePacks** extend `IntegrationKit` with declarative **auth requirements**, **lifecycle hooks**, and **dependency management**:
+
+```typescript
+interface ServicePack extends IntegrationKit {
+  authRequirements?: KitAuthRequirement[];  // Declare needed credentials
+  dependencies?: string[];                   // Kit names this pack requires
+  onActivate?(): Promise<void>;             // Called after registration
+  onDeactivate?(): Promise<void>;           // Called before unregistration
+}
+
+interface KitAuthRequirement {
+  provider: 'azure-msal' | 'github-oauth' | ...;
+  scopes: string[];
+}
+```
+
+**Registration is transactional:**
+- Validates dependencies exist (DFS cycle detection)
+- Validates auth schemas
+- Calls `onActivate()` on all kits; rolls back on failure
+- Unregistration keeps a kit if its `onDeactivate()` fails (safety-first)
+
+**Example:** The `github` kit declares `{ provider: 'github-oauth', scopes: ['repo', 'read:user'] }`. When a component needs GitHub functionality, the app calls `GitHubConnector.authenticate()`, which kicks off device code flow (with in-memory token storage — no localStorage).
+
 ---
 
-## Tool System
+### Fat Components & Component Lifecycle
+
+**Fat A2UI components** are self-managing, opinionated implementations of common workflows:
+
+| Component | Auth | Lifecycle | Security |
+|-----------|------|-----------|----------|
+| **AzureLoginCard** | MSAL (Device Code) | Display code → poll token → fetch profile | Token in memory; logout clears it |
+| **AzureResourcePicker** | AzureARMConnector | Fetch subscriptions → list resources with live search | Rate-limit handling + stub fallback |
+| **AzureResourceForm** | AzureARMConnector | Collect deployment params, preview cost, submit | Input validation + cost estimation |
+| **GitHubLoginCard** | GitHub OAuth (Device Code) | Display code → poll token → fetch user + profile | Token in memory; no localStorage |
+| **GitHubRepoPicker** | GitHubConnector | Fetch user's repos, debounced search, pagination | Rate-limit warnings + stub fallback |
+| **GitHubAction** | GitHubConnector | Map to allowlisted GitHub API operations, require typed confirmation for destructive ops | Blocks main/master/production branches |
+| **GitHubCommit** | GitHubConnector | Artifact selection, branch name validation, PR creation flow, diff preview | Protected-branch guards |
+
+**Security guardrails:**
+- **In-memory token storage only** — tokens are cleared on logout or session end
+- **Operation allowlisting** — write operations must be explicitly listed (no arbitrary API calls)
+- **Typed confirmation** — DELETE and merge operations require developer confirmation
+- **Protected-branch blocking** — Cannot push to main/master/production via the component
+
+---
+
+## Tool System & LLM Function Calling
 
 The `ToolRegistry` is the central register for LLM-callable tools. Tools are plain objects implementing `Tool<TArgs>`:
 
@@ -211,19 +259,57 @@ interface Tool<TArgs> {
 }
 ```
 
-The registry exports tools in OpenAI function-calling format via `toOpenAIFormat()` and routes `execute(name, args)` calls with structured logging.
+The registry exports tools in **OpenAI function-calling format** via `toOpenAIFormat()` and routes `execute(name, args)` calls with structured logging. When the LLM returns a `tool_calls` response, the engine:
+1. Maps tool names to `ToolRegistry` entries
+2. Validates arguments against JSON schemas
+3. Executes each tool and collects results
+4. Sends results back to the LLM for follow-up reasoning
 
-**7 built-in tools** (auto-registered at import):
+**9 built-in tools** (auto-registered at import):
 
-| Tool | Kit | Purpose |
-|------|-----|---------|
-| `azure_resource_list` | azure | List Azure resources in a subscription |
-| `azure_resource_get` | azure | Inspect a specific Azure resource |
-| `estimate_cost` | azure | Monthly cost estimate for a deployment plan |
-| `github_repo_info` | github | Detect language, runtime, CI setup from a GitHub repo |
-| `generate_kubernetes_manifest` | core | Generate K8s Deployment/Service/Ingress YAML |
-| `list_artifacts` | core | List generated artifacts in the store |
-| `get_artifact` | core | Retrieve a generated artifact by path |
+| Tool | Kit | Purpose | Function Call? |
+|------|-----|---------|:---:|
+| `azure_resource_list` | azure | List Azure resources in a subscription | ✓ |
+| `azure_resource_get` | azure | Inspect a specific Azure resource | ✓ |
+| `estimate_cost` | azure | Monthly cost estimate for a deployment plan | ✓ |
+| `github_repo_info` | github | Detect language, runtime, CI setup from a GitHub repo | ✓ |
+| `github_api_get` | github | General-purpose GitHub REST API read-only query | ✓ |
+| `fetch_webpage` | core | Fetch webpage and convert HTML to text (SSRF-protected) | ✓ |
+| `generate_kubernetes_manifest` | core | Generate K8s Deployment/Service/Ingress YAML | No |
+| `list_artifacts` | core | List generated artifacts in the store | No |
+| `get_artifact` | core | Retrieve a generated artifact by path | No |
+
+**SSRF & Security Controls:**
+- `fetch_webpage` blocks private IP ranges (10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x)
+- Blocks localhost, cloud metadata endpoints, and suspicious redirects
+- All tools sanitize output to prevent injection attacks
+
+### ServiceConnector Pattern
+
+**ServiceConnectors** (`AzureARMConnector`, `GitHubConnector`, `PricingConnector`) handle authenticated API calls on behalf of the engine. Each connector:
+
+1. **Manages authentication** — Token lifecycle, refresh, and credential storage
+2. **Implements uniform interface** — `authenticate()`, `request()`, `isAuthenticated()`
+3. **Provides domain methods** — `listResources()`, `getResource()`, `listUserRepos()`, etc.
+4. **Handles errors gracefully** — Rate limiting, retry logic, stub fallback for offline mode
+
+Connectors are registered in `APIConnectorRegistry` and are shared across tools and fat components. When a component or tool needs to call an API, it looks up the connector by name and calls its methods.
+
+---
+
+## CORS Proxy Security
+
+The web API provides CORS proxy endpoints (`/api/arm-proxy`, `/api/github-proxy`, `/api/pricing-proxy`) to allow the browser to access external APIs. These proxies enforce strict security controls:
+
+| Control | Purpose |
+|---------|---------|
+| **Private IP blocking** | Rejects requests to 10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x |
+| **Redirect validation** | Follows redirects only to same origin or Azure/GitHub domains |
+| **Hostname allowlist** | Blocks localhost, 127.0.0.1, cloud metadata endpoints (169.254.169.254, etc.) |
+| **Rate limiting** | Per-user, per-endpoint throttling to prevent abuse |
+| **Header filtering** | Strips sensitive headers; only allows safe response headers back to browser |
+
+**Auto-continue middleware** wraps the conversation engine to automatically advance past "waiting for user decision" phases when the LLM has enough context. This keeps the flow smooth even with network latency.
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -178,3 +178,4 @@ export type {
   SessionState,
   ConversationMessage,
 } from "./types.js";
+


### PR DESCRIPTION
## Overview
Updates documentation to reflect v0.3.0 architectural patterns and features:

- **ServicePack Pattern** — Declarative auth requirements, kit lifecycle hooks, transactional registration with rollback
- **Fat A2UI Components** — Self-managing Azure/GitHub login, resource pickers with security controls (in-memory tokens, operation allowlisting)
- **LLM Function Calling** — 9 built-in tools enable the LLM to query Azure/GitHub and fetch web pages
- **ServiceConnector Pattern** — Unified API authentication and domain-specific methods
- **CORS Proxy Security** — Private IP filtering, redirect validation, hostname allowlisting

## Changes
- **README.md** — Added fat components, LLM function calling, ServiceConnector/ServicePack patterns, CORS proxy security to features list
- **docs/README.md** — Expanded docs index with full documentation references and v0.3.0 architecture highlights
- **docs/architecture.md** — Added ServicePack section with lifecycle hooks, fat components table with security details, updated tool system section with function calling, added CORS proxy security section
- **docs/a2ui-catalog.md** — Added new Fat A2UI Components section documenting Azure and GitHub components with security features

## Acceptance Criteria
- [x] README reflects current architecture
- [x] API reference docs present (docs/api-reference.md)
- [x] Component catalog documented (docs/a2ui-catalog.md with fat components)
- [x] Deployment guide current (docs/deployment.md)