### PR TITLE
fix: footer shows correct version from package.json

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -26,10 +26,9 @@
 
   <!-- React app renders the full UI into #root -->
 
-  <!-- Build metadata — replaced by CI pipeline at deploy time -->
+  <!-- Build metadata — SHA replaced by CI pipeline at deploy time -->
   <script>
     window.__BUILD_SHA__ = 'dev';
-    window.__BUILD_VERSION__ = '0.1.0';
   </script>
 
   <!-- App entry point (ES modules) -->

--- a/packages/web/src/components/Landing.tsx
+++ b/packages/web/src/components/Landing.tsx
@@ -310,7 +310,7 @@ export function Landing({ onStartChat, recentSessions, onResumeSession, onDelete
           </div>
           <div className="landing-footer-meta">
             <span className="landing-footer-version">
-              Kickstart Preview v{(window as any).__BUILD_VERSION__ || '0.1.0'}
+              Kickstart Preview v{__BUILD_VERSION__}
               {(window as any).__BUILD_SHA__ && (window as any).__BUILD_SHA__ !== 'dev'
                 ? ` · ${(window as any).__BUILD_SHA__}`
                 : ' · dev'}

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1371,7 +1371,7 @@ function PlaygroundInner() {
 
           <div className={classes.sidebarFooter}>
             <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
-              v{(window as any).__BUILD_VERSION__ || '0.0.0'} · {(window as any).__BUILD_SHA__ || 'dev'}
+              v{__BUILD_VERSION__} · {(window as any).__BUILD_SHA__ || 'dev'}
             </Caption1>
           </div>
         </aside>

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __BUILD_VERSION__: string;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+import { readFileSync } from 'fs';
+
+const rootPkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'));
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __BUILD_VERSION__: JSON.stringify(rootPkg.version),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
The footer was hardcoded to `v0.1.0` in `index.html`. Now uses Vite `define()` to inject the version from root `package.json` at build time.

**Changes:**
- `vite.config.ts`: reads root `package.json` version, injects as `__BUILD_VERSION__`
- `index.html`: removed hardcoded `__BUILD_VERSION__` (kept `__BUILD_SHA__` for CI)
- `vite-env.d.ts`: declared `__BUILD_VERSION__` global
- `Landing.tsx` + `Playground.tsx`: use Vite constant instead of `window.__BUILD_VERSION__`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>