### PR TITLE
fix: bump version to 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kickstart",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "AI-guided onboarding for deploying apps to AKS",
   "license": "MIT",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Kickstart conversation engine, A2UI catalog, and code generators",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Squash merge of PR #137 didn't include the version bump commit. Fixes footer showing 0.5.3 instead of 0.5.4.