### PR TITLE
feat: Frontend Wave 2 — inspiration button, URL links, 5 Fluent components

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -49,6 +49,9 @@ Fry (Frontend Dev) has shipped the web surface for Kickstart. The stack evolved 
 - B-33: Theme customization system ✅ (pushed 2026-04-11)
 - #9: Table, Alert, Link catalog components ✅ (PR #111, 2026-07-17)
 - #106: VSCode/Insiders SVG icon fix ✅ (PR #111, 2026-07-17)
+- #56: Inspiration button in Create tab follow-up input ✅ (PR #118, 2026-04-10)
+- #58: Clickable URLs in chat messages ✅ (PR #118, 2026-04-10)
+- #18: Badge, Accordion, Toggle, ComboBox, MultiSelect components ✅ (PR #118, 2026-04-10)
 
 ## Learnings
 
@@ -262,3 +265,12 @@ Fry (Frontend Dev) has shipped the web surface for Kickstart. The stack evolved 
 ## Completed Tasks
 - #38: FileEditor Monaco + tabs, CostEstimate SKU + projection ✅ (PR #115, 2026-04-10)
 - #20: add-component.prompt.md ✅ (PR #115, 2026-04-10)
+
+### Frontend Wave 2 (#56, #58, #18) — 2026-04-10
+
+- **Multi-issue PR pattern:** Batching small related issues (3 frontend features) into one PR is efficient — keeps review scope manageable while reducing branch churn. Order by size: smallest first.
+- **URL linkification in two paths:** Chat HTML path uses regex→string→DOMPurify. A2UI Text path uses regex→React JSX (FluentLink). Never mix them — HTML path needs sanitization, JSX path is inherently safe.
+- **Strict URL allowlist:** `https?://` regex is the correct security boundary — blocks `javascript:`, `data:`, `vbscript:` by never matching them. No URL validation library needed for this pattern.
+- **ChildList pattern for nested components:** Accordion items use the same `ChildList` + `buildChild` pattern as Row/Column — not `context.renderChild()` which doesn't exist in the adapter.
+- **ComboBox vs MultiSelect split:** Two components is correct — LLM schema is simpler with distinct names. Fluent `Combobox` has a `multiselect` prop but separate APIs avoid prompt confusion.
+- **Stash across branches is dangerous:** `git stash` + `git stash pop` on a different branch silently merges working tree changes from the original branch. Always verify branch + diff before committing after stash operations.

--- a/packages/core/src/catalog/index.ts
+++ b/packages/core/src/catalog/index.ts
@@ -205,6 +205,61 @@ export interface DeploymentProgressComponent extends BaseComponent {
   steps: DeploymentStep[];
 }
 
+// ── New Fluent Components (5) — Issue #18 ───────────────────────────
+
+export interface BadgeComponent extends BaseComponent {
+  component: "Badge";
+  text?: string;
+  color?: "brand" | "danger" | "important" | "informative" | "severe" | "subtle" | "success" | "warning";
+  shape?: "circular" | "rounded" | "square";
+  size?: "tiny" | "small" | "medium" | "large" | "extra-large";
+  appearance?: "filled" | "ghost" | "outline" | "tint";
+  variant?: "badge" | "counter" | "presence";
+  count?: number;
+  status?: "available" | "away" | "busy" | "do-not-disturb" | "offline" | "out-of-office" | "unknown";
+}
+
+export interface AccordionItemDef {
+  title: string;
+  children: string[];
+}
+
+export interface AccordionComponent extends BaseComponent {
+  component: "Accordion";
+  items: AccordionItemDef[];
+  collapsible?: boolean;
+  multiple?: boolean;
+}
+
+export interface ToggleComponent extends BaseComponent {
+  component: "Toggle";
+  label?: string;
+  checked?: boolean;
+  disabled?: boolean;
+}
+
+export interface ComboBoxOption {
+  text: string;
+  value: string;
+}
+
+export interface ComboBoxComponent extends BaseComponent {
+  component: "ComboBox";
+  label?: string;
+  options: ComboBoxOption[];
+  placeholder?: string;
+  allowCustom?: boolean;
+  value?: string;
+}
+
+export interface MultiSelectComponent extends BaseComponent {
+  component: "MultiSelect";
+  label?: string;
+  options: ComboBoxOption[];
+  placeholder?: string;
+  selectedValues?: string[];
+}
+
 // ── Union Type ──────────────────────────────────────────────────────
 
 export type Component =
@@ -230,7 +285,12 @@ export type Component =
   | ArchitectureDiagramComponent
   | FileEditorComponent
   | AuthCardComponent
-  | DeploymentProgressComponent;
+  | DeploymentProgressComponent
+  | BadgeComponent
+  | AccordionComponent
+  | ToggleComponent
+  | ComboBoxComponent
+  | MultiSelectComponent;
 
 // ── A2UI v0.9 Document ──────────────────────────────────────────────
 

--- a/packages/core/src/catalog/kickstart-catalog.json
+++ b/packages/core/src/catalog/kickstart-catalog.json
@@ -9,345 +9,666 @@
       "type": "object",
       "description": "Every component has a unique id and a component type name.",
       "properties": {
-        "id": { "type": "string", "description": "Unique component identifier" },
-        "component": { "type": "string", "description": "Component type name from catalog" }
+        "id": {
+          "type": "string",
+          "description": "Unique component identifier"
+        },
+        "component": {
+          "type": "string",
+          "description": "Component type name from catalog"
+        }
       },
-      "required": ["id", "component"]
+      "required": [
+        "id",
+        "component"
+      ]
     },
-
     "Text": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Text" },
-            "text": { "type": "string" },
-            "variant": { "type": "string", "enum": ["h1", "h2", "h3", "body", "caption", "code"] }
+            "component": {
+              "const": "Text"
+            },
+            "text": {
+              "type": "string"
+            },
+            "variant": {
+              "type": "string",
+              "enum": [
+                "h1",
+                "h2",
+                "h3",
+                "body",
+                "caption",
+                "code"
+              ]
+            }
           },
-          "required": ["component", "text"]
+          "required": [
+            "component",
+            "text"
+          ]
         }
       ]
     },
-
     "Image": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Image" },
-            "src": { "type": "string", "format": "uri" },
-            "alt": { "type": "string" }
+            "component": {
+              "const": "Image"
+            },
+            "src": {
+              "type": "string",
+              "format": "uri"
+            },
+            "alt": {
+              "type": "string"
+            }
           },
-          "required": ["component", "src", "alt"]
+          "required": [
+            "component",
+            "src",
+            "alt"
+          ]
         }
       ]
     },
-
     "Icon": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Icon" },
-            "name": { "type": "string" },
-            "size": { "type": "string" }
+            "component": {
+              "const": "Icon"
+            },
+            "name": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            }
           },
-          "required": ["component", "name"]
+          "required": [
+            "component",
+            "name"
+          ]
         }
       ]
     },
-
     "Video": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Video" },
-            "src": { "type": "string", "format": "uri" }
+            "component": {
+              "const": "Video"
+            },
+            "src": {
+              "type": "string",
+              "format": "uri"
+            }
           },
-          "required": ["component", "src"]
+          "required": [
+            "component",
+            "src"
+          ]
         }
       ]
     },
-
     "AudioPlayer": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "AudioPlayer" },
-            "src": { "type": "string", "format": "uri" }
+            "component": {
+              "const": "AudioPlayer"
+            },
+            "src": {
+              "type": "string",
+              "format": "uri"
+            }
           },
-          "required": ["component", "src"]
+          "required": [
+            "component",
+            "src"
+          ]
         }
       ]
     },
-
     "Row": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Row" },
-            "children": { "type": "array", "items": { "type": "string" }, "description": "Array of child component ids" },
-            "gap": { "type": "string" },
-            "justify": { "type": "string", "enum": ["start", "center", "end", "spaceBetween", "spaceAround"] },
-            "align": { "type": "string", "enum": ["start", "center", "end", "stretch"] },
-            "wrap": { "type": "boolean" }
+            "component": {
+              "const": "Row"
+            },
+            "children": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of child component ids"
+            },
+            "gap": {
+              "type": "string"
+            },
+            "justify": {
+              "type": "string",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "spaceBetween",
+                "spaceAround"
+              ]
+            },
+            "align": {
+              "type": "string",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "stretch"
+              ]
+            },
+            "wrap": {
+              "type": "boolean"
+            }
           },
-          "required": ["component", "children"]
+          "required": [
+            "component",
+            "children"
+          ]
         }
       ]
     },
-
     "Column": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Column" },
-            "children": { "type": "array", "items": { "type": "string" } },
-            "gap": { "type": "string" }
+            "component": {
+              "const": "Column"
+            },
+            "children": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "gap": {
+              "type": "string"
+            }
           },
-          "required": ["component", "children"]
+          "required": [
+            "component",
+            "children"
+          ]
         }
       ]
     },
-
     "List": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "List" },
-            "children": { "type": "array", "items": { "type": "string" } },
-            "ordered": { "type": "boolean", "default": false }
+            "component": {
+              "const": "List"
+            },
+            "children": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ordered": {
+              "type": "boolean",
+              "default": false
+            }
           },
-          "required": ["component", "children"]
+          "required": [
+            "component",
+            "children"
+          ]
         }
       ]
     },
-
     "Card": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Card" },
-            "children": { "type": "array", "items": { "type": "string" } }
+            "component": {
+              "const": "Card"
+            },
+            "children": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
-          "required": ["component", "children"]
+          "required": [
+            "component",
+            "children"
+          ]
         }
       ]
     },
-
     "Tabs": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Tabs" },
+            "component": {
+              "const": "Tabs"
+            },
             "tabs": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "label": { "type": "string" },
-                  "children": { "type": "array", "items": { "type": "string" } }
+                  "label": {
+                    "type": "string"
+                  },
+                  "children": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
                 },
-                "required": ["label", "children"]
+                "required": [
+                  "label",
+                  "children"
+                ]
               }
             }
           },
-          "required": ["component", "tabs"]
+          "required": [
+            "component",
+            "tabs"
+          ]
         }
       ]
     },
-
     "Divider": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Divider" }
+            "component": {
+              "const": "Divider"
+            }
           },
-          "required": ["component"]
+          "required": [
+            "component"
+          ]
         }
       ]
     },
-
     "Modal": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Modal" },
-            "child": { "type": "string", "description": "Single child component id" },
-            "title": { "type": "string" },
-            "open": { "type": "boolean", "default": false }
+            "component": {
+              "const": "Modal"
+            },
+            "child": {
+              "type": "string",
+              "description": "Single child component id"
+            },
+            "title": {
+              "type": "string"
+            },
+            "open": {
+              "type": "boolean",
+              "default": false
+            }
           },
-          "required": ["component", "child", "title"]
+          "required": [
+            "component",
+            "child",
+            "title"
+          ]
         }
       ]
     },
-
     "Button": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Button" },
-            "child": { "type": "string", "description": "Label component id" },
-            "variant": { "type": "string", "enum": ["primary", "secondary", "outline", "danger", "ghost"] },
-            "disabled": { "type": "boolean", "default": false },
+            "component": {
+              "const": "Button"
+            },
+            "child": {
+              "type": "string",
+              "description": "Label component id"
+            },
+            "variant": {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "outline",
+                "danger",
+                "ghost"
+              ]
+            },
+            "disabled": {
+              "type": "boolean",
+              "default": false
+            },
             "action": {
               "type": "object",
               "properties": {
                 "event": {
                   "type": "object",
                   "properties": {
-                    "name": { "type": "string" },
-                    "data": { "type": "object" }
+                    "name": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
                   },
-                  "required": ["name"]
+                  "required": [
+                    "name"
+                  ]
                 }
               }
             }
           },
-          "required": ["component", "child", "action"]
+          "required": [
+            "component",
+            "child",
+            "action"
+          ]
         }
       ]
     },
-
     "TextField": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "TextField" },
-            "label": { "type": "string" },
-            "placeholder": { "type": "string" },
-            "value": { "type": "string" },
-            "action": { "type": "object" }
+            "component": {
+              "const": "TextField"
+            },
+            "label": {
+              "type": "string"
+            },
+            "placeholder": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "action": {
+              "type": "object"
+            }
           },
-          "required": ["component", "label"]
+          "required": [
+            "component",
+            "label"
+          ]
         }
       ]
     },
-
     "CheckBox": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "CheckBox" },
-            "label": { "type": "string" },
-            "checked": { "type": "boolean", "default": false },
-            "action": { "type": "object" }
+            "component": {
+              "const": "CheckBox"
+            },
+            "label": {
+              "type": "string"
+            },
+            "checked": {
+              "type": "boolean",
+              "default": false
+            },
+            "action": {
+              "type": "object"
+            }
           },
-          "required": ["component", "label"]
+          "required": [
+            "component",
+            "label"
+          ]
         }
       ]
     },
-
     "ChoicePicker": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "ChoicePicker" },
-            "label": { "type": "string" },
+            "component": {
+              "const": "ChoicePicker"
+            },
+            "label": {
+              "type": "string"
+            },
             "options": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "label": { "type": "string" },
-                  "value": { "type": "string" }
+                  "label": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
                 },
-                "required": ["label", "value"]
+                "required": [
+                  "label",
+                  "value"
+                ]
               }
             },
-            "action": { "type": "object" }
+            "action": {
+              "type": "object"
+            }
           },
-          "required": ["component", "label", "options"]
+          "required": [
+            "component",
+            "label",
+            "options"
+          ]
         }
       ]
     },
-
     "Slider": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "Slider" },
-            "label": { "type": "string" },
-            "min": { "type": "number" },
-            "max": { "type": "number" },
-            "value": { "type": "number" },
-            "action": { "type": "object" }
+            "component": {
+              "const": "Slider"
+            },
+            "label": {
+              "type": "string"
+            },
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "value": {
+              "type": "number"
+            },
+            "action": {
+              "type": "object"
+            }
           },
-          "required": ["component", "label", "min", "max"]
+          "required": [
+            "component",
+            "label",
+            "min",
+            "max"
+          ]
         }
       ]
     },
-
     "DateTimeInput": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "DateTimeInput" },
-            "label": { "type": "string" },
-            "value": { "type": "string", "format": "date-time" }
+            "component": {
+              "const": "DateTimeInput"
+            },
+            "label": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
-          "required": ["component", "label"]
+          "required": [
+            "component",
+            "label"
+          ]
         }
       ]
     },
-
     "CostEstimate": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "CostEstimate" },
+            "component": {
+              "const": "CostEstimate"
+            },
             "items": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": { "type": "string" },
-                  "sku": { "type": "string" },
-                  "monthlyCost": { "type": "number" }
+                  "name": {
+                    "type": "string"
+                  },
+                  "sku": {
+                    "type": "string"
+                  },
+                  "monthlyCost": {
+                    "type": "number"
+                  }
                 },
-                "required": ["name", "sku", "monthlyCost"]
+                "required": [
+                  "name",
+                  "sku",
+                  "monthlyCost"
+                ]
               }
             },
-            "total": { "type": "number" },
-            "currency": { "type": "string", "default": "USD" }
+            "total": {
+              "type": "number"
+            },
+            "currency": {
+              "type": "string",
+              "default": "USD"
+            }
           },
-          "required": ["component", "items", "total", "currency"]
+          "required": [
+            "component",
+            "items",
+            "total",
+            "currency"
+          ]
         }
       ]
     },
-
     "ArchitectureDiagram": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "ArchitectureDiagram" },
+            "component": {
+              "const": "ArchitectureDiagram"
+            },
             "nodes": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string" },
-                  "label": { "type": "string" },
-                  "type": { "type": "string", "enum": ["compute", "database", "cache", "network", "storage", "ai", "messaging"] }
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "compute",
+                      "database",
+                      "cache",
+                      "network",
+                      "storage",
+                      "ai",
+                      "messaging"
+                    ]
+                  }
                 },
-                "required": ["id", "label", "type"]
+                "required": [
+                  "id",
+                  "label",
+                  "type"
+                ]
               }
             },
             "edges": {
@@ -355,104 +676,491 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "from": { "type": "string" },
-                  "to": { "type": "string" }
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
+                  }
                 },
-                "required": ["from", "to"]
+                "required": [
+                  "from",
+                  "to"
+                ]
               }
             }
           },
-          "required": ["component", "nodes", "edges"]
+          "required": [
+            "component",
+            "nodes",
+            "edges"
+          ]
         }
       ]
     },
-
     "FileEditor": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "FileEditor" },
-            "filename": { "type": "string" },
-            "language": { "type": "string" },
-            "content": { "type": "string" }
+            "component": {
+              "const": "FileEditor"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "language": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            }
           },
-          "required": ["component", "filename", "language", "content"]
+          "required": [
+            "component",
+            "filename",
+            "language",
+            "content"
+          ]
         }
       ]
     },
-
     "AuthCard": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "AuthCard" },
-            "provider": { "type": "string", "enum": ["azure", "github"] },
-            "title": { "type": "string" },
-            "description": { "type": "string" }
+            "component": {
+              "const": "AuthCard"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "azure",
+                "github"
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
           },
-          "required": ["component", "provider", "title"]
+          "required": [
+            "component",
+            "provider",
+            "title"
+          ]
         }
       ]
     },
-
     "DeploymentProgress": {
       "allOf": [
-        { "$ref": "#/$defs/BaseComponent" },
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
         {
           "properties": {
-            "component": { "const": "DeploymentProgress" },
+            "component": {
+              "const": "DeploymentProgress"
+            },
             "steps": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string" },
-                  "label": { "type": "string" },
-                  "status": { "type": "string", "enum": ["pending", "running", "complete", "error", "skipped"] }
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "running",
+                      "complete",
+                      "error",
+                      "skipped"
+                    ]
+                  }
                 },
-                "required": ["id", "label", "status"]
+                "required": [
+                  "id",
+                  "label",
+                  "status"
+                ]
               }
             }
           },
-          "required": ["component", "steps"]
+          "required": [
+            "component",
+            "steps"
+          ]
         }
       ]
     },
-
     "Component": {
       "oneOf": [
-        { "$ref": "#/$defs/Text" },
-        { "$ref": "#/$defs/Image" },
-        { "$ref": "#/$defs/Icon" },
-        { "$ref": "#/$defs/Video" },
-        { "$ref": "#/$defs/AudioPlayer" },
-        { "$ref": "#/$defs/Row" },
-        { "$ref": "#/$defs/Column" },
-        { "$ref": "#/$defs/List" },
-        { "$ref": "#/$defs/Card" },
-        { "$ref": "#/$defs/Tabs" },
-        { "$ref": "#/$defs/Divider" },
-        { "$ref": "#/$defs/Modal" },
-        { "$ref": "#/$defs/Button" },
-        { "$ref": "#/$defs/TextField" },
-        { "$ref": "#/$defs/CheckBox" },
-        { "$ref": "#/$defs/ChoicePicker" },
-        { "$ref": "#/$defs/Slider" },
-        { "$ref": "#/$defs/DateTimeInput" },
-        { "$ref": "#/$defs/CostEstimate" },
-        { "$ref": "#/$defs/ArchitectureDiagram" },
-        { "$ref": "#/$defs/FileEditor" },
-        { "$ref": "#/$defs/AuthCard" },
-        { "$ref": "#/$defs/DeploymentProgress" }
+        {
+          "$ref": "#/$defs/Text"
+        },
+        {
+          "$ref": "#/$defs/Image"
+        },
+        {
+          "$ref": "#/$defs/Icon"
+        },
+        {
+          "$ref": "#/$defs/Video"
+        },
+        {
+          "$ref": "#/$defs/AudioPlayer"
+        },
+        {
+          "$ref": "#/$defs/Row"
+        },
+        {
+          "$ref": "#/$defs/Column"
+        },
+        {
+          "$ref": "#/$defs/List"
+        },
+        {
+          "$ref": "#/$defs/Card"
+        },
+        {
+          "$ref": "#/$defs/Tabs"
+        },
+        {
+          "$ref": "#/$defs/Divider"
+        },
+        {
+          "$ref": "#/$defs/Modal"
+        },
+        {
+          "$ref": "#/$defs/Button"
+        },
+        {
+          "$ref": "#/$defs/TextField"
+        },
+        {
+          "$ref": "#/$defs/CheckBox"
+        },
+        {
+          "$ref": "#/$defs/ChoicePicker"
+        },
+        {
+          "$ref": "#/$defs/Slider"
+        },
+        {
+          "$ref": "#/$defs/DateTimeInput"
+        },
+        {
+          "$ref": "#/$defs/CostEstimate"
+        },
+        {
+          "$ref": "#/$defs/ArchitectureDiagram"
+        },
+        {
+          "$ref": "#/$defs/FileEditor"
+        },
+        {
+          "$ref": "#/$defs/AuthCard"
+        },
+        {
+          "$ref": "#/$defs/DeploymentProgress"
+        },
+        {
+          "$ref": "#/$defs/Badge"
+        },
+        {
+          "$ref": "#/$defs/Accordion"
+        },
+        {
+          "$ref": "#/$defs/Toggle"
+        },
+        {
+          "$ref": "#/$defs/ComboBox"
+        },
+        {
+          "$ref": "#/$defs/MultiSelect"
+        }
+      ]
+    },
+    "Badge": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
+        {
+          "properties": {
+            "component": {
+              "const": "Badge"
+            },
+            "text": {
+              "type": "string"
+            },
+            "color": {
+              "type": "string",
+              "enum": [
+                "brand",
+                "danger",
+                "important",
+                "informative",
+                "severe",
+                "subtle",
+                "success",
+                "warning"
+              ]
+            },
+            "shape": {
+              "type": "string",
+              "enum": [
+                "circular",
+                "rounded",
+                "square"
+              ]
+            },
+            "size": {
+              "type": "string",
+              "enum": [
+                "tiny",
+                "small",
+                "medium",
+                "large",
+                "extra-large"
+              ]
+            },
+            "appearance": {
+              "type": "string",
+              "enum": [
+                "filled",
+                "ghost",
+                "outline",
+                "tint"
+              ]
+            },
+            "variant": {
+              "type": "string",
+              "enum": [
+                "badge",
+                "counter",
+                "presence"
+              ]
+            },
+            "count": {
+              "type": "number"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "available",
+                "away",
+                "busy",
+                "do-not-disturb",
+                "offline",
+                "out-of-office",
+                "unknown"
+              ]
+            }
+          },
+          "required": [
+            "component"
+          ]
+        }
+      ]
+    },
+    "Accordion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
+        {
+          "properties": {
+            "component": {
+              "const": "Accordion"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "children": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "title",
+                  "children"
+                ]
+              }
+            },
+            "collapsible": {
+              "type": "boolean",
+              "default": true
+            },
+            "multiple": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "component",
+            "items"
+          ]
+        }
+      ]
+    },
+    "Toggle": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
+        {
+          "properties": {
+            "component": {
+              "const": "Toggle"
+            },
+            "label": {
+              "type": "string"
+            },
+            "checked": {
+              "type": "boolean",
+              "default": false
+            },
+            "disabled": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "component"
+          ]
+        }
+      ]
+    },
+    "ComboBox": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
+        {
+          "properties": {
+            "component": {
+              "const": "ComboBox"
+            },
+            "label": {
+              "type": "string"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text",
+                  "value"
+                ]
+              }
+            },
+            "placeholder": {
+              "type": "string"
+            },
+            "allowCustom": {
+              "type": "boolean",
+              "default": false
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "component",
+            "options"
+          ]
+        }
+      ]
+    },
+    "MultiSelect": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseComponent"
+        },
+        {
+          "properties": {
+            "component": {
+              "const": "MultiSelect"
+            },
+            "label": {
+              "type": "string"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text",
+                  "value"
+                ]
+              }
+            },
+            "placeholder": {
+              "type": "string"
+            },
+            "selectedValues": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "component",
+            "options"
+          ]
+        }
       ]
     }
   },
-
   "properties": {
-    "version": { "type": "string", "const": "0.9" },
-    "root": { "$ref": "#/$defs/Component" }
+    "version": {
+      "type": "string",
+      "const": "0.9"
+    },
+    "root": {
+      "$ref": "#/$defs/Component"
+    }
   },
-  "required": ["version", "root"]
+  "required": [
+    "version",
+    "root"
+  ]
 }

--- a/packages/web/src/catalog/fluent-components/Accordion.tsx
+++ b/packages/web/src/catalog/fluent-components/Accordion.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {createReactComponent} from '../../vendor/a2ui/react/adapter';
+import {z} from 'zod';
+import {DynamicStringSchema} from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Accordion as FluentAccordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionPanel,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import {ChildList} from './ChildList';
+
+const FlexibleAccordionApi = {
+  name: 'Accordion' as const,
+  schema: z.object({
+    accessibility: z.any().optional(),
+    weight: z.number().optional(),
+    items: z.array(z.object({
+      title: DynamicStringSchema,
+      children: z.array(z.string()),
+    })),
+    collapsible: z.boolean().optional(),
+    multiple: z.boolean().optional(),
+  }),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalS,
+    width: '100%',
+  },
+});
+
+export const Accordion = createReactComponent(FlexibleAccordionApi, ({props, buildChild, context}) => {
+  const classes = useStyles();
+  const items = props.items ?? [];
+
+  return (
+    <FluentAccordion
+      className={classes.root}
+      collapsible={props.collapsible !== false}
+      multiple={props.multiple === true}
+    >
+      {items.map((item: any, i: number) => (
+        <AccordionItem key={i} value={String(i)}>
+          <AccordionHeader>{item.title ?? ''}</AccordionHeader>
+          <AccordionPanel>
+            <ChildList childList={item.children} buildChild={buildChild} context={context} />
+          </AccordionPanel>
+        </AccordionItem>
+      ))}
+    </FluentAccordion>
+  );
+});

--- a/packages/web/src/catalog/fluent-components/Badge.tsx
+++ b/packages/web/src/catalog/fluent-components/Badge.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {createReactComponent} from '../../vendor/a2ui/react/adapter';
+import {z} from 'zod';
+import {DynamicStringSchema} from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Badge as FluentBadge,
+  CounterBadge,
+  PresenceBadge,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+
+const FlexibleBadgeApi = {
+  name: 'Badge' as const,
+  schema: z.object({
+    accessibility: z.any().optional(),
+    weight: z.number().optional(),
+    text: DynamicStringSchema.optional(),
+    color: z.enum([
+      'brand', 'danger', 'important', 'informative',
+      'severe', 'subtle', 'success', 'warning',
+    ]).optional(),
+    shape: z.enum(['circular', 'rounded', 'square']).optional(),
+    size: z.enum(['tiny', 'small', 'medium', 'large', 'extra-large']).optional(),
+    appearance: z.enum(['filled', 'ghost', 'outline', 'tint']).optional(),
+    variant: z.enum(['badge', 'counter', 'presence']).optional(),
+    count: z.number().optional(),
+    status: z.enum(['available', 'away', 'busy', 'do-not-disturb', 'offline', 'out-of-office', 'unknown']).optional(),
+  }),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalXXS,
+    marginBottom: tokens.spacingVerticalXXS,
+  },
+});
+
+export const Badge = createReactComponent(FlexibleBadgeApi, ({props}) => {
+  const classes = useStyles();
+  const variant = (props.variant as string) || 'badge';
+
+  if (variant === 'counter') {
+    return (
+      <CounterBadge
+        className={classes.root}
+        count={props.count ?? 0}
+        color={props.color as any}
+        shape={props.shape as any}
+        size={props.size as any}
+        appearance={props.appearance as any}
+      />
+    );
+  }
+
+  if (variant === 'presence') {
+    return (
+      <PresenceBadge
+        className={classes.root}
+        status={props.status as any ?? 'available'}
+        size={props.size as any}
+      />
+    );
+  }
+
+  return (
+    <FluentBadge
+      className={classes.root}
+      color={props.color as any}
+      shape={props.shape as any}
+      size={props.size as any}
+      appearance={props.appearance as any}
+    >
+      {props.text ?? ''}
+    </FluentBadge>
+  );
+});

--- a/packages/web/src/catalog/fluent-components/ComboBox.tsx
+++ b/packages/web/src/catalog/fluent-components/ComboBox.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {createReactComponent} from '../../vendor/a2ui/react/adapter';
+import {z} from 'zod';
+import {DynamicStringSchema} from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Combobox,
+  Option,
+  Field,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+
+const FlexibleComboBoxApi = {
+  name: 'ComboBox' as const,
+  schema: z.object({
+    accessibility: z.any().optional(),
+    weight: z.number().optional(),
+    label: DynamicStringSchema.optional(),
+    options: z.array(z.object({
+      text: DynamicStringSchema,
+      value: DynamicStringSchema,
+    })),
+    placeholder: DynamicStringSchema.optional(),
+    allowCustom: z.boolean().optional(),
+    value: DynamicStringSchema.optional(),
+  }),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalS,
+    width: '100%',
+  },
+});
+
+export const ComboBox = createReactComponent(FlexibleComboBoxApi, ({props}) => {
+  const classes = useStyles();
+  const options = props.options ?? [];
+
+  const onOptionSelect = (_ev: any, data: { optionValue?: string }) => {
+    if (props.setValue && data.optionValue) {
+      props.setValue(data.optionValue);
+    }
+  };
+
+  return (
+    <div className={classes.root}>
+      <Field label={props.label || undefined}>
+        <Combobox
+          placeholder={props.placeholder || undefined}
+          freeform={props.allowCustom === true}
+          value={props.value ?? ''}
+          onOptionSelect={onOptionSelect}
+        >
+          {options.map((opt: any, i: number) => (
+            <Option key={i} value={opt.value ?? ''}>
+              {opt.text ?? opt.value ?? ''}
+            </Option>
+          ))}
+        </Combobox>
+      </Field>
+    </div>
+  );
+});

--- a/packages/web/src/catalog/fluent-components/MultiSelect.tsx
+++ b/packages/web/src/catalog/fluent-components/MultiSelect.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {createReactComponent} from '../../vendor/a2ui/react/adapter';
+import {z} from 'zod';
+import {DynamicStringSchema} from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Combobox,
+  Option,
+  Field,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+
+const FlexibleMultiSelectApi = {
+  name: 'MultiSelect' as const,
+  schema: z.object({
+    accessibility: z.any().optional(),
+    weight: z.number().optional(),
+    label: DynamicStringSchema.optional(),
+    options: z.array(z.object({
+      text: DynamicStringSchema,
+      value: DynamicStringSchema,
+    })),
+    placeholder: DynamicStringSchema.optional(),
+    selectedValues: z.array(DynamicStringSchema).optional(),
+  }),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalS,
+    width: '100%',
+  },
+});
+
+export const MultiSelect = createReactComponent(FlexibleMultiSelectApi, ({props}) => {
+  const classes = useStyles();
+  const options = props.options ?? [];
+  const selected = Array.isArray(props.selectedValues) ? props.selectedValues : [];
+
+  const onOptionSelect = (_ev: any, data: { selectedOptions: string[] }) => {
+    if (props.setValue) {
+      props.setValue(data.selectedOptions);
+    }
+  };
+
+  return (
+    <div className={classes.root}>
+      <Field label={props.label || undefined}>
+        <Combobox
+          placeholder={props.placeholder || undefined}
+          multiselect
+          selectedOptions={selected}
+          onOptionSelect={onOptionSelect}
+        >
+          {options.map((opt: any, i: number) => (
+            <Option key={i} value={opt.value ?? ''}>
+              {opt.text ?? opt.value ?? ''}
+            </Option>
+          ))}
+        </Combobox>
+      </Field>
+    </div>
+  );
+});

--- a/packages/web/src/catalog/fluent-components/MultiSelect.tsx
+++ b/packages/web/src/catalog/fluent-components/MultiSelect.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {createReactComponent} from '../../vendor/a2ui/react/adapter';
 import {z} from 'zod';
-import {DynamicStringSchema} from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  DynamicStringSchema,
+  DynamicStringListSchema,
+} from '../../vendor/a2ui/web_core/schema/common-types';
 import {
   Combobox,
   Option,
@@ -21,7 +24,7 @@ const FlexibleMultiSelectApi = {
       value: DynamicStringSchema,
     })),
     placeholder: DynamicStringSchema.optional(),
-    selectedValues: z.array(DynamicStringSchema).optional(),
+    value: DynamicStringListSchema.optional(),
   }),
 };
 
@@ -36,12 +39,10 @@ const useStyles = makeStyles({
 export const MultiSelect = createReactComponent(FlexibleMultiSelectApi, ({props}) => {
   const classes = useStyles();
   const options = props.options ?? [];
-  const selected = Array.isArray(props.selectedValues) ? props.selectedValues : [];
+  const selected = Array.isArray(props.value) ? props.value : [];
 
   const onOptionSelect = (_ev: any, data: { selectedOptions: string[] }) => {
-    if (props.setValue) {
-      props.setValue(data.selectedOptions);
-    }
+    props.setValue(data.selectedOptions);
   };
 
   return (

--- a/packages/web/src/catalog/fluent-components/Text.tsx
+++ b/packages/web/src/catalog/fluent-components/Text.tsx
@@ -9,9 +9,11 @@ import {
   Subtitle2,
   Caption1,
   Body1,
+  Link as FluentLink,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
+import {OpenRegular} from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
@@ -19,13 +21,18 @@ const useStyles = makeStyles({
     marginBottom: tokens.spacingVerticalXS,
     display: 'inline-block',
   },
+  linkIcon: {
+    marginLeft: '2px',
+    fontSize: '12px',
+    verticalAlign: 'middle',
+  },
 });
 
-// Parse basic inline markdown: **bold** and *italic*
+// Parse basic inline markdown: **bold**, *italic*, and https?:// URLs
 function parseInlineMarkdown(text: string): React.ReactNode[] {
   const parts: React.ReactNode[] = [];
-  // Match **bold** first, then *italic* (order matters)
-  const regex = /(\*\*(.+?)\*\*|\*(.+?)\*)/g;
+  // Match URLs first (strict http/https only), then **bold**, then *italic*
+  const regex = /(https?:\/\/[^\s*<>")\]]+|\*\*(.+?)\*\*|\*(.+?)\*)/g;
   let lastIndex = 0;
   let match;
   let key = 0;
@@ -34,7 +41,15 @@ function parseInlineMarkdown(text: string): React.ReactNode[] {
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
-    if (match[2]) {
+    if (match[0].startsWith('http')) {
+      const url = match[0];
+      parts.push(
+        <FluentLink key={key++} href={url} target="_blank" rel="noopener noreferrer" inline>
+          {url}
+          <OpenRegular style={{ marginLeft: 2, fontSize: 12 }} />
+        </FluentLink>
+      );
+    } else if (match[2]) {
       parts.push(<strong key={key++}>{match[2]}</strong>);
     } else if (match[3]) {
       parts.push(<em key={key++}>{match[3]}</em>);

--- a/packages/web/src/catalog/fluent-components/Toggle.tsx
+++ b/packages/web/src/catalog/fluent-components/Toggle.tsx
@@ -29,9 +29,7 @@ export const Toggle = createReactComponent(FlexibleToggleApi, ({props}) => {
   const classes = useStyles();
 
   const onChange = (_ev: React.ChangeEvent<HTMLInputElement>, data: { checked: boolean }) => {
-    if (props.setValue) {
-      props.setValue(data.checked);
-    }
+    props.setChecked(data.checked);
   };
 
   return (

--- a/packages/web/src/catalog/fluent-components/Toggle.tsx
+++ b/packages/web/src/catalog/fluent-components/Toggle.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {createReactComponent} from '../../vendor/a2ui/react/adapter';
+import {z} from 'zod';
+import {
+  DynamicStringSchema,
+  DynamicBooleanSchema,
+} from '../../vendor/a2ui/web_core/schema/common-types';
+import {Switch, Field, makeStyles, tokens} from '@fluentui/react-components';
+
+const FlexibleToggleApi = {
+  name: 'Toggle' as const,
+  schema: z.object({
+    accessibility: z.any().optional(),
+    weight: z.number().optional(),
+    label: DynamicStringSchema.optional(),
+    checked: DynamicBooleanSchema.optional(),
+    disabled: z.boolean().optional(),
+  }),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalS,
+  },
+});
+
+export const Toggle = createReactComponent(FlexibleToggleApi, ({props}) => {
+  const classes = useStyles();
+
+  const onChange = (_ev: React.ChangeEvent<HTMLInputElement>, data: { checked: boolean }) => {
+    if (props.setValue) {
+      props.setValue(data.checked);
+    }
+  };
+
+  return (
+    <div className={classes.root}>
+      <Field>
+        <Switch
+          checked={!!props.checked}
+          onChange={onChange}
+          label={props.label || undefined}
+          disabled={props.disabled === true}
+        />
+      </Field>
+    </div>
+  );
+});

--- a/packages/web/src/catalog/fluent-components/index.ts
+++ b/packages/web/src/catalog/fluent-components/index.ts
@@ -20,6 +20,11 @@ import {DateTimeInput} from './DateTimeInput';
 import {Table} from './Table';
 import {Alert} from './Alert';
 import {Link} from './Link';
+import {Badge} from './Badge';
+import {Accordion} from './Accordion';
+import {Toggle} from './Toggle';
+import {ComboBox} from './ComboBox';
+import {MultiSelect} from './MultiSelect';
 
 export {Text} from './Text';
 export {Image} from './Image';
@@ -42,8 +47,13 @@ export {DateTimeInput} from './DateTimeInput';
 export {Table} from './Table';
 export {Alert} from './Alert';
 export {Link} from './Link';
+export {Badge} from './Badge';
+export {Accordion} from './Accordion';
+export {Toggle} from './Toggle';
+export {ComboBox} from './ComboBox';
+export {MultiSelect} from './MultiSelect';
 
-/** Fluent UI v9 overrides for all 21 basic catalog components. */
+/** Fluent UI v9 overrides for all 26 basic catalog components. */
 export const fluentOverrides: ReactComponentImplementation[] = [
   Text,
   Image,
@@ -66,4 +76,9 @@ export const fluentOverrides: ReactComponentImplementation[] = [
   Table,
   Alert,
   Link,
+  Badge,
+  Accordion,
+  Toggle,
+  ComboBox,
+  MultiSelect,
 ];

--- a/packages/web/src/components/Chat/ChatMessage.tsx
+++ b/packages/web/src/components/Chat/ChatMessage.tsx
@@ -61,6 +61,8 @@ export function ChatMessage({ message, getSurface, isActive = true }: ChatMessag
 
 function formatText(text: string): string {
   return text
+    // URLs — strict http/https allowlist, reject javascript:/data:/malformed
+    .replace(/(https?:\/\/[^\s<>")\]]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>')
     // Bold
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     // Newlines to paragraphs

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1663,6 +1663,16 @@ function PlaygroundInner() {
           {/* Pinned input bar */}
           <div className={classes.createInputBar}>
             <div className={classes.createInputRow} style={{ maxWidth: '600px', width: '100%' }}>
+              {inspireLoading && <div className="hero-input-progress" />}
+              <button
+                className={`hero-inspire-btn${inspireLoading ? ' loading' : ''}`}
+                aria-label="Inspire me"
+                title="Inspire me"
+                onClick={handleInspire}
+                disabled={inspireLoading || createLoading}
+              >
+                <Sparkle24Regular />
+              </button>
               <input
                 className={classes.createInput}
                 value={createPrompt}
@@ -1671,7 +1681,7 @@ function PlaygroundInner() {
                 aria-label="Continue the conversation"
                 onKeyDown={(e) => { if (e.key === 'Enter') handleCreateSend(createPrompt); }}
                 disabled={createLoading}
-                style={{ paddingRight: '48px' }}
+                style={{ paddingRight: '48px', paddingLeft: '40px' }}
               />
               <button
                 className="hero-send-btn"


### PR DESCRIPTION
Closes #56
Closes #58
Closes #18

## Summary
Three approved DPs implemented in one PR — all frontend-only, no new dependencies.

## Changes

### #56 — Inspiration button in Create tab follow-up input (~10 lines)
- Added sparkle/inspire button to pinned input bar (reuses existing `handleInspire` handler)
- Added loading progress indicator during SSE streaming
- Adjusted input padding for sparkle button placement

### #58 — Clickable URLs in chat messages
- **ChatMessage.tsx**: URL regex (strict `https?://` allowlist) runs before bold in `formatText()`. DOMPurify sanitization preserved — no `javascript:`, `data:`, or malformed URLs can pass through.
- **Text.tsx**: Extended `parseInlineMarkdown()` to render URLs as `<FluentLink>` with `OpenRegular` icon. React JSX rendering path (no HTML injection). All links: `target=_blank` + `rel=noopener noreferrer`.

### #18 — Badge, Accordion, Toggle, ComboBox, MultiSelect
- **Badge**: 3 variants (badge/counter/presence), 8 colors, 4 appearances
- **Accordion**: `ChildList` pattern for nested component rendering (same as Row/Column)
- **Toggle**: `Switch` primitive with `DynamicBooleanSchema` two-way binding
- **ComboBox**: Searchable dropdown with freeform (`allowCustom`) — freeform values treated as untrusted, React-only rendering
- **MultiSelect**: Multi-value `Combobox` with `selectedOptions` binding
- All follow: Zod schema → `createReactComponent` → Fluent primitive → `makeStyles` + `tokens`
- Registered in `fluent-components/index.ts`, core catalog JSON schema, and TypeScript types

## Security (Zapp's conditions addressed)
- **#18**: All freeform input (ComboBox `allowCustom`) rendered via React JSX only — zero `dangerouslySetInnerHTML` ✓
- **#58**: Strict `https?://` regex blocks `javascript:`, `data:`, `vbscript:` URIs. DOMPurify preserved in ChatMessage HTML path. `rel=noopener noreferrer` on all links ✓
- **#56**: No new security surface — pure UI reuse of existing handler ✓

## Testing
- Lint: ✅ clean
- TypeScript: ✅ zero errors
- Vitest: ✅ 518/518 tests pass (same as main)
- Vite build: ⚠️ pre-existing failure (stale .js files in repo) — not caused by this PR