### PR TITLE
fix: Wave 2 quick fixes — Integration Kit visibility, carousel animation, debug panel (#168, #170, #175)

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -23,6 +23,9 @@ Backend engineer owning MCP server, API layer, and database design. Expertise in
 - v0.4.0 tool system: Function calling protocol, multi-round loops, streaming SSE events
 - v0.3.0 service layer: APIConnector auth abstraction, IntegrationKit packs, CORS proxies
 
+## Work Log
+- (2026-04-14 11:02) Wave 1: SWA continuous deploy + version footer → PR #177 opened. Auto-deploy from main, version shows SHA.
+
 ## Learnings
 - SWA deploy workflow (`deploy-swa.yml`) needs explicit `push → branches: [main]` trigger — tag-only triggers mean no continuous deployment from main.
 - `__BUILD_VERSION__` in `vite.config.ts` can embed git SHA via `execSync('git rev-parse --short HEAD')` — works both locally and in CI without relying on `GITHUB_SHA` env var.

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -47,3 +47,8 @@ Frontend engineer owning web surface and A2UI catalog components. Expertise in R
 **Key Notes:** #166 is a critical blocker preventing rich component rendering. All other work is independent. Fast-track approved for 5 CSS/config items (skip DP ceremony). Success = all P0 + P1 closed; P2 best-effort.
 
 ## Learnings
+- (2026-04-14) SSE parsing in `useStreaming.ts` must handle both `event:` type lines and `data:` lines. The backend sends A2UI via typed SSE events (`event: a2ui\ndata: {...}`) AND inside a JSON envelope in the accumulated chunk content. Both paths must route to `callbacks.onA2UI()`.
+- (2026-04-14) The accumulated stream content can be either plain text OR a JSON envelope `{message, a2ui, actions}`. After stream completion, always try parsing as JSON to extract structured data before passing to `onComplete`.
+
+## Work Log
+- (2026-04-14 11:02) Wave 1: Fixed #166 A2UI rendering blocker → PR #179 opened. SSE parser fixes in useStreaming.ts complete.

--- a/packages/web/src/catalog/components/SteppedCarousel.tsx
+++ b/packages/web/src/catalog/components/SteppedCarousel.tsx
@@ -68,6 +68,9 @@ const useStyles = makeStyles({
   body: {
     marginTop: tokens.spacingVerticalM,
     marginBottom: tokens.spacingVerticalM,
+    transitionProperty: 'opacity, transform',
+    transitionDuration: tokens.durationNormal,
+    transitionTimingFunction: tokens.curveEasyEase,
   },
   footer: {
     display: 'flex',

--- a/packages/web/src/components/Chat/DebugPanel.tsx
+++ b/packages/web/src/components/Chat/DebugPanel.tsx
@@ -129,9 +129,9 @@ export function DebugPanel({ debugInfo }: DebugPanelProps) {
           {/* Raw LLM Response */}
           <div className={styles.section}>
             <Text className={styles.sectionLabel}>Raw LLM Response</Text>
-            {debugInfo?.rawResponse ? (
+            {(debugInfo?.rawContent ?? debugInfo?.rawResponse) ? (
               <code className={codeBlockClass}>
-                {debugInfo.rawResponse}
+                {debugInfo?.rawContent ?? debugInfo?.rawResponse}
               </code>
             ) : (
               <Text className={styles.notAvailable} size={200}>Not available</Text>

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -129,15 +129,17 @@ export function useStreaming() {
         }
       }
 
-      // Extract A2UI from the accumulated JSON envelope (chunks build a full response)
+      // Preserve the raw accumulated content before envelope extraction
+      const rawContent = accumulated;
+
+      // Extract message/A2UI from the accumulated JSON envelope
       try {
         const envelope = JSON.parse(accumulated);
-        if (envelope?.a2ui && Array.isArray(envelope.a2ui) && envelope.a2ui.length > 0) {
+        if (typeof envelope?.message === 'string') {
+          accumulated = envelope.message;
+        }
+        if (Array.isArray(envelope?.a2ui) && envelope.a2ui.length > 0) {
           callbacks.onA2UI(envelope.a2ui);
-          // Use the text message from the envelope if present
-          if (typeof envelope.message === 'string') {
-            accumulated = envelope.message;
-          }
         }
       } catch { /* accumulated is plain text, not JSON — expected for non-envelope responses */ }
 
@@ -146,6 +148,7 @@ export function useStreaming() {
         ? {
             model: lastModel,
             rawResponse: accumulated,
+            rawContent: rawContent !== accumulated ? rawContent : undefined,
             renderDecisions: renderDecisions.length > 0 ? renderDecisions : undefined,
           }
         : undefined;

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -174,7 +174,7 @@ function normalizePlaygroundComponents(raw: any[]): any[] {
 }
 
 // Scenario grouping for tabs
-const GALLERY_GROUPS = ['Kickstart Scenarios', 'Data Binding', 'Events & Actions', 'Surface Lifecycle', 'Dynamic Patterns'];
+const GALLERY_GROUPS = ['Kickstart Scenarios', 'Data Binding', 'Events & Actions', 'Surface Lifecycle', 'Dynamic Patterns', 'Integration Kits'];
 const COMPONENT_GROUPS = ['Layout', 'Content', 'Inputs', 'Custom Controls'];
 
 const GALLERY_SCENARIOS = [...KICKSTART_SCENARIOS, ...CONTROL_SCENARIOS].filter(s => GALLERY_GROUPS.includes(s.group));

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -5,6 +5,8 @@ export interface DebugMetadata {
   model?: string;
   /** Raw LLM response text before rendering. */
   rawResponse?: string;
+  /** Full JSON envelope content before message extraction. */
+  rawContent?: string;
   /** Rendering engine decisions (component choices, catalog, degradation). */
   renderDecisions?: string[];
 }


### PR DESCRIPTION
## Wave 2 Quick Fixes

### Changes

1. **#170 — Integration Kits not visible in Playground sidebar**
   Added `'Integration Kits'` to the `GALLERY_GROUPS` array so Integration Kit scenarios appear in the sidebar.

2. **#168 — SteppedCarousel no panel transition animation**
   Added CSS transition for `opacity` and `transform` on step changes using Fluent UI `tokens.durationNormal` and `tokens.curveEasyEase`.

3. **#175 — Debug panel raw response shows plain text instead of full JSON envelope**
   Preserved the full JSON envelope as `rawContent` in `DebugMetadata` before extracting the message text. The debug panel now displays the complete `{"message":"...", "a2ui":[...], "actions":[]}` JSON when available.

### Validation
- `npx tsc --noEmit` — ✅ pass
- `npm run lint` — ✅ pass (0 errors, 1 pre-existing warning)

Closes #168, Closes #170, Closes #175

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)