### PR TITLE
feat: add existing-repo analysis protocol to githubKit Discover phase

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -613,3 +613,16 @@ Addressed Copilot review on PR #78 (data→context terminology fix). PR merged s
 - **ESLint rule:** `preserve-caught-error` requires `{ cause: err }` on re-thrown errors. Use eslint-disable comment for intentional `console.warn`.
 - **Test count:** 61 total (45 original + 16 new for security conditions), all passing.
 
+
+### 2025-07-26: Existing-Repo Analysis Protocol (#17, PR #110)
+
+- **Issue:** #17 — Add existing-repo analysis protocol to githubKit Discover phase
+- **PR:** #110 (draft)
+- **New tools:** `github_repo_tree` (recursive file tree + key-file detection), `github_repo_file_read` (file content reader with base64 decode)
+- **GitHubConnector additions:** `getTree(owner, repo, ref)` (Git Trees API, recursive), `getFileContent(owner, repo, path, ref)` (Contents API). Full stub/offline support for both.
+- **New types:** `GitHubTree`, `GitHubTreeEntry`, `GitHubFileContent` — exported from `connectors/index.ts`
+- **Key-file patterns:** 22 well-known files/dirs for deployment readiness detection (Dockerfile, package.json, go.mod, K8s manifests, CI workflows, etc.)
+- **Base64 portability:** Used `globalThis.atob()` instead of Node.js `Buffer` — core package targets `lib: ["ES2022", "DOM"]` with no `@types/node`
+- **Discover phase prompt:** Replaced single `github_repo_info` call with 4-step analysis protocol (metadata → file tree → read key manifests → summarize readiness). Max 5 file reads to stay within context limits.
+- **Registration:** Both tools in `githubKit.tools[]` and `defaultRegistry`. Exports in `tools/index.ts`.
+- **Test count:** 465 tests, all passing. Lint clean. Build clean.

--- a/packages/core/src/__tests__/github-security.test.ts
+++ b/packages/core/src/__tests__/github-security.test.ts
@@ -1,0 +1,251 @@
+/**
+ * @module @kickstart/core/__tests__/github-security
+ *
+ * Tests for the two security hardening additions:
+ *   1. Path/ref input validation (github-input-validation.ts)
+ *   2. GitHub API rate-limit guard (github-rate-limit.ts)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { validatePath, validateRef } from "../tools/github-input-validation.js";
+import { gitHubRateLimiter } from "../connectors/github-rate-limit.js";
+
+// ---------------------------------------------------------------------------
+// Path validation
+// ---------------------------------------------------------------------------
+
+describe("validatePath", () => {
+  it("accepts a simple file name", () => {
+    expect(validatePath("Dockerfile")).toEqual({ valid: true });
+  });
+
+  it("accepts a nested path", () => {
+    expect(validatePath("src/index.ts")).toEqual({ valid: true });
+  });
+
+  it("accepts a deeply nested path", () => {
+    expect(validatePath(".github/workflows/ci.yml")).toEqual({ valid: true });
+  });
+
+  it("rejects empty path", () => {
+    const r = validatePath("");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("empty");
+  });
+
+  it("rejects path traversal with ../", () => {
+    const r = validatePath("../../../etc/passwd");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("traversal");
+  });
+
+  it("rejects path traversal in the middle", () => {
+    const r = validatePath("src/../../../etc/shadow");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("traversal");
+  });
+
+  it("rejects absolute paths", () => {
+    const r = validatePath("/etc/passwd");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("relative");
+  });
+
+  it("rejects null bytes", () => {
+    const r = validatePath("file\x00.txt");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("forbidden");
+  });
+
+  it("rejects current-directory segment", () => {
+    const r = validatePath("./src/index.ts");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain(".");
+  });
+
+  it("rejects control characters", () => {
+    const r = validatePath("file\x07name");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("forbidden");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ref validation
+// ---------------------------------------------------------------------------
+
+describe("validateRef", () => {
+  it("accepts HEAD", () => {
+    expect(validateRef("HEAD")).toEqual({ valid: true });
+  });
+
+  it("accepts a 40-char lowercase hex SHA", () => {
+    expect(validateRef("abc123def456789012345678901234567890abcd")).toEqual({
+      valid: true,
+    });
+  });
+
+  it("accepts a simple branch name", () => {
+    expect(validateRef("main")).toEqual({ valid: true });
+  });
+
+  it("accepts branch names with slashes", () => {
+    expect(validateRef("feature/my-thing")).toEqual({ valid: true });
+  });
+
+  it("accepts branch names with dots", () => {
+    expect(validateRef("release-1.0")).toEqual({ valid: true });
+  });
+
+  it("accepts a tag name like v1.0.0", () => {
+    expect(validateRef("v1.0.0")).toEqual({ valid: true });
+  });
+
+  it("rejects empty ref", () => {
+    const r = validateRef("");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("empty");
+  });
+
+  it("rejects double-dot path traversal", () => {
+    const r = validateRef("main/../secrets");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("..");
+  });
+
+  it("rejects .lock suffix", () => {
+    const r = validateRef("branch.lock");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain(".lock");
+  });
+
+  it("rejects leading slash", () => {
+    const r = validateRef("/main");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("start or end with '/'");
+  });
+
+  it("rejects trailing slash", () => {
+    const r = validateRef("main/");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("start or end with '/'");
+  });
+
+  it("rejects leading dot", () => {
+    const r = validateRef(".hidden");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("start or end with '.'");
+  });
+
+  it("rejects whitespace", () => {
+    const r = validateRef("main branch");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("forbidden");
+  });
+
+  it("rejects null bytes", () => {
+    const r = validateRef("main\x00");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("forbidden");
+  });
+
+  it("rejects special characters like ~", () => {
+    const r = validateRef("main~1");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("invalid characters");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate-limit tracker
+// ---------------------------------------------------------------------------
+
+describe("gitHubRateLimiter", () => {
+  beforeEach(() => {
+    gitHubRateLimiter.reset();
+  });
+
+  it("allows requests when no state has been recorded", () => {
+    const check = gitHubRateLimiter.check();
+    expect(check.allowed).toBe(true);
+    expect(check.state).toBeNull();
+  });
+
+  it("allows requests when remaining is high", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 3600;
+    const headers = new Headers({
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "4500",
+      "X-RateLimit-Reset": String(resetAt),
+    });
+    gitHubRateLimiter.update({ headers } as unknown as Response);
+
+    const check = gitHubRateLimiter.check();
+    expect(check.allowed).toBe(true);
+    expect(check.warning).toBeUndefined();
+    expect(check.state?.remaining).toBe(4500);
+  });
+
+  it("warns when remaining is below threshold", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 3600;
+    const headers = new Headers({
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "30",
+      "X-RateLimit-Reset": String(resetAt),
+    });
+    gitHubRateLimiter.update({ headers } as unknown as Response);
+
+    const check = gitHubRateLimiter.check();
+    expect(check.allowed).toBe(true);
+    expect(check.warning).toContain("low");
+    expect(check.warning).toContain("30");
+  });
+
+  it("blocks when remaining is 0 and reset is in the future", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 3600;
+    const headers = new Headers({
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "0",
+      "X-RateLimit-Reset": String(resetAt),
+    });
+    gitHubRateLimiter.update({ headers } as unknown as Response);
+
+    const check = gitHubRateLimiter.check();
+    expect(check.allowed).toBe(false);
+    expect(check.warning).toContain("exhausted");
+  });
+
+  it("allows requests after the reset window has passed", () => {
+    const resetAt = Math.floor(Date.now() / 1000) - 10; // 10 seconds ago
+    const headers = new Headers({
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "0",
+      "X-RateLimit-Reset": String(resetAt),
+    });
+    gitHubRateLimiter.update({ headers } as unknown as Response);
+
+    const check = gitHubRateLimiter.check();
+    expect(check.allowed).toBe(true);
+  });
+
+  it("ignores responses without rate-limit headers", () => {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    gitHubRateLimiter.update({ headers } as unknown as Response);
+
+    expect(gitHubRateLimiter.state).toBeNull();
+  });
+
+  it("reset() clears internal state", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 3600;
+    const headers = new Headers({
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "100",
+      "X-RateLimit-Reset": String(resetAt),
+    });
+    gitHubRateLimiter.update({ headers } as unknown as Response);
+    expect(gitHubRateLimiter.state).not.toBeNull();
+
+    gitHubRateLimiter.reset();
+    expect(gitHubRateLimiter.state).toBeNull();
+  });
+});

--- a/packages/core/src/connectors/GitHubConnector.ts
+++ b/packages/core/src/connectors/GitHubConnector.ts
@@ -1,5 +1,7 @@
-import type { ConnectorConfig } from './types.js';
+import type { ConnectorConfig, HttpMethod, APIConnectorRequestOptions } from './types.js';
 import { BaseConnector } from './BaseConnector.js';
+import { gitHubRateLimiter } from './github-rate-limit.js';
+import { ConnectorError } from './types.js';
 
 export interface GitHubRepo {
   id: number;
@@ -107,6 +109,30 @@ export class GitHubConnector extends BaseConnector {
       Accept: 'application/vnd.github+json',
       'X-GitHub-Api-Version': '2022-11-28',
     };
+  }
+
+  /**
+   * Override request to enforce rate-limit guard and track response headers.
+   * Blocks requests when the GitHub rate-limit quota is exhausted.
+   */
+  override async request(
+    method: HttpMethod,
+    path: string,
+    body?: unknown,
+    options?: APIConnectorRequestOptions,
+  ): Promise<Response> {
+    const check = gitHubRateLimiter.check();
+    if (!check.allowed) {
+      throw new ConnectorError(
+        check.warning ?? 'GitHub API rate limit exhausted.',
+        'RATE_LIMITED',
+        { status: 429, retryable: true },
+      );
+    }
+
+    const response = await super.request(method, path, body, options);
+    gitHubRateLimiter.update(response);
+    return response;
   }
 
   // ── Domain methods ─────────────────────────────────────────────────────────

--- a/packages/core/src/connectors/github-rate-limit.ts
+++ b/packages/core/src/connectors/github-rate-limit.ts
@@ -1,0 +1,106 @@
+/**
+ * @module @kickstart/core/connectors/github-rate-limit
+ *
+ * Tracks GitHub API rate-limit state from response headers and provides
+ * pre-flight guards that tools call before issuing requests.
+ *
+ * GitHub sends these headers on every authenticated response:
+ *   X-RateLimit-Limit      — total quota for the current window
+ *   X-RateLimit-Remaining  — requests left in the current window
+ *   X-RateLimit-Reset      — Unix epoch seconds when the window resets
+ */
+
+/** Warn when remaining requests drop below this threshold. */
+const WARN_THRESHOLD = 50;
+
+export interface RateLimitState {
+  /** Total requests allowed per window. */
+  limit: number;
+  /** Requests remaining in the current window. */
+  remaining: number;
+  /** Unix epoch seconds when the window resets. */
+  resetAt: number;
+}
+
+export interface RateLimitCheckResult {
+  allowed: boolean;
+  /** Present when remaining is low or exhausted. */
+  warning?: string;
+  state: RateLimitState | null;
+}
+
+/**
+ * Singleton rate-limit tracker for the GitHub connector.
+ *
+ * Usage:
+ *   1. After every GitHub API response, call `update(response)`.
+ *   2. Before issuing a new request, call `check()`.
+ *      If `allowed` is false the caller must abort.
+ */
+class GitHubRateLimitTracker {
+  private _state: RateLimitState | null = null;
+
+  /** Update internal state from GitHub response headers. */
+  update(response: Response): void {
+    const limit = response.headers.get("X-RateLimit-Limit");
+    const remaining = response.headers.get("X-RateLimit-Remaining");
+    const reset = response.headers.get("X-RateLimit-Reset");
+
+    if (remaining === null) return; // Not a rate-limited endpoint
+
+    this._state = {
+      limit: parseInt(limit ?? "5000", 10),
+      remaining: parseInt(remaining, 10),
+      resetAt: parseInt(reset ?? "0", 10),
+    };
+  }
+
+  /**
+   * Pre-flight check. Returns `allowed: false` when the quota is exhausted
+   * and the reset window hasn't passed yet.
+   */
+  check(): RateLimitCheckResult {
+    if (!this._state) {
+      return { allowed: true, state: null };
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+
+    // If the reset window has passed, optimistically allow
+    if (now >= this._state.resetAt) {
+      return { allowed: true, state: this._state };
+    }
+
+    if (this._state.remaining <= 0) {
+      const waitSec = this._state.resetAt - now;
+      return {
+        allowed: false,
+        warning: `GitHub API rate limit exhausted. Resets in ${waitSec}s. Request blocked.`,
+        state: this._state,
+      };
+    }
+
+    if (this._state.remaining <= WARN_THRESHOLD) {
+      return {
+        allowed: true,
+        warning: `GitHub API rate limit low: ${this._state.remaining}/${this._state.limit} remaining.`,
+        state: this._state,
+      };
+    }
+
+    return { allowed: true, state: this._state };
+  }
+
+  /** Current snapshot (for diagnostics / logging). */
+  get state(): Readonly<RateLimitState> | null {
+    return this._state;
+  }
+
+  /** Reset internal state (useful for tests). */
+  reset(): void {
+    this._state = null;
+  }
+}
+
+/** Singleton instance shared by all GitHub tools. */
+export const gitHubRateLimiter = new GitHubRateLimitTracker();

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -38,3 +38,7 @@ export { GitHubConnector } from './GitHubConnector.js';
 export type { GitHubRepo, GitHubBranch, GitHubRepoOptions, GitHubUser, GitHubDeviceCodeResponse, GitHubPullRequest, GitHubTree, GitHubTreeEntry, GitHubFileContent } from './GitHubConnector.js';
 export { PricingConnector } from './PricingConnector.js';
 export type { ResourceCostInput, ResourceCostEstimate, CostEstimateResult } from './PricingConnector.js';
+
+// Rate-limit tracker
+export { gitHubRateLimiter } from './github-rate-limit.js';
+export type { RateLimitState, RateLimitCheckResult } from './github-rate-limit.js';

--- a/packages/core/src/tools/github-input-validation.ts
+++ b/packages/core/src/tools/github-input-validation.ts
@@ -1,0 +1,133 @@
+/**
+ * @module @kickstart/core/tools/github-input-validation
+ *
+ * Input sanitisation for GitHub repo-analysis tools.
+ * Prevents path-traversal attacks and rejects malformed git refs.
+ */
+
+/** Characters that must never appear in a file path sent to the GitHub API. */
+const FORBIDDEN_PATH_CHARS = /[\x00-\x1f\\]/;
+
+/**
+ * Git ref format per git-check-ref-format(1):
+ *   - 40-char lowercase hex SHA
+ *   - or a branch/tag name: alphanumeric, hyphens, underscores, dots, slashes
+ *     (no consecutive dots, no leading/trailing dot or slash, no ".lock" suffix)
+ */
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const REF_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._\-/]*$/;
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate a file path before sending it to the GitHub Contents API.
+ *
+ * Rejects:
+ *  - Path traversal segments (`..`)
+ *  - Absolute paths (leading `/`)
+ *  - Null bytes or control characters
+ *  - Empty paths
+ */
+export function validatePath(path: string): ValidationResult {
+  if (!path || path.trim().length === 0) {
+    return { valid: false, error: "Path must not be empty." };
+  }
+
+  if (path.startsWith("/")) {
+    return { valid: false, error: "Path must be relative (no leading '/')." };
+  }
+
+  if (FORBIDDEN_PATH_CHARS.test(path)) {
+    return {
+      valid: false,
+      error: "Path contains forbidden characters (null bytes or control chars).",
+    };
+  }
+
+  // Check every segment for path traversal
+  const segments = path.split("/");
+  for (const seg of segments) {
+    if (seg === "..") {
+      return {
+        valid: false,
+        error: "Path traversal ('..') is not allowed.",
+      };
+    }
+    if (seg === ".") {
+      return {
+        valid: false,
+        error: "Current-directory segment ('.') is not allowed in paths.",
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validate a git ref (branch name, tag, or SHA) before using it in a GitHub API request.
+ *
+ * Accepts:
+ *  - 40-char lowercase hex SHA
+ *  - HEAD (literal)
+ *  - Branch / tag names matching git-check-ref-format rules
+ *
+ * Rejects:
+ *  - Path traversal in ref (`..`)
+ *  - Control characters / null bytes
+ *  - Names ending in `.lock`
+ *  - Consecutive dots (`..`)
+ *  - Leading or trailing slashes / dots
+ *  - Whitespace
+ */
+export function validateRef(ref: string): ValidationResult {
+  if (!ref || ref.trim().length === 0) {
+    return { valid: false, error: "Ref must not be empty." };
+  }
+
+  // HEAD is always valid
+  if (ref === "HEAD") {
+    return { valid: true };
+  }
+
+  // Full SHA
+  if (SHA_PATTERN.test(ref)) {
+    return { valid: true };
+  }
+
+  if (FORBIDDEN_PATH_CHARS.test(ref) || /\s/.test(ref)) {
+    return {
+      valid: false,
+      error: "Ref contains forbidden characters (control chars or whitespace).",
+    };
+  }
+
+  if (ref.includes("..")) {
+    return { valid: false, error: "Ref must not contain '..' (path traversal)." };
+  }
+
+  if (ref.endsWith(".lock")) {
+    return { valid: false, error: "Ref must not end with '.lock'." };
+  }
+
+  if (ref.startsWith("/") || ref.endsWith("/")) {
+    return { valid: false, error: "Ref must not start or end with '/'." };
+  }
+
+  if (ref.startsWith(".") || ref.endsWith(".")) {
+    return { valid: false, error: "Ref must not start or end with '.'." };
+  }
+
+  if (!REF_NAME_PATTERN.test(ref)) {
+    return {
+      valid: false,
+      error:
+        "Ref contains invalid characters. Only alphanumerics, hyphens, underscores, dots, and slashes are allowed.",
+    };
+  }
+
+  return { valid: true };
+}

--- a/packages/core/src/tools/github-repo-file-read.ts
+++ b/packages/core/src/tools/github-repo-file-read.ts
@@ -9,6 +9,8 @@
 import type { Tool } from "../types.js";
 import { defaultConnectorRegistry } from "../connectors/index.js";
 import type { GitHubConnector } from "../connectors/index.js";
+import { validatePath, validateRef } from "./github-input-validation.js";
+import { gitHubRateLimiter } from "../connectors/github-rate-limit.js";
 
 interface GitHubRepoFileReadArgs {
   owner: string;
@@ -59,6 +61,26 @@ export const githubRepoFileRead: Tool<GitHubRepoFileReadArgs> = {
   },
 
   async execute(args: GitHubRepoFileReadArgs): Promise<unknown> {
+    // Validate path — reject traversal, absolute paths, control chars
+    const pathCheck = validatePath(args.path);
+    if (!pathCheck.valid) {
+      return { error: `Invalid path: ${pathCheck.error}` };
+    }
+
+    // Validate ref if provided
+    if (args.ref) {
+      const refCheck = validateRef(args.ref);
+      if (!refCheck.valid) {
+        return { error: `Invalid ref: ${refCheck.error}` };
+      }
+    }
+
+    // Pre-flight rate-limit check
+    const rateCheck = gitHubRateLimiter.check();
+    if (!rateCheck.allowed) {
+      return { error: rateCheck.warning };
+    }
+
     const gh = defaultConnectorRegistry.get("github") as
       | GitHubConnector
       | undefined;
@@ -105,7 +127,7 @@ export const githubRepoFileRead: Tool<GitHubRepoFileReadArgs> = {
       const decoded = decodeBase64(file.content);
 
       if (decoded.length > MAX_INLINE_SIZE) {
-        return {
+        const truncResult: Record<string, unknown> = {
           owner: args.owner,
           repo: args.repo,
           path: args.path,
@@ -114,9 +136,12 @@ export const githubRepoFileRead: Tool<GitHubRepoFileReadArgs> = {
           totalSize: file.size,
           htmlUrl: file.html_url,
         };
+        const postCheck1 = gitHubRateLimiter.check();
+        if (postCheck1.warning) truncResult.rateLimitWarning = postCheck1.warning;
+        return truncResult;
       }
 
-      return {
+      const result: Record<string, unknown> = {
         owner: args.owner,
         repo: args.repo,
         path: args.path,
@@ -124,6 +149,12 @@ export const githubRepoFileRead: Tool<GitHubRepoFileReadArgs> = {
         size: file.size,
         htmlUrl: file.html_url,
       };
+
+      // Surface rate-limit warnings to the LLM
+      const postCheck2 = gitHubRateLimiter.check();
+      if (postCheck2.warning) result.rateLimitWarning = postCheck2.warning;
+
+      return result;
     } catch (err) {
       return {
         owner: args.owner,

--- a/packages/core/src/tools/github-repo-tree.ts
+++ b/packages/core/src/tools/github-repo-tree.ts
@@ -9,6 +9,8 @@
 import type { Tool } from "../types.js";
 import { defaultConnectorRegistry } from "../connectors/index.js";
 import type { GitHubConnector } from "../connectors/index.js";
+import { validateRef } from "./github-input-validation.js";
+import { gitHubRateLimiter } from "../connectors/github-rate-limit.js";
 
 interface GitHubRepoTreeArgs {
   owner: string;
@@ -70,6 +72,20 @@ export const githubRepoTree: Tool<GitHubRepoTreeArgs> = {
   },
 
   async execute(args: GitHubRepoTreeArgs): Promise<unknown> {
+    // Validate ref if provided
+    if (args.ref) {
+      const refCheck = validateRef(args.ref);
+      if (!refCheck.valid) {
+        return { error: `Invalid ref: ${refCheck.error}` };
+      }
+    }
+
+    // Pre-flight rate-limit check
+    const rateCheck = gitHubRateLimiter.check();
+    if (!rateCheck.allowed) {
+      return { error: rateCheck.warning };
+    }
+
     const gh = defaultConnectorRegistry.get("github") as
       | GitHubConnector
       | undefined;
@@ -113,7 +129,7 @@ export const githubRepoTree: Tool<GitHubRepoTreeArgs> = {
       )
       .map((entry) => entry.path);
 
-    return {
+    const result: Record<string, unknown> = {
       owner: args.owner,
       repo: args.repo,
       ref: args.ref ?? "HEAD",
@@ -122,5 +138,13 @@ export const githubRepoTree: Tool<GitHubRepoTreeArgs> = {
       keyFiles,
       truncated: treeData.truncated,
     };
+
+    // Surface rate-limit warnings to the LLM
+    const postCheck = gitHubRateLimiter.check();
+    if (postCheck.warning) {
+      result.rateLimitWarning = postCheck.warning;
+    }
+
+    return result;
   },
 };

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -21,6 +21,10 @@ export { estimateCost } from "./estimate-cost.js";
 export { listArtifacts } from "./list-artifacts.js";
 export { getArtifact } from "./get-artifact.js";
 
+// Input validation
+export { validatePath, validateRef } from "./github-input-validation.js";
+export type { ValidationResult } from "./github-input-validation.js";
+
 // Bootstrap the default registry with all built-in tools
 import { defaultRegistry } from "./registry.js";
 import { azureResourceList } from "./azure-resource-list.js";


### PR DESCRIPTION
Closes #17

## Summary
Implements the multi-step existing-repo analysis protocol for the Discover phase, matching the TryAKS `§6a EXISTING REPO ANALYSIS` pattern.

## Changes

### New tools
- **`github_repo_tree`** — Gets the recursive file tree for a repo; returns compact path listing plus a `keyFiles` array highlighting deployment-relevant files (Dockerfile, package.json, K8s manifests, CI workflows, etc.)
- **`github_repo_file_read`** — Reads individual files from a repo with base64 decode, 100 KB inline limit, and portable `atob()` for browser+Node compatibility

### GitHubConnector domain methods
- **`getTree(owner, repo, ref)`** — GitHub Git Trees API (recursive)
- **`getFileContent(owner, repo, path, ref)`** — GitHub Contents API
- New types exported: `GitHubTree`, `GitHubTreeEntry`, `GitHubFileContent`
- Full stub/offline support for both methods

### Discover phase prompt update
Replaced the single-shot `github_repo_info` call with a 4-step analysis protocol:
1. **Metadata** — `github_repo_info` for language, framework, default branch
2. **File tree** — `github_repo_tree` for structure + key file detection
3. **Read key manifests** — `github_repo_file_read` on up to 5 priority files
4. **Summarize** — app type, runtime, container readiness, CI/CD status, K8s manifests, deployment readiness

### Registration
- Both tools registered in `githubKit.tools[]` and the global `defaultRegistry`
- Exports added to `tools/index.ts` and `connectors/index.ts`

## Testing
- Build: `npm run build -w @kickstart/core` ✅
- Lint: `npm run lint` ✅
- Tests: 465/465 passing ✅