### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 This project uses [@changesets/cli](https://github.com/changesets/changesets) for versioning.
 
+## 0.4.0
+
+### Knowledge & Prompts
+
+- **System prompt rules** — Self-contained components, JSON validation, no pre-selection, architect mindset (#6, #10, #11, #15)
+- **AKS Automatic knowledge block** — Detailed feature overview with YAML examples and pricing details (#7, #14)
+- **ARM PUT body templates** — Common Azure resources with body schema guidance for githubKit code generation (#8)
+- **Existing-repo analysis protocol** — Structured discovery of existing repos for githubKit Discover phase (#17)
+
+### Frontend
+
+- **Fluent UI v9 overhaul** — All 18 A2UI basic components upgraded to Fluent v9 with updated API surface (#57)
+- **New catalog components** — Table, Alert, Link with Fluent v9 integration and Storybook stories (#9)
+- **VS Code SVG icons** — Proper VS Code / VS Code Insiders logos, replacing generic icon placeholders (#106)
+- **Dark mode CSS removal** — Simplified docs site CSS, removed unused dark-mode-in-JS patterns (#55)
+
+### Docs
+
+- **README and architecture docs** — Updated for v0.3.0 patterns and A2UI component usage (#52)
+
 ## 0.3.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kickstart",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI-guided onboarding for deploying apps to AKS",
   "license": "MIT",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Kickstart conversation engine, A2UI catalog, and code generators",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for AKS Kickstart — exposes conversation tools and A2UI responses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/web",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "Kickstart web frontend — Azure Portal-style UX for AI-guided AKS deployment",


### PR DESCRIPTION
Release v0.4.0 with knowledge hardening, Fluent UI v9 overhaul, and expanded AKS knowledge blocks.