### PR TITLE
fix: add AuthCard adapter for Azure/GitHub login (#150)

### DIFF
--- a/packages/core/src/__tests__/integration-kit.test.ts
+++ b/packages/core/src/__tests__/integration-kit.test.ts
@@ -375,10 +375,10 @@ describe('azureKit', () => {
     }
   });
 
-  it('registers component types for azureLoginCard and azureResourcePicker', () => {
+  it('registers component types for AuthCard and azureResourcePicker', () => {
     expect(azureKit.components).toBeDefined();
     const types = azureKit.components!.map((c) => c.type);
-    expect(types).toContain('azureLoginCard');
+    expect(types).toContain('AuthCard');
     expect(types).toContain('azureResourcePicker');
   });
 
@@ -432,10 +432,10 @@ describe('githubKit', () => {
     }
   });
 
-  it('registers component types for githubLoginCard and githubRepoPicker', () => {
+  it('registers component types for AuthCard and githubRepoPicker', () => {
     expect(githubKit.components).toBeDefined();
     const types = githubKit.components!.map((c) => c.type);
-    expect(types).toContain('githubLoginCard');
+    expect(types).toContain('AuthCard');
     expect(types).toContain('githubRepoPicker');
   });
 

--- a/packages/core/src/kits/azure-kit.ts
+++ b/packages/core/src/kits/azure-kit.ts
@@ -14,7 +14,7 @@
  *   - PricingConnector     (Azure Retail Pricing API, no auth required)
  *
  * Component registrations (rendered by packages/web):
- *   - azureLoginCard       (MSAL sign-in card with subscription auto-select)
+ *   - AuthCard             (MSAL sign-in card, provider: "azure")
  *   - azureResourcePicker  (cascading subscription → RG → resource selector)
  *   - azureResourceForm    (dynamic ARM-driven form for resource creation)
  *   - azureAction          (write-with-confirm pattern for ARM operations)
@@ -519,14 +519,13 @@ Use estimate_cost tool for live pricing when available; these reference prices a
 
   components: [
     {
-      type: 'azureLoginCard',
+      type: 'AuthCard',
       description:
-        'MSAL sign-in card with automatic subscription discovery.\n' +
+        'Azure sign-in card (provider: "azure"). Uses MSAL with automatic subscription discovery.\n' +
         'Props:\n' +
-        '  - displayName (optional string): Display name shown on the avatar and user info. Defaults to "Azure User".\n' +
-        '  - showTokenInfo (optional boolean): Show authentication timestamp. Never exposes raw tokens.\n' +
-        '  - onSignIn (optional action): Callback fired after successful MSAL sign-in.\n' +
-        '  - onSignOut (optional action): Callback fired when the user signs out.',
+        '  - provider (required string): Must be "azure".\n' +
+        '  - title (optional string): Card heading. Defaults to "Azure".\n' +
+        '  - description (optional string): Subheading text.',
     },
     {
       type: 'azureResourcePicker',

--- a/packages/core/src/kits/github-kit.ts
+++ b/packages/core/src/kits/github-kit.ts
@@ -13,7 +13,7 @@
  *   - GitHubConnector    (GitHub REST API with OAuth Device Flow + PAT auth)
  *
  * Component registrations (rendered by packages/web):
- *   - githubLoginCard    (OAuth Device Flow sign-in card)
+ *   - AuthCard            (OAuth Device Flow sign-in card, provider: "github")
  *   - githubRepoPicker   (repository picker with search and client-side filtering)
  */
 
@@ -147,14 +147,13 @@ export const githubKit: IntegrationKit = {
 
   components: [
     {
-      type: 'githubLoginCard',
+      type: 'AuthCard',
       description:
-        'OAuth Device Flow sign-in card with token confirmation.\n' +
+        'GitHub sign-in card (provider: "github"). Uses OAuth Device Flow.\n' +
         'Props:\n' +
-        '  - username (optional string): GitHub username shown on the avatar and user info when signed in.\n' +
-        '  - avatarUrl (optional string): URL of the user\'s GitHub avatar image.\n' +
-        '  - onSignIn (optional action): Callback fired after successful GitHub OAuth sign-in.\n' +
-        '  - onSignOut (optional action): Callback fired when the user signs out.',
+        '  - provider (required string): Must be "github".\n' +
+        '  - title (optional string): Card heading. Defaults to "GitHub".\n' +
+        '  - description (optional string): Subheading text.',
     },
     {
       type: 'githubRepoPicker',

--- a/packages/web/src/catalog/components/AuthCard.tsx
+++ b/packages/web/src/catalog/components/AuthCard.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { createReactComponent } from '../../vendor/a2ui/react/adapter';
+import { z } from 'zod';
+import { DynamicStringSchema, type DynamicString } from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Body1Strong,
+  Button,
+  Card,
+  CardHeader,
+  Caption1,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { useAPIConnector } from '../../contexts/APIConnectorContext';
+
+const AuthCardApi = {
+  name: 'AuthCard',
+  schema: z.object({
+    provider: z.enum(['azure', 'github']),
+    title: DynamicStringSchema.optional(),
+    description: DynamicStringSchema.optional(),
+  }).strict(),
+};
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalS,
+    padding: tokens.spacingHorizontalL,
+    width: '100%',
+  },
+  statusDot: {
+    width: '8px',
+    height: '8px',
+    borderRadius: tokens.borderRadiusCircular,
+    backgroundColor: tokens.colorPaletteGreenBackground3,
+    display: 'inline-block',
+    marginRight: tokens.spacingHorizontalXS,
+  },
+  actions: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalS,
+    marginTop: tokens.spacingVerticalS,
+  },
+});
+
+function str(value: DynamicString | null | undefined): string | undefined {
+  if (value == null) return undefined;
+  return typeof value === 'string' ? value : '';
+}
+
+const CONNECTOR_NAME: Record<string, string> = {
+  azure: 'azure-arm',
+  github: 'github',
+};
+
+const DEFAULT_TITLE: Record<string, string> = {
+  azure: 'Azure',
+  github: 'GitHub',
+};
+
+const DEFAULT_DESCRIPTION: Record<string, string> = {
+  azure: 'Sign in to access your Azure resources',
+  github: 'Sign in to connect your repositories',
+};
+
+export const AuthCard = createReactComponent(AuthCardApi, ({ props }) => {
+  const classes = useStyles();
+  const connectorName = CONNECTOR_NAME[props.provider];
+  const connector = useAPIConnector(connectorName);
+
+  const [loading, setLoading] = useState(false);
+  const [authenticated, setAuthenticated] = useState(
+    () => connector?.isAuthenticated() ?? false,
+  );
+  const [error, setError] = useState<string | undefined>();
+
+  const title = str(props.title) || DEFAULT_TITLE[props.provider];
+  const description =
+    str(props.description) || DEFAULT_DESCRIPTION[props.provider];
+
+  useEffect(() => {
+    setAuthenticated(connector?.isAuthenticated() ?? false);
+  }, [connector]);
+
+  const handleSignIn = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      if (!connector) {
+        // Stub mode — simulate sign-in
+        setAuthenticated(true);
+        return;
+      }
+      await connector.authenticate();
+      setAuthenticated(connector.isAuthenticated());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign-in failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [connector]);
+
+  const handleSignOut = useCallback(() => {
+    setAuthenticated(false);
+    setError(undefined);
+  }, []);
+
+  if (authenticated) {
+    return (
+      <Card className={classes.root}>
+        <CardHeader
+          header={<Body1Strong>{title}</Body1Strong>}
+          description={
+            <Caption1>
+              <span className={classes.statusDot} />
+              Connected
+            </Caption1>
+          }
+        />
+        <div className={classes.actions}>
+          <Button appearance="subtle" size="small" onClick={handleSignOut}>
+            Sign out
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={classes.root}>
+      <CardHeader
+        header={<Body1Strong>{title}</Body1Strong>}
+        description={<Caption1>{description}</Caption1>}
+      />
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+      <div className={classes.actions}>
+        <Button
+          appearance="primary"
+          onClick={handleSignIn}
+          disabled={loading}
+          icon={loading ? <Spinner size="tiny" /> : undefined}
+        >
+          {loading ? 'Signing in\u2026' : `Sign in to ${title}`}
+        </Button>
+      </div>
+      {!connector && (
+        <Caption1
+          style={{
+            color: tokens.colorNeutralForeground3,
+            marginTop: tokens.spacingVerticalXS,
+          }}
+        >
+          Running in offline mode &mdash; sign-in will use stub data
+        </Caption1>
+      )}
+    </Card>
+  );
+});

--- a/packages/web/src/catalog/kickstart-catalog.ts
+++ b/packages/web/src/catalog/kickstart-catalog.ts
@@ -11,6 +11,7 @@ import { GitHubLoginCard } from './components/GitHubLoginCard';
 import { GitHubRepoPicker } from './components/GitHubRepoPicker';
 import { GitHubAction } from './components/GitHubAction';
 import { GitHubCommit } from './components/GitHubCommit';
+import { AuthCard } from './components/AuthCard';
 import { AzureLoginCard } from './components/AzureLoginCard';
 import { AzureResourcePicker } from './components/AzureResourcePicker';
 import { AzureResourceForm } from './components/AzureResourceForm';
@@ -30,6 +31,7 @@ const kickstartComponents: ReactComponentImplementation[] = [
   CodeBlock,
   ProgressSteps,
   Markdown,
+  AuthCard,
   GitHubLoginCard,
   GitHubRepoPicker,
   GitHubAction,


### PR DESCRIPTION
Closes #150

Working as Fry (Frontend Dev)

## Summary

The system prompt and core catalog instruct the LLM to emit `AuthCard` with a `provider` prop (`"azure"` | `"github"`), but no `AuthCard` renderer existed in the web catalog. The LLM emits `AuthCard` → catalog lookup fails → "Unknown component: AuthCard". The existing `AzureLoginCard`/`GitHubLoginCard` renderers work but are never found because the LLM never emits those names.

## Changes

- **New:** `packages/web/src/catalog/components/AuthCard.tsx` — adapter component that dispatches to Azure or GitHub auth flow based on `provider` prop, using the existing `APIConnector` infrastructure
- **Updated:** `kickstart-catalog.ts` — registers `AuthCard` in the component array
- **Updated:** `azure-kit.ts` — component type `'azureLoginCard'` → `'AuthCard'` (with `provider: "azure"`)
- **Updated:** `github-kit.ts` — component type `'githubLoginCard'` → `'AuthCard'` (with `provider: "github"`)
- **Updated:** `integration-kit.test.ts` — test expectations aligned to `'AuthCard'`

Existing `AzureLoginCard` and `GitHubLoginCard` remain registered for backward compatibility.

⚠️ Cross-package change — touches `packages/core/src/kits` (Bender's domain). Kit type changes are string constants only, zero auth logic modifications.

## Testing

- `npx tsc --noEmit` — zero errors (packages/web)
- `npx vitest run integration-kit.test.ts` — 65/65 tests pass
- Provider strict enum (`'azure' | 'github'`) per security review guidance