### PR TITLE
fix: debug panel model leak + render decisions (v0.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This project uses [@changesets/cli](https://github.com/changesets/changesets) for versioning.
 
+## 0.5.3
+
+### Bug Fixes
+
+- **Debug panel model leak** — Model name no longer shown as plain text outside the debug panel; only visible inside the expandable accordion
+- **Render decisions populated** — Fixed `renderDecisions` nesting bug (was inside `debug` object, now top-level in SSE data) and type mismatch (objects → formatted strings). Debug panel now shows actual A2UI pipeline decisions per message.
+
 ## 0.5.2
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kickstart",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "AI-guided onboarding for deploying apps to AKS",
   "license": "MIT",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Kickstart conversation engine, A2UI catalog, and code generators",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -29,7 +29,7 @@ import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
 import { safeErrorResponse, safeStreamError } from "../lib/error-response.js";
 import { chatCompletionWithAutoContinue, isTruncated } from "../lib/auto-continue.js";
 import { sanitizeToolOutput } from "../lib/sanitize-tool-output.js";
-import { isDebugMode, buildConverseDebugMeta } from "../lib/debug-mode.js";
+import { isDebugMode, buildConverseDebugMeta, formatRenderDecisions } from "../lib/debug-mode.js";
 import type { DebugMetadata } from "../lib/debug-mode.js";
 
 interface ConverseRequest {
@@ -190,12 +190,16 @@ app.http("converse", {
       // Attach debug metadata when requested
       if (debugMode) {
         const hadExplicitA2UI = processed.a2uiMessages.length > 0;
-        (responseBody as unknown as Record<string, unknown>).debug = buildConverseDebugMeta(
+        const debugMeta = buildConverseDebugMeta(
           getChatDeploymentName(),
           finalContent,
           processed.a2uiMessages.length,
           hadExplicitA2UI,
+          engineState.currentPhase,
         );
+        (responseBody as unknown as Record<string, unknown>).debug = debugMeta;
+        (responseBody as unknown as Record<string, unknown>).renderDecisions =
+          formatRenderDecisions(debugMeta.renderDecisions);
       }
 
       return { status: 200, jsonBody: responseBody };
@@ -279,12 +283,15 @@ function handleStreaming(
 
             if (debugMode) {
               const hadExplicitA2UI = processed.a2uiMessages.length > 0;
-              donePayload.debug = buildConverseDebugMeta(
+              const debugMeta = buildConverseDebugMeta(
                 getChatDeploymentName(),
                 fullContent,
                 processed.a2uiMessages.length,
                 hadExplicitA2UI,
+                engineState.currentPhase,
               );
+              donePayload.debug = debugMeta;
+              donePayload.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
             }
 
             controller.enqueue(

--- a/packages/web/api/src/functions/generate.ts
+++ b/packages/web/api/src/functions/generate.ts
@@ -22,7 +22,7 @@ import {
 } from "../lib/openai-client.js";
 import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
 import { safeErrorResponse, safeStreamError } from "../lib/error-response.js";
-import { isDebugMode, buildGenerateDebugMeta } from "../lib/debug-mode.js";
+import { isDebugMode, buildGenerateDebugMeta, formatRenderDecisions } from "../lib/debug-mode.js";
 import type { ChatMessage } from "../lib/openai-client.js";
 
 type GenerateType =
@@ -123,10 +123,12 @@ app.http("generate", {
       };
 
       if (debugMode) {
-        responseBody.debug = buildGenerateDebugMeta(
+        const debugMeta = buildGenerateDebugMeta(
           getCodexDeploymentName(),
           result.content,
         );
+        responseBody.debug = debugMeta;
+        responseBody.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
       }
 
       return { status: 200, jsonBody: responseBody };
@@ -168,10 +170,12 @@ function handleCodexStreaming(
         };
 
         if (debugMode) {
-          donePayload.debug = buildGenerateDebugMeta(
+          const debugMeta = buildGenerateDebugMeta(
             getCodexDeploymentName(),
             fullContent,
           );
+          donePayload.debug = debugMeta;
+          donePayload.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
         }
 
         controller.enqueue(

--- a/packages/web/api/src/lib/debug-mode.ts
+++ b/packages/web/api/src/lib/debug-mode.ts
@@ -41,29 +41,37 @@ export interface DebugMetadata {
  * @param rawContent - The raw LLM output before processing
  * @param a2uiCount  - Number of A2UI messages extracted
  * @param hadExplicitA2UI - Whether the LLM returned explicit A2UI JSON
+ * @param currentPhase - Current conversation phase name
  */
 export function buildConverseDebugMeta(
   model: string,
   rawContent: string,
   a2uiCount: number,
   hadExplicitA2UI: boolean,
+  currentPhase?: string,
 ): DebugMetadata {
   const renderDecisions: RenderDecision[] = [];
 
+  // Phase indicator is always injected
+  renderDecisions.push({
+    type: "phase_indicator",
+    detail: `ConversationPhase component added for phase: ${currentPhase ?? "unknown"}`,
+  });
+
   if (hadExplicitA2UI) {
     renderDecisions.push({
-      type: "a2ui-parsed",
-      detail: `LLM returned structured JSON envelope with ${a2uiCount} A2UI message(s)`,
+      type: "a2ui_parsed",
+      detail: `LLM returned structured JSON envelope with ${a2uiCount} A2UI component(s)`,
     });
   } else if (a2uiCount > 0) {
     renderDecisions.push({
-      type: "component-inferred",
+      type: "component_inferred",
       detail: `No explicit A2UI block; ${a2uiCount} component(s) inferred from response text`,
     });
   } else {
     renderDecisions.push({
-      type: "text-only",
-      detail: "Plain text response — no A2UI components generated",
+      type: "no_a2ui",
+      detail: "Text-only response, no A2UI components generated",
     });
   }
 
@@ -81,7 +89,17 @@ export function buildGenerateDebugMeta(
     model,
     rawContent,
     renderDecisions: [
-      { type: "codex-generation", detail: `Code generated via ${model}` },
+      { type: "codex_generation", detail: `Code generated via ${model}` },
+      { type: "no_a2ui", detail: "Code generation endpoint — no A2UI rendering" },
     ],
   };
+}
+
+/**
+ * Format render decisions as plain strings for SSE transmission.
+ * The frontend expects `renderDecisions: string[]` at the top level
+ * of SSE event data payloads.
+ */
+export function formatRenderDecisions(decisions: RenderDecision[]): string[] {
+  return decisions.map((d) => `[${d.type}] ${d.detail}`);
 }

--- a/packages/web/src/components/Chat/ChatMessage.tsx
+++ b/packages/web/src/components/Chat/ChatMessage.tsx
@@ -53,11 +53,6 @@ export function ChatMessage({ message, getSurface, isActive = true, debugEnabled
           );
         })}
 
-        {/* Model indicator */}
-        {message.model && (
-          <span className="model-indicator">{message.model}</span>
-        )}
-
         {/* Debug panel — shown only when debug mode is active */}
         {debugEnabled && <DebugPanel debugInfo={message.debugInfo} />}
       </div>


### PR DESCRIPTION
Fixes two bugs found during debug mode testing:

1. **Model name leak** — model name was rendered as plain text outside the debug panel. Now only shows inside the accordion.
2. **Render decisions empty** — `renderDecisions` was nested inside `debug` object instead of top-level in SSE data, and had a type mismatch. Now shows actual A2UI pipeline decisions.

Bumps version to v0.5.3.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>