### PR TITLE
feat: IndexedDB virtual filesystem with file tree + Monaco editor

### DIFF
--- a/.squad/decisions/inbox/fry-indexeddb-vfs-architecture.md
+++ b/.squad/decisions/inbox/fry-indexeddb-vfs-architecture.md
@@ -1,0 +1,31 @@
+# Decision: IndexedDB VFS Architecture (Dual Filesystem + Sync Bridge)
+
+**Author:** Fry (Frontend Dev)
+**Date:** 2026-04-12
+**Status:** Implemented
+**Issue:** #39
+
+## Context
+
+The app has two virtual filesystems with different lifecycle concerns:
+1. **VirtualFileSystem** (in-memory) — tracks streaming state ("generating" vs "complete"), used for real-time file generation feedback during conversation.
+2. **VirtualFS** (IndexedDB) — persistent storage that survives page reloads.
+
+## Decision
+
+Keep both filesystems. Add a sync bridge in `App.tsx` that auto-persists "complete" files from the in-memory FS to IndexedDB. The UI shows both:
+- In-memory `FileEditor` for streaming feedback (generating state)
+- IndexedDB `FileTreePanel` for persistent file browsing with Monaco
+
+## Rationale
+
+- Merging into one system would complicate the streaming pipeline (can't await IndexedDB during synchronous useSyncExternalStore updates).
+- The sync bridge is a clean one-way flow: in-memory → IndexedDB on completion.
+- Session clear/new wipes both stores to prevent stale data.
+
+## Files Affected
+
+- `packages/web/src/services/virtual-fs.ts` — VFSFile records, buildFileTree, clear()
+- `packages/web/src/contexts/VirtualFSContext.tsx` — tree + fileRecords exposure
+- `packages/web/src/components/FileTreePanel.tsx` — Fluent UI panel with Monaco
+- `packages/web/src/App.tsx` — sync bridge + dual panel rendering

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -56,15 +56,22 @@ export function App() {
   const fs = useMemo(() => new VirtualFileSystem(), []);
 
   // IndexedDB-backed persistent filesystem (provided via context)
-  const { fs: vfs } = useVirtualFS();
+  const { fs: vfs, files: vfsFiles } = useVirtualFS();
 
-  // Sync in-memory VFS → IndexedDB when files complete
+  // Sync in-memory VFS → IndexedDB when files complete (with deduplication)
+  const lastPersistedRef = useRef<Map<string, string>>(new Map());
   useEffect(() => {
     const unsub = fs.subscribe(() => {
       const snapshot = fs.getSnapshot();
       for (const file of snapshot) {
         if (file.status === 'complete') {
-          void vfs.writeFile(file.path, file.content, file.language);
+          const prev = lastPersistedRef.current.get(file.path);
+          if (prev !== file.content) {
+            lastPersistedRef.current.set(file.path, file.content);
+            vfs.writeFile(file.path, file.content, file.language).catch((err) => {
+              console.error(`[VFS sync] failed to persist ${file.path}:`, err);
+            });
+          }
         }
       }
     });
@@ -285,7 +292,6 @@ export function App() {
   const isStreaming = mockEnabled ? mockStreaming.isStreaming : streaming.isStreaming;
   const currentStreamText = mockEnabled ? mockStreaming.streamText : streaming.streamText;
   const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot);
-  const { files: vfsFiles } = useVirtualFS();
   const hasFiles = fsFiles.length > 0 || vfsFiles.length > 0;
 
   // Playground mode — standalone A2UI test harness

--- a/packages/web/src/components/FileTreePanel.tsx
+++ b/packages/web/src/components/FileTreePanel.tsx
@@ -6,7 +6,7 @@
  * file, download-all ZIP, and delete actions.
  */
 
-import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Body1Strong,
   Button,
@@ -33,6 +33,24 @@ import type { FileTreeNode, VFSFile } from '../services/virtual-fs';
 import { ensureMonacoLocal } from '../catalog/components/monaco-local-setup';
 import { sanitizeHtml } from '../utils/sanitize';
 import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript';
+import typescript from 'highlight.js/lib/languages/typescript';
+import json from 'highlight.js/lib/languages/json';
+import xml from 'highlight.js/lib/languages/xml';
+import css from 'highlight.js/lib/languages/css';
+import markdown from 'highlight.js/lib/languages/markdown';
+import yaml from 'highlight.js/lib/languages/yaml';
+import bash from 'highlight.js/lib/languages/bash';
+
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('html', xml);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('bash', bash);
 
 const MonacoEditor = lazy(() =>
   import('@monaco-editor/react').then((mod) => ({ default: mod.default }))
@@ -226,6 +244,10 @@ function TreeNodeItem({
         onClick={handleClick}
         title={node.path}
         type="button"
+        role="treeitem"
+        aria-expanded={node.isDirectory ? expanded : undefined}
+        aria-level={depth + 1}
+        aria-selected={isSelected}
       >
         {ChevronIcon && (
           <span className={classes.treeIcon}>
@@ -238,15 +260,19 @@ function TreeNodeItem({
         </span>
         <span className={classes.treeName}>{node.name}</span>
       </button>
-      {node.isDirectory && expanded && node.children?.map((child) => (
-        <TreeNodeItem
-          key={child.path}
-          node={child}
-          depth={depth + 1}
-          selectedPath={selectedPath}
-          onSelectFile={onSelectFile}
-        />
-      ))}
+      {node.isDirectory && expanded && (
+        <div role="group">
+          {node.children?.map((child) => (
+            <TreeNodeItem
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              selectedPath={selectedPath}
+              onSelectFile={onSelectFile}
+            />
+          ))}
+        </div>
+      )}
     </>
   );
 }
@@ -282,8 +308,11 @@ export function FileTreePanel({ onOpenFile }: FileTreePanelProps) {
   // Monaco setup
   const [monacoReady, setMonacoReady] = useState(false);
   useEffect(() => {
-    ensureMonacoLocal();
-    setMonacoReady(true);
+    let disposed = false;
+    Promise.resolve(ensureMonacoLocal())
+      .then(() => { if (!disposed) setMonacoReady(true); })
+      .catch(() => { if (!disposed) setMonacoReady(false); });
+    return () => { disposed = true; };
   }, []);
 
   const handleSelectFile = useCallback(
@@ -313,12 +342,21 @@ export function FileTreePanel({ onOpenFile }: FileTreePanelProps) {
     }
   }, [fs, files, selectedPath]);
 
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Cleanup copy timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
+
   const handleCopy = useCallback(async () => {
     if (!selectedFile) return;
     try {
       await navigator.clipboard.writeText(selectedFile.content);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       // Fallback for non-secure contexts
       const ta = document.createElement('textarea');
@@ -328,7 +366,7 @@ export function FileTreePanel({ onOpenFile }: FileTreePanelProps) {
       document.execCommand('copy');
       document.body.removeChild(ta);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     }
   }, [selectedFile]);
 

--- a/packages/web/src/contexts/VirtualFSContext.tsx
+++ b/packages/web/src/contexts/VirtualFSContext.tsx
@@ -50,9 +50,14 @@ export function VirtualFSProvider({ children, store: externalStore }: VirtualFSP
   const mountedRef = useRef(true);
 
   const refresh = useCallback(() => {
-    fs.readAll().then((records) => {
-      if (mountedRef.current) setFileRecords(records);
-    });
+    fs.readAll()
+      .then((records) => {
+        if (mountedRef.current) setFileRecords(records);
+      })
+      .catch((err) => {
+        console.error('[VirtualFS] readAll failed:', err);
+        if (mountedRef.current) setFileRecords([]);
+      });
   }, [fs]);
 
   useEffect(() => {

--- a/packages/web/src/services/virtual-fs.ts
+++ b/packages/web/src/services/virtual-fs.ts
@@ -311,14 +311,23 @@ export class VirtualFS {
     this.dbPromise = openIDB();
   }
 
+  private normalizePath(raw: string): string {
+    return raw
+      .replace(/\\/g, '/')
+      .replace(/^\/+/, '')
+      .replace(/\/+/g, '/')
+      .replace(/\/+$/, '');
+  }
+
   async writeFile(path: string, content: string, language?: string): Promise<void> {
+    const normalized = this.normalizePath(path);
     const db = await this.dbPromise;
     const now = Date.now();
-    const existing = await this.getFile(path).catch(() => null);
+    const existing = await this.getFile(normalized).catch(() => null);
     const record: VFSFile = {
-      path,
+      path: normalized,
       content,
-      language: language ?? detectLang(path),
+      language: language ?? detectLang(normalized),
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     };
@@ -344,14 +353,20 @@ export class VirtualFS {
       req.onsuccess = () => {
         if (req.result) {
           const raw = req.result as Record<string, unknown>;
-          // Migrate v1 records (path+content only) to full VFSFile shape
-          resolve({
+          const needsMigration = !raw.language || !raw.createdAt || !raw.updatedAt;
+          const migrated: VFSFile = {
             path: raw.path as string,
             content: raw.content as string,
             language: (raw.language as string) ?? detectLang(raw.path as string),
-            createdAt: (raw.createdAt as number) ?? Date.now(),
-            updatedAt: (raw.updatedAt as number) ?? Date.now(),
-          });
+            createdAt: (raw.createdAt as number) ?? 0,
+            updatedAt: (raw.updatedAt as number) ?? 0,
+          };
+          // Persist migrated record so v1 files get stable metadata
+          if (needsMigration) {
+            const writeTx = db.transaction(IDB_STORE, 'readwrite');
+            writeTx.objectStore(IDB_STORE).put(migrated);
+          }
+          resolve(migrated);
         } else {
           reject(new Error(`File not found: ${path}`));
         }
@@ -384,8 +399,8 @@ export class VirtualFS {
           path: raw.path as string,
           content: raw.content as string,
           language: (raw.language as string) ?? detectLang(raw.path as string),
-          createdAt: (raw.createdAt as number) ?? Date.now(),
-          updatedAt: (raw.updatedAt as number) ?? Date.now(),
+          createdAt: (raw.createdAt as number) ?? 0,
+          updatedAt: (raw.updatedAt as number) ?? 0,
         }));
         resolve(records.sort((a, b) => a.path.localeCompare(b.path)));
       };


### PR DESCRIPTION
Closes #39

Working as Fry (Frontend Dev)

## Summary

IndexedDB-backed virtual filesystem with a Fluent UI file browser panel and Monaco editor integration. Files generated during conversation are auto-persisted to IndexedDB and survive page reloads.

## Changes

### IndexedDB Storage Layer (`packages/web/src/services/virtual-fs.ts`)
- Enhanced `VirtualFS` class with rich `VFSFile` records: `path`, `content`, `language`, `createdAt`, `updatedAt`
- IDB schema upgraded to v2 with backward-compatible v1 record migration
- Added `getFile()`, `readAll()`, `clear()` methods
- Added `buildFileTree()` utility for hierarchical `FileTreeNode[]` from flat files
- Language detection via extension + filename maps

### File Tree UI (`packages/web/src/components/FileTreePanel.tsx`)
- Full Fluent UI rewrite using `makeStyles` + tokens (no hardcoded colors)
- Hierarchical collapsible tree with Fluent icons (`FolderRegular`, `DocumentRegular`, chevrons)
- Monaco editor integration (lazy-loaded via `React.lazy` + `Suspense`)
- Toolbar actions: copy to clipboard, download single file, download all as ZIP, delete file
- `hljs` fallback with `sanitizeHtml()` for code preview when Monaco hasn't loaded

### Context Enhancement (`packages/web/src/contexts/VirtualFSContext.tsx`)
- Exposes `fileRecords: VFSFile[]` (rich metadata) alongside flat `files: string[]`
- Exposes `tree: FileTreeNode[]` (hierarchical, auto-built from `fileRecords`)

### App Integration (`packages/web/src/App.tsx`)
- Sync bridge: in-memory `VirtualFileSystem` → IndexedDB `VirtualFS` on file completion
- Session clear/new/start wipes IndexedDB via `VirtualFS.clear()`
- `hasFiles` flag checks both in-memory and IndexedDB stores
- `FileTreePanel` rendered alongside `FileEditor` in the file panel slot

## Testing
- 580/580 vitest tests pass
- TypeScript: zero type errors (pre-existing TS5101 deprecation warning only)
- Vite build: succeeds (chunk size warnings are pre-existing)