### PR TITLE
fix: prevent 'Failed to fetch' on expired SWA auth sessions

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -98,6 +98,14 @@
 - **A2UI Catalog:** All 17 components documented with JSON examples and property tables from `kickstart-catalog.json`. Standard (6): Text, Button, TextField, Row, Column, Card. Kickstart Custom (7): ConversationPhase, CodeBlock, ResourcePicker, DeploymentProgress, ArchitectureDiagram, CostEstimate, HandoffCard. GitHub (4): RepoPicker, WorkflowStatus, CodespaceLink, AppOverview. Includes step-by-step guide for adding new components.
 - **Prompt Architecture:** Three-layer architecture (Layer 1 Azure Skills future, Layer 2 system prompt, Layer 3 phase prompts). All 6 phase prompt summaries with template variables and exit conditions. Full DS001–DS013 safeguard table. `buildSystemPrompt()` flow and `interpolate()` mechanics documented.
 - **Deployment:** Bicep template walkthrough, both GitHub Actions workflows (deploy-swa.yml and deploy-infra.yml), OIDC auth for infra, Entra app registration setup, all secrets/env vars, local dev instructions with SWA CLI.
+
+### 2026-04-13: SWA Auth Redirect CORS Fix (#130)
+
+- **Root cause:** When SWA auth cookies expire, API `fetch()` calls receive a 302 redirect to Azure AD's login page. The browser follows this cross-origin redirect silently, and Azure AD doesn't return CORS headers, so `fetch()` throws `TypeError: Failed to fetch` — an opaque error.
+- **Fix pattern:** `apiFetch()` wrapper in `api-client.ts` sets `redirect: 'manual'` on all authenticated API calls, preventing the browser from following cross-origin redirects. Detects opaque redirect responses and throws `SessionExpiredError` with a clear message.
+- **SSE error gap:** The `StreamEvent` interface was missing an `error` field, causing server-side streaming errors to be silently swallowed. Added `error` field and early-return handling in `useStreaming.ts`.
+- **Key files:** `packages/web/src/services/api-client.ts` (apiFetch, SessionExpiredError), `packages/web/src/hooks/useStreaming.ts`, `packages/web/src/types.ts`
+- **Lesson:** Any SWA app with `responseOverrides.401.redirect` will cause CORS failures for `fetch()` API calls when auth expires. Always use `redirect: 'manual'` for authenticated API endpoints.
 - **Cross-referencing:** All 5 docs link to each other where relevant.
 - **Key lesson:** The task description said 7 standard components including "Tabs" but the actual catalog has 6 (no Tabs). Always document from source code, not specs.
 

--- a/packages/web/src/components/Landing.tsx
+++ b/packages/web/src/components/Landing.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Sparkle24Regular } from '@fluentui/react-icons';
 import type { Session } from '../types';
+import { apiFetch } from '../services/api-client';
 
 const INSPIRATIONS = [
   "Movie night pick that settles disputes",
@@ -74,7 +75,7 @@ export function Landing({ onStartChat, recentSessions, onResumeSession, onDelete
     setInspireLoading(true);
     setInputValue(''); // Clear input before streaming
     try {
-      const res = await fetch('/api/inspirations?stream=true');
+      const res = await apiFetch('/api/inspirations?stream=true');
       if (!res.ok) throw new Error('API error');
       
       const reader = res.body?.getReader();

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -68,6 +68,8 @@ export function useStreaming() {
             const event: StreamEvent = JSON.parse(data);
 
             if (event.error) {
+              await reader.cancel();
+              controller.abort();
               callbacks.onError(event.error);
               return;
             }

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import type { StreamEvent, A2uiMsg } from '../types';
+import { apiFetch, SessionExpiredError } from '../services/api-client';
 
 interface StreamCallbacks {
   onDelta: (text: string) => void;
@@ -30,7 +31,7 @@ export function useStreaming() {
     let lastSessionId: string | undefined;
 
     try {
-      const res = await fetch('/api/converse', {
+      const res = await apiFetch('/api/converse', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -66,6 +67,11 @@ export function useStreaming() {
           try {
             const event: StreamEvent = JSON.parse(data);
 
+            if (event.error) {
+              callbacks.onError(event.error);
+              return;
+            }
+
             if (event.delta) {
               accumulated += event.delta;
               setStreamText(accumulated);
@@ -99,9 +105,13 @@ export function useStreaming() {
 
       callbacks.onComplete(accumulated, lastModel, lastSessionId);
     } catch (err: any) {
-      if (err.name !== 'AbortError') {
-        callbacks.onError(err.message || 'Connection failed');
+      if (err.name === 'AbortError') return;
+      if (err instanceof SessionExpiredError) {
+        callbacks.onError(err.message);
+        window.location.href = '/.auth/login/aad?post_login_redirect_uri=/';
+        return;
       }
+      callbacks.onError(err.message || 'Connection failed');
     } finally {
       setIsStreaming(false);
       abortRef.current = null;

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -40,6 +40,7 @@ import {
   type IconEntry,
 } from './playground-icons';
 import { getFluentIcon } from '../catalog/icons/fluent-icons';
+import { apiFetch } from '../services/api-client';
 
 // ── LLM → A2UI component normalizer ─────────────────────────────────────
 // The LLM may output components in two formats:
@@ -971,7 +972,7 @@ function PlaygroundInner() {
     inspireAbortRef.current = controller;
 
     try {
-      const res = await fetch('/api/inspirations/widgets?stream=true', { signal: controller.signal });
+      const res = await apiFetch('/api/inspirations/widgets?stream=true', { signal: controller.signal });
       if (!res.ok || !res.body) throw new Error('Streaming API error');
 
       const reader = res.body.getReader();
@@ -1000,7 +1001,7 @@ function PlaygroundInner() {
       if (err instanceof Error && err.name === 'AbortError') return;
       setCreatePrompt('');
       try {
-        const res = await fetch('/api/inspirations/widgets');
+        const res = await apiFetch('/api/inspirations/widgets');
         if (res.ok) {
           const ideas = await res.json();
           if (Array.isArray(ideas) && ideas.length > 0) {
@@ -1153,7 +1154,7 @@ function PlaygroundInner() {
     setCreateLoading(true);
 
     try {
-      const res = await fetch('/api/playground', {
+      const res = await apiFetch('/api/playground', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/packages/web/src/services/api-client.ts
+++ b/packages/web/src/services/api-client.ts
@@ -1,6 +1,30 @@
 // Typed API client for the Kickstart backend
 // Supports both streaming (SSE) and standard request modes
 
+export class SessionExpiredError extends Error {
+  constructor() {
+    super('Your session has expired. Please refresh the page to sign in again.');
+    this.name = 'SessionExpiredError';
+  }
+}
+
+/**
+ * Wrapper around fetch() for authenticated API endpoints.
+ *
+ * Uses `redirect: 'manual'` to prevent the browser from silently following
+ * SWA's 401→302 auth redirect to Azure AD. Without this, the cross-origin
+ * redirect fails with a CORS error that surfaces as "Failed to fetch".
+ */
+export async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(url, { ...init, redirect: 'manual' });
+
+  if (res.type === 'opaqueredirect' || (res.status >= 300 && res.status < 400)) {
+    throw new SessionExpiredError();
+  }
+
+  return res;
+}
+
 export interface ConversationRequest {
   sessionId?: string;
   message: string;
@@ -28,7 +52,7 @@ export async function healthCheck(): Promise<boolean> {
 }
 
 export async function converse(req: ConversationRequest): Promise<ConversationResponse> {
-  const res = await fetch('/api/converse', {
+  const res = await apiFetch('/api/converse', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(req),

--- a/packages/web/src/services/api-client.ts
+++ b/packages/web/src/services/api-client.ts
@@ -3,7 +3,7 @@
 
 export class SessionExpiredError extends Error {
   constructor() {
-    super('Your session has expired. Please refresh the page to sign in again.');
+    super('Your session has expired. Please sign in again. You may be redirected to the login page.');
     this.name = 'SessionExpiredError';
   }
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -59,6 +59,7 @@ export interface A2uiComponent {
 }
 
 export interface StreamEvent {
+  error?: string;
   delta?: string;
   content?: string;
   a2ui?: A2uiMsg[];


### PR DESCRIPTION
## Summary

Fixes the "Failed to fetch" error users see when their Azure Static Web Apps authentication session expires during a chat conversation.

## Root Cause

When a user's SWA auth cookie expires mid-session, API calls (e.g. `POST /api/converse`) receive a **401** from the SWA platform, which is converted to a **302 redirect** to Azure AD's login page via the `responseOverrides` in `staticwebapp.config.json`.

The browser's `fetch()` silently follows this redirect. Since the redirect crosses origins (from the SWA app to `login.microsoftonline.com`), and Azure AD doesn't return CORS headers, the browser throws `TypeError: Failed to fetch` — an opaque error with no useful context.

## Fix

1. **`apiFetch()` wrapper** — new function in `api-client.ts` that sets `redirect: 'manual'` on all authenticated API calls, preventing the browser from following cross-origin auth redirects
2. **`SessionExpiredError`** — typed error with a clear user-facing message instead of the cryptic "Failed to fetch"
3. **Auto-redirect** — on session expiry, shows the error then navigates to the SWA login endpoint
4. **SSE error handling** — added `error` field to `StreamEvent` so server-side streaming errors are properly surfaced (previously silently swallowed)
5. **Applied consistently** — all authenticated endpoints use `apiFetch`: converse, inspirations, playground

## Testing

- All 533 existing tests pass (`npx vitest run`)
- TypeScript compiles clean (only pre-existing deprecation warning for `baseUrl`)

Working as Bender (Backend Dev).

Closes #130