### PR TITLE
fix: remove list_artifacts/get_artifact from default LLM tool set

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -655,3 +655,12 @@ Addressed Copilot review on PR #78 (data→context terminology fix). PR merged s
 - **Tests:** 15 new tests (43 total in skill-resolver.test.ts). Covers typed skills, phase filtering, priority ordering, skill+phasePrompt coexistence, resolveSkillsFromList, resolveSkillsAsync, and all 5 IaC skills including Zapp requirement assertions.
 - **PR:** #119 (draft) — squad/21-33-knowledge-skills branch.
 - **Key files:** `packages/core/src/engine/types.ts`, `packages/core/src/engine/skill-resolver.ts`, `packages/core/src/kits/types.ts`, `packages/core/src/kits/azure-kit.ts`, `packages/core/src/__tests__/skill-resolver.test.ts`
+
+### 2026-07-27: LLM Endpoint Files Request Regression (#117, PR #121)
+
+- **Issue:** #117 — LLM endpoints firing a spurious "files request" alongside every LLM call
+- **Root cause:** PR #116 added `list_artifacts` and `get_artifact` to `defaultRegistry.registerAll()` in `tools/index.ts`. Since `converse.ts` sends all registered tools to the LLM via `defaultRegistry.toOpenAIFormat()`, the LLM was calling `list_artifacts` on every conversation turn.
+- **Fix:** Removed `list_artifacts` and `get_artifact` from the default registry bootstrap. They remain exported as named exports for programmatic use but are no longer sent to the LLM as callable tools. Tool count reduced from 11 to 9.
+- **Key file:** `packages/core/src/tools/index.ts` (lines 28-53)
+- **Lesson:** Be cautious about adding tools to `defaultRegistry` — every tool there gets sent to the LLM on every converse call. Artifact management tools should be registered on-demand or phase-gated, not globally.
+- **Tests:** All 533 tests pass, build clean.

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -25,7 +25,12 @@ export { getArtifact } from "./get-artifact.js";
 export { validatePath, validateRef } from "./github-input-validation.js";
 export type { ValidationResult } from "./github-input-validation.js";
 
-// Bootstrap the default registry with all built-in tools
+// Bootstrap the default registry with all built-in tools.
+// NOTE: list_artifacts and get_artifact are intentionally excluded from the
+// default set sent to the LLM. Including them caused the LLM to call
+// list_artifacts on every turn ("files request" regression — #117). These
+// tools are still exported for programmatic use and can be registered
+// on-demand when artifact enumeration is needed.
 import { defaultRegistry } from "./registry.js";
 import { azureResourceList } from "./azure-resource-list.js";
 import { azureResourceGet } from "./azure-resource-get.js";
@@ -36,8 +41,6 @@ import { githubApiGet } from "./github-api-get.js";
 import { fetchWebpage } from "./fetch-webpage.js";
 import { generateKubernetesManifest } from "./generate-kubernetes-manifest.js";
 import { estimateCost } from "./estimate-cost.js";
-import { listArtifacts } from "./list-artifacts.js";
-import { getArtifact } from "./get-artifact.js";
 
 defaultRegistry.registerAll([
   azureResourceList,
@@ -49,6 +52,4 @@ defaultRegistry.registerAll([
   fetchWebpage,
   generateKubernetesManifest,
   estimateCost,
-  listArtifacts,
-  getArtifact,
 ]);


### PR DESCRIPTION
## Summary

Fixes the spurious "files request" fired on every LLM endpoint call.

**Root cause:** PR #116 added `list_artifacts` and `get_artifact` to `defaultRegistry`. Since `converse.ts` sends all registered tools to the LLM via `defaultRegistry.toOpenAIFormat()`, the LLM was calling `list_artifacts` on every conversation turn — creating the extra "files request" described in the issue.

**Fix:** Remove `list_artifacts` and `get_artifact` from the default registry bootstrap in `tools/index.ts`. These tools remain exported for programmatic use but are no longer included in the tool definitions sent to the LLM. The artifact store still works — `generate_kubernetes_manifest` writes artifacts directly via `context.artifactStore.put()`.

**Verified:** All 533 tests pass. Tool count reduced from 11 → 9 in `toOpenAIFormat()`.

Working as Bender (Backend Dev)

Closes #117