### PR TITLE
feat(playground): debug mode + create-to-widget flow

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -53,8 +53,16 @@ Fry (Frontend Dev) has shipped the web surface for Kickstart. The stack evolved 
 - #58: Clickable URLs in chat messages ✅ (PR #118, 2026-04-10)
 - #18: Badge, Accordion, Toggle, ComboBox, MultiSelect components ✅ (PR #118, 2026-04-10)
 - Debug mode toggle & per-message debug panel (v0.5.2) ✅ (squad/debug-mode-ui, 2026-04-13)
+- Playground debug mode + create-to-widget flow ✅ (PR #137, squad/prototype-debug-create)
 
 ## Learnings
+
+### Playground Debug + Create-to-Widget — PR #137
+
+- **Debug mode in Playground:** Reused `useDebug` + `DebugPanel` from the main chat — the `DebugProvider` is already in `main.tsx` above both the Landing and Playground code paths, so `useDebug()` just works in Playground without any provider changes.
+- **apiFetch debugMode param:** The existing `apiFetch(url, init, debugMode)` third parameter is the cleanest pattern for injecting the `x-kickstart-debug` header — no need to manually construct Headers in each call site.
+- **addWidget return value:** Changed `addWidget` from `void` to returning the widget ID string. This is backward-compatible — existing callers that ignore the return value are unaffected. Needed for "create → navigate to widget" flow.
+- **Deferred navigation after state update:** Used `setTimeout(() => setActiveTab('widgets'), 0)` to defer tab switch after `addWidget`. Without deferral, React's state batching means the widget list hasn't re-rendered yet when we try to open the detail dialog, causing the widget lookup to fail.
 
 ### Debug Mode UI (v0.5.2) — 2026-04-13
 

--- a/packages/web/src/hooks/useWidgets.tsx
+++ b/packages/web/src/hooks/useWidgets.tsx
@@ -15,7 +15,7 @@ export interface Widget {
 
 interface WidgetsContextValue {
   widgets: Widget[];
-  addWidget: (name: string, messages: A2uiMsg[]) => void;
+  addWidget: (name: string, messages: A2uiMsg[]) => string;
   updateWidget: (id: string, messages: A2uiMsg[]) => void;
   deleteWidget: (id: string) => void;
   duplicateWidget: (id: string) => void;
@@ -41,14 +41,11 @@ export function WidgetsProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(widgets));
   }, [widgets]);
 
-  const addWidget = useCallback((name: string, messages: A2uiMsg[]) => {
-    const newWidget: Widget = {
-      id: `widget-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      name,
-      createdAt: Date.now(),
-      messages,
-    };
+  const addWidget = useCallback((name: string, messages: A2uiMsg[]): string => {
+    const id = `widget-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const newWidget: Widget = { id, name, createdAt: Date.now(), messages };
     setWidgets(prev => [...prev, newWidget]);
+    return id;
   }, []);
 
   const updateWidget = useCallback((id: string, messages: A2uiMsg[]) => {

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -22,9 +22,11 @@ import {
 } from '@fluentui/react-icons';
 import { useA2UI } from '../hooks/useA2UI';
 import { WidgetsProvider, useWidgets } from '../hooks/useWidgets';
+import { useDebug } from '../contexts/DebugContext';
 import { getDemoResponse, resetDemoState } from '../services/demo-scenarios';
 import { A2UISurfaceWrapper } from '../components/A2UI/A2UISurfaceWrapper';
-import type { A2uiMsg, ChatMessage } from '../types';
+import { DebugPanel } from '../components/Chat/DebugPanel';
+import type { A2uiMsg, ChatMessage, DebugMetadata } from '../types';
 import type { SurfaceModel } from '../vendor/a2ui/web_core/index';
 import type { ReactComponentImplementation } from '../vendor/a2ui/react/adapter';
 import {
@@ -920,6 +922,7 @@ const ICON_SECTIONS = [
 
 function PlaygroundInner() {
   const classes = useStyles();
+  const { debugEnabled, toggleDebug } = useDebug();
   const [activeTab, setActiveTab] = useState<'create' | 'gallery' | 'components' | 'icons' | 'widgets'>('gallery');
   const [filterQuery, setFilterQuery] = useState('');
   const [iconFilter, setIconFilter] = useState('');
@@ -972,7 +975,7 @@ function PlaygroundInner() {
     inspireAbortRef.current = controller;
 
     try {
-      const res = await apiFetch('/api/inspirations/widgets?stream=true', { signal: controller.signal });
+      const res = await apiFetch('/api/inspirations/widgets?stream=true', { signal: controller.signal }, debugEnabled);
       if (!res.ok || !res.body) throw new Error('Streaming API error');
 
       const reader = res.body.getReader();
@@ -1001,7 +1004,7 @@ function PlaygroundInner() {
       if (err instanceof Error && err.name === 'AbortError') return;
       setCreatePrompt('');
       try {
-        const res = await apiFetch('/api/inspirations/widgets');
+        const res = await apiFetch('/api/inspirations/widgets', undefined, debugEnabled);
         if (res.ok) {
           const ideas = await res.json();
           if (Array.isArray(ideas) && ideas.length > 0) {
@@ -1013,7 +1016,7 @@ function PlaygroundInner() {
     } finally {
       inspireAbortRef.current = null;
     }
-  }, []);
+  }, [debugEnabled]);
 
   // Filter scenarios
   const filteredGalleryScenarios = useMemo(() => {
@@ -1161,14 +1164,21 @@ function PlaygroundInner() {
           sessionId: createSessionIdRef.current,
           message: text,
         }),
-      });
+      }, debugEnabled);
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: `API error: ${res.status}` }));
         throw new Error(err.error || `API error: ${res.status}`);
       }
 
-      const data = await res.json() as { sessionId: string; message: string; a2ui?: object[] };
+      const data = await res.json() as {
+        sessionId: string;
+        message: string;
+        a2ui?: object[];
+        model?: string;
+        rawResponse?: string;
+        renderDecisions?: string[];
+      };
 
       if (data.sessionId && !createSessionIdRef.current) {
         createSessionIdRef.current = data.sessionId;
@@ -1176,15 +1186,32 @@ function PlaygroundInner() {
 
       // Process A2UI components through the surface system
       let surfaceIds: string[] | undefined;
+      let a2uiMessages: A2uiMsg[] | undefined;
       if (data.a2ui && data.a2ui.length > 0) {
         const surfaceId = `pg-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         const components = normalizePlaygroundComponents(data.a2ui as any[]);
-        const a2uiMessages: A2uiMsg[] = [
+        a2uiMessages = [
           { version: 'v0.9', createSurface: { surfaceId, catalogId: 'kickstart' } },
           { version: 'v0.9', updateComponents: { surfaceId, components } },
         ];
         surfaceIds = createA2ui.processMessages(a2uiMessages);
+
+        // Save the A2UI spec as a widget and navigate to Widgets
+        const widgetName = text.length > 40 ? text.slice(0, 40) + '…' : text;
+        const widgetId = addWidget(widgetName, a2uiMessages);
+        // Defer navigation so the widget list re-renders first
+        setTimeout(() => {
+          setActiveTab('widgets');
+          setSelectedWidget(widgetId);
+          setDetailTab('preview');
+          setDialogOpen(true);
+        }, 0);
       }
+
+      // Capture debug metadata when debug mode is on
+      const debugInfo: DebugMetadata | undefined = debugEnabled
+        ? { model: data.model, rawResponse: data.rawResponse, renderDecisions: data.renderDecisions }
+        : undefined;
 
       const assistantMsg: ChatMessage = {
         id: `create-${Date.now()}-assistant`,
@@ -1192,6 +1219,7 @@ function PlaygroundInner() {
         text: data.message,
         surfaceIds: surfaceIds && surfaceIds.length > 0 ? surfaceIds : undefined,
         timestamp: Date.now(),
+        debugInfo,
       };
       setCreateMessages(prev => [...prev, assistantMsg]);
     } catch (err: any) {
@@ -1205,7 +1233,7 @@ function PlaygroundInner() {
     } finally {
       setCreateLoading(false);
     }
-  }, [createLoading, createA2ui]);
+  }, [createLoading, createA2ui, debugEnabled, addWidget]);
 
   // Handle clear all
   const handleClearAll = useCallback(() => {
@@ -1370,6 +1398,21 @@ function PlaygroundInner() {
           )}
 
           <div className={classes.sidebarFooter}>
+            {debugEnabled && (
+              <button
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: '4px',
+                  background: 'none', border: 'none', cursor: 'pointer',
+                  fontSize: tokens.fontSizeBase200, color: tokens.colorPaletteYellowForeground1,
+                  padding: `${tokens.spacingVerticalXXS} 0`, marginBottom: tokens.spacingVerticalXS,
+                }}
+                aria-label="Debug mode active — click to disable"
+                title="Debug mode ON (Ctrl+Shift+D to toggle)"
+                onClick={toggleDebug}
+              >
+                🐛 Debug
+              </button>
+            )}
             <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
               v{__BUILD_VERSION__} · {(window as any).__BUILD_SHA__ || 'dev'}
             </Caption1>
@@ -1593,6 +1636,10 @@ function PlaygroundInner() {
                     </div>
                   ) : null;
                 })}
+                {/* Debug panel — shown only when debug mode is active on assistant messages */}
+                {debugEnabled && msg.role === 'assistant' && (
+                  <DebugPanel debugInfo={msg.debugInfo} />
+                )}
               </div>
             ))}
 


### PR DESCRIPTION
## Summary

Two features for the Prototype/Playground experience.

### Feature 1: Debug mode in Playground
- `useDebug` + `DebugPanel` integrated into the Playground page
- 🐛 Debug badge appears in sidebar footer when debug mode is active (Ctrl+Shift+D / `?debug=true`)
- `x-kickstart-debug: true` header sent on all Playground API requests when debug is on
- DebugPanel shown below assistant messages in Create chat, displaying model/raw response/render decisions

### Feature 2: Create → A2UI Widget spec
- When Create returns A2UI components, they are automatically saved as a widget
- After creation, navigates to Widgets tab and opens the detail dialog for the new widget
- `addWidget` now returns the widget ID to enable navigation

### Changes
- `packages/web/src/pages/Playground.tsx` — main feature implementation
- `packages/web/src/hooks/useWidgets.tsx` — `addWidget` returns widget ID

### Verification
- `npx tsc --noEmit` passes with zero errors

Working as Fry (Frontend Dev)
Closes no specific issue — requested by Ahmed Sabbour directly.