### PR TITLE
fix: add A2UI message shape adapter for backend→frontend format (#166)

### DIFF
--- a/packages/web/src/hooks/useA2UI.ts
+++ b/packages/web/src/hooks/useA2UI.ts
@@ -5,6 +5,7 @@ import type { ReactComponentImplementation } from '../vendor/a2ui/react/adapter'
 import type { SurfaceModel } from '../vendor/a2ui/web_core/index';
 import type { A2uiClientAction } from '../vendor/a2ui/web_core/schema/client-to-server';
 import type { A2uiMsg } from '../types';
+import { adaptA2uiMessage } from '../utils/a2ui-adapter';
 import type { ActionHandler } from './useActionDispatch';
 
 export interface A2UIOptions {
@@ -71,13 +72,14 @@ export function useA2UI(options: A2UIOptions = {}): A2UIHandle {
   const processor = processorRef.current;
 
   const processMessages = useCallback((msgs: A2uiMsg[]): string[] => {
+    const adapted = msgs.map(adaptA2uiMessage);
     const surfaceIds: string[] = [];
-    for (const msg of msgs) {
+    for (const msg of adapted) {
       if (msg.createSurface) {
         surfaceIds.push(msg.createSurface.surfaceId);
       }
     }
-    processor.processMessages(msgs as any);
+    processor.processMessages(adapted as any);
     return surfaceIds;
   }, [processor]);
 

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import type { StreamEvent, A2uiMsg, DebugMetadata } from '../types';
 import { apiFetch, SessionExpiredError } from '../services/api-client';
+import { adaptA2uiMessage } from '../utils/a2ui-adapter';
 
 interface StreamCallbacks {
   onDelta: (text: string) => void;
@@ -77,7 +78,7 @@ export function useStreaming() {
           try {
             // Handle typed SSE events (e.g. `event: a2ui`)
             if (currentEventType === 'a2ui') {
-              const a2uiMsg: A2uiMsg = JSON.parse(data);
+              const a2uiMsg = adaptA2uiMessage(JSON.parse(data));
               callbacks.onA2UI([a2uiMsg]);
               currentEventType = '';
               continue;
@@ -139,7 +140,7 @@ export function useStreaming() {
           accumulated = envelope.message;
         }
         if (Array.isArray(envelope?.a2ui) && envelope.a2ui.length > 0) {
-          callbacks.onA2UI(envelope.a2ui);
+          callbacks.onA2UI(envelope.a2ui.map(adaptA2uiMessage));
         }
       } catch { /* accumulated is plain text, not JSON — expected for non-envelope responses */ }
 

--- a/packages/web/src/utils/a2ui-adapter.ts
+++ b/packages/web/src/utils/a2ui-adapter.ts
@@ -1,0 +1,36 @@
+import type { A2uiMsg } from '../types';
+
+/**
+ * Adapts a raw A2UI message from the backend (flat, with `type` discriminator)
+ * into the nested shape the frontend A2UI processor expects.
+ *
+ * Backend sends:  { type: "createSurface", surfaceId: "…", catalogId: "…" }
+ * Frontend needs: { version: "v0.9", createSurface: { surfaceId: "…", catalogId: "…" } }
+ *
+ * Messages already in the nested shape (i.e. they have `version`) pass through unchanged.
+ */
+export function adaptA2uiMessage(raw: any): A2uiMsg {
+  // Already in nested/frontend shape — pass through
+  if (raw?.version) {
+    return raw as A2uiMsg;
+  }
+
+  const msg: A2uiMsg = { version: 'v0.9' as const };
+
+  switch (raw?.type) {
+    case 'createSurface':
+      msg.createSurface = { surfaceId: raw.surfaceId, catalogId: raw.catalogId };
+      break;
+    case 'updateComponents':
+      msg.updateComponents = { surfaceId: raw.surfaceId, components: raw.components };
+      break;
+    case 'deleteSurface':
+      msg.deleteSurface = { surfaceId: raw.surfaceId };
+      break;
+    case 'updateDataModel':
+      msg.updateDataModel = { surfaceId: raw.surfaceId, path: raw.path, value: raw.value };
+      break;
+  }
+
+  return msg;
+}


### PR DESCRIPTION
## Summary

Closes #166

The backend sends A2UI messages in a **flat shape** with a `type` discriminator:
```json
{"type": "createSurface", "surfaceId": "msg-2", "catalogId": "kickstart"}
```

The frontend A2UI processor expects a **nested shape** with a `version` field:
```json
{"version": "v0.9", "createSurface": {"surfaceId": "msg-2", "catalogId": "kickstart"}}
```

This mismatch caused all A2UI messages to be silently dropped, preventing rich component rendering even after the SSE parser fix in dacd6df.

## Changes

- **New `adaptA2uiMessage()` utility** (`packages/web/src/utils/a2ui-adapter.ts`) — transforms flat backend format to nested frontend format; messages already in nested shape pass through unchanged
- **Applied in `useStreaming.ts`** at both parse points: typed SSE events (line ~80) and JSON envelope extraction (line ~142)
- **Applied in `useA2UI.ts`** `processMessages()` as a safety net — ensures any raw messages that slip through are still adapted

## Testing

- `npx tsc --noEmit` — passes ✅
- `npm run lint` — no new warnings ✅

Working as Fry (Frontend Dev)

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)