### PR TITLE
feat: dynamic A2UI component catalog in system prompt (#185)

### DIFF
--- a/packages/core/src/__tests__/component-catalog.test.ts
+++ b/packages/core/src/__tests__/component-catalog.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for dynamic A2UI component catalog injection (Issue #185).
+ *
+ * Verifies:
+ *   - Base catalog generates all 28 component entries
+ *   - Kit-contributed components appear in the generated section
+ *   - Kit entries override base entries of the same type (dedup)
+ *   - Component count updates dynamically
+ *   - buildSystemPrompt injects the catalog via the placeholder
+ *   - IntegrationKitRegistry.getComponentCatalogEntries() works
+ *   - Backward-compatible: no kit entries means base 28 components appear
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateComponentCatalogSection,
+  BASE_COMPONENT_CATALOG,
+} from "../prompts/component-catalog.js";
+import type { ComponentCatalogEntry } from "../prompts/component-catalog.js";
+import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import { Phase } from "../engine/types.js";
+import { IntegrationKitRegistry } from "../kits/registry.js";
+import { ToolRegistry } from "../tools/registry.js";
+import { APIConnectorRegistry } from "../connectors/registry.js";
+import type { IntegrationKit } from "../kits/types.js";
+
+// ---------------------------------------------------------------------------
+// generateComponentCatalogSection
+// ---------------------------------------------------------------------------
+
+describe("generateComponentCatalogSection", () => {
+  it("generates all 28 base components", () => {
+    const section = generateComponentCatalogSection();
+    expect(section).toContain("You have 28 components");
+  });
+
+  it("includes all four category headings", () => {
+    const section = generateComponentCatalogSection();
+    expect(section).toContain("### Layout Components");
+    expect(section).toContain("### Content Components");
+    expect(section).toContain("### Input Components");
+    expect(section).toContain("### Kickstart Domain Components");
+  });
+
+  it("includes specific component entries from each category", () => {
+    const section = generateComponentCatalogSection();
+    expect(section).toContain("- Row:");
+    expect(section).toContain("- Accordion:");
+    expect(section).toContain("- Text:");
+    expect(section).toContain("- Badge:");
+    expect(section).toContain("- Button:");
+    expect(section).toContain("- ChoicePicker:");
+    expect(section).toContain("- CostEstimate:");
+    expect(section).toContain("- DeploymentProgress:");
+  });
+
+  it("includes notes for components that have them", () => {
+    const section = generateComponentCatalogSection();
+    expect(section).toContain("variants: h1, h2, h3, body, caption, code");
+    expect(section).toContain("Variants: primary, secondary, outline, danger, ghost");
+    expect(section).toContain("Node types: compute, database, cache, network, storage, ai, messaging");
+  });
+
+  it("merges kit entries and updates component count", () => {
+    const kitEntries: ComponentCatalogEntry[] = [
+      {
+        type: "AzureResourcePicker",
+        category: "domain",
+        example: '{"id":"arp1","component":"AzureResourcePicker","resourceType":"Microsoft.Web/sites"}',
+        notes: "Picks Azure resources",
+      },
+    ];
+    const section = generateComponentCatalogSection(BASE_COMPONENT_CATALOG, kitEntries);
+    expect(section).toContain("You have 29 components");
+    expect(section).toContain("- AzureResourcePicker:");
+    expect(section).toContain("Picks Azure resources");
+  });
+
+  it("kit entry overrides base entry with same type", () => {
+    const kitEntries: ComponentCatalogEntry[] = [
+      {
+        type: "Text",
+        category: "content",
+        example: '{"id":"t1","component":"Text","text":"Custom","variant":"h1"}',
+        notes: "customized by kit",
+      },
+    ];
+    const section = generateComponentCatalogSection(BASE_COMPONENT_CATALOG, kitEntries);
+    expect(section).toContain("You have 28 components");
+    expect(section).toContain("customized by kit");
+  });
+
+  it("handles empty base catalog with only kit entries", () => {
+    const kitEntries: ComponentCatalogEntry[] = [
+      {
+        type: "CustomWidget",
+        category: "domain",
+        example: '{"id":"cw1","component":"CustomWidget","data":"test"}',
+      },
+    ];
+    const section = generateComponentCatalogSection([], kitEntries);
+    expect(section).toContain("You have 1 components");
+    expect(section).toContain("- CustomWidget:");
+  });
+
+  it("preserves JSON examples exactly as provided", () => {
+    const section = generateComponentCatalogSection();
+    expect(section).toContain('{"id":"div1","component":"Divider"}');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSystemPrompt -- dynamic catalog injection
+// ---------------------------------------------------------------------------
+
+describe("buildSystemPrompt with dynamic component catalog", () => {
+  it("includes the dynamically generated catalog in the prompt", () => {
+    const prompt = buildSystemPrompt({ phase: Phase.Discover });
+    expect(prompt).toContain("## 5. A2UI COMPONENT CATALOG");
+    expect(prompt).toContain("You have 28 components");
+    expect(prompt).toContain("### Layout Components");
+  });
+
+  it("does NOT contain the placeholder in output", () => {
+    const prompt = buildSystemPrompt({ phase: Phase.Discover });
+    expect(prompt).not.toContain("{{componentCatalog}}");
+  });
+
+  it("includes kit-contributed components when kitComponentEntries provided", () => {
+    const prompt = buildSystemPrompt({
+      phase: Phase.Discover,
+      kitComponentEntries: [
+        {
+          type: "GitHubRepoPicker",
+          category: "domain",
+          example: '{"id":"ghp1","component":"GitHubRepoPicker","owner":"user"}',
+        },
+      ],
+    });
+    expect(prompt).toContain("You have 29 components");
+    expect(prompt).toContain("- GitHubRepoPicker:");
+  });
+
+  it("backward-compatible: no kitComponentEntries means base 28 appear", () => {
+    const prompt = buildSystemPrompt({ phase: Phase.Design });
+    expect(prompt).toContain("You have 28 components");
+    expect(prompt).toContain("- Row:");
+    expect(prompt).toContain("- DeploymentProgress:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IntegrationKitRegistry.getComponentCatalogEntries()
+// ---------------------------------------------------------------------------
+
+describe("IntegrationKitRegistry.getComponentCatalogEntries", () => {
+  function makeIsolatedRegistry() {
+    const toolRegistry = new ToolRegistry();
+    const connectorRegistry = new APIConnectorRegistry();
+    return new IntegrationKitRegistry(toolRegistry, connectorRegistry);
+  }
+
+  it("returns empty array when no kits are registered", () => {
+    const registry = makeIsolatedRegistry();
+    expect(registry.getComponentCatalogEntries()).toEqual([]);
+  });
+
+  it("returns empty array when kit has no promptMeta", async () => {
+    const registry = makeIsolatedRegistry();
+    const kit: IntegrationKit = {
+      name: "test-kit",
+      description: "test",
+      tools: [],
+      connectors: [],
+      components: [
+        { type: "TestComp", description: "A test component" },
+      ],
+    };
+    await registry.register(kit);
+    expect(registry.getComponentCatalogEntries()).toEqual([]);
+  });
+
+  it("returns catalog entries from kit components with promptMeta", async () => {
+    const registry = makeIsolatedRegistry();
+    const kit: IntegrationKit = {
+      name: "azure-kit-test",
+      description: "test azure kit",
+      tools: [],
+      connectors: [],
+      components: [
+        {
+          type: "AzureLoginCard",
+          description: "Azure login component",
+          promptMeta: {
+            category: "domain",
+            example: '{"id":"alc1","component":"AzureLoginCard","tenant":"contoso.com"}',
+            notes: "Triggers Azure MSAL login flow",
+          },
+        },
+        {
+          type: "AzureResourceForm",
+          description: "Azure resource form",
+        },
+      ],
+    };
+    await registry.register(kit);
+    const entries = registry.getComponentCatalogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("AzureLoginCard");
+    expect(entries[0].category).toBe("domain");
+    expect(entries[0].notes).toBe("Triggers Azure MSAL login flow");
+  });
+
+  it("collects entries from multiple kits", async () => {
+    const registry = makeIsolatedRegistry();
+    const kit1: IntegrationKit = {
+      name: "kit-a",
+      description: "kit A",
+      tools: [],
+      connectors: [],
+      components: [
+        {
+          type: "CompA",
+          description: "Component A",
+          promptMeta: {
+            category: "input",
+            example: '{"id":"a1","component":"CompA"}',
+          },
+        },
+      ],
+    };
+    const kit2: IntegrationKit = {
+      name: "kit-b",
+      description: "kit B",
+      tools: [],
+      connectors: [],
+      components: [
+        {
+          type: "CompB",
+          description: "Component B",
+          promptMeta: {
+            category: "content",
+            example: '{"id":"b1","component":"CompB"}',
+          },
+        },
+      ],
+    };
+    await registry.register(kit1);
+    await registry.register(kit2);
+    const entries = registry.getComponentCatalogEntries();
+    expect(entries).toHaveLength(2);
+    const types = entries.map((e) => e.type);
+    expect(types).toContain("CompA");
+    expect(types).toContain("CompB");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BASE_COMPONENT_CATALOG integrity
+// ---------------------------------------------------------------------------
+
+describe("BASE_COMPONENT_CATALOG", () => {
+  it("has exactly 28 entries", () => {
+    expect(BASE_COMPONENT_CATALOG).toHaveLength(28);
+  });
+
+  it("has unique type names", () => {
+    const types = BASE_COMPONENT_CATALOG.map((e) => e.type);
+    expect(new Set(types).size).toBe(types.length);
+  });
+
+  it("every entry has valid JSON in its example", () => {
+    for (const entry of BASE_COMPONENT_CATALOG) {
+      const normalized = entry.example.replace(/\\\\/g, "\\");
+      expect(() => JSON.parse(normalized)).not.toThrow();
+    }
+  });
+
+  it("every example includes the matching component type", () => {
+    for (const entry of BASE_COMPONENT_CATALOG) {
+      const normalized = entry.example.replace(/\\\\/g, "\\");
+      const parsed = JSON.parse(normalized);
+      expect(parsed.component).toBe(entry.type);
+    }
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,11 +95,15 @@ export {
   DEPLOYMENT_SAFEGUARDS,
   buildSystemPrompt,
   sanitizePromptValue,
+  BASE_COMPONENT_CATALOG,
+  generateComponentCatalogSection,
 } from "./prompts/index.js";
 export type {
   DeploymentSafeguard,
   SafeguardSeverity,
   SystemPromptContext,
+  ComponentCatalogEntry,
+  ComponentCategory,
 } from "./prompts/index.js";
 
 // Tool registry

--- a/packages/core/src/kits/registry.ts
+++ b/packages/core/src/kits/registry.ts
@@ -27,6 +27,7 @@
  */
 
 import type { IntegrationKit } from './types.js';
+import type { ComponentCatalogEntry } from '../prompts/component-catalog.js';
 import { ToolRegistry, defaultRegistry } from '../tools/registry.js';
 import { APIConnectorRegistry, defaultConnectorRegistry } from '../connectors/registry.js';
 
@@ -281,6 +282,28 @@ export class IntegrationKitRegistry {
    */
   getConnectorOwner(connectorName: string): string | undefined {
     return this.connectorOwners.get(connectorName);
+  }
+
+  /**
+   * Collect component catalog entries from all registered kits that provide
+   * `promptMeta` on their component registrations. Used to dynamically
+   * inject kit-contributed components into the system prompt §5 catalog.
+   */
+  getComponentCatalogEntries(): ComponentCatalogEntry[] {
+    const entries: ComponentCatalogEntry[] = [];
+    for (const kit of this.kits.values()) {
+      for (const comp of kit.components ?? []) {
+        if (comp.promptMeta) {
+          entries.push({
+            type: comp.type,
+            category: comp.promptMeta.category,
+            example: comp.promptMeta.example,
+            notes: comp.promptMeta.notes,
+          });
+        }
+      }
+    }
+    return entries;
   }
 
   /**

--- a/packages/core/src/kits/types.ts
+++ b/packages/core/src/kits/types.ts
@@ -18,6 +18,7 @@
 import type { Tool } from '../tools/types.js';
 import type { APIConnector } from '../connectors/types.js';
 import type { Phase } from '../engine/types.js';
+import type { ComponentCategory } from '../prompts/component-catalog.js';
 
 /**
  * A lightweight descriptor for a UI component contributed by a kit.
@@ -30,6 +31,18 @@ export interface ComponentRegistration {
   type: string;
   /** Human-readable description of what this component renders */
   description: string;
+  /**
+   * Optional prompt metadata -- when present, the component is included
+   * in the dynamically generated A2UI component catalog.
+   */
+  promptMeta?: {
+    /** Category grouping for the prompt catalog */
+    category: ComponentCategory;
+    /** JSON example string shown to the LLM */
+    example: string;
+    /** Optional notes appended after the example */
+    notes?: string;
+  };
 }
 
 /**

--- a/packages/core/src/prompts/component-catalog.ts
+++ b/packages/core/src/prompts/component-catalog.ts
@@ -1,0 +1,289 @@
+/**
+ * @module @kickstart/core/prompts/component-catalog
+ *
+ * Dynamic A2UI component catalog for system prompt injection.
+ * Generates the section 5 "A2UI COMPONENT CATALOG" section from structured
+ * catalog entries rather than hardcoded prompt text.
+ *
+ * Components from IntegrationKit registrations are merged with the base
+ * catalog at buildSystemPrompt() time, so adding a new component to
+ * the registry automatically documents it in the prompt.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Category grouping for prompt rendering. */
+export type ComponentCategory =
+  | "layout"
+  | "content"
+  | "input"
+  | "domain";
+
+/**
+ * A catalog entry carries the metadata needed to render one component's
+ * documentation line in the system prompt.
+ */
+export interface ComponentCatalogEntry {
+  /** A2UI component type identifier, e.g. "Row", "Button" */
+  type: string;
+  /** Category for grouping in the prompt */
+  category: ComponentCategory;
+  /** JSON example string shown to the LLM */
+  example: string;
+  /** Optional notes appended after the example (e.g. variant lists) */
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Base catalog -- the 28 core Kickstart components
+// ---------------------------------------------------------------------------
+
+export const BASE_COMPONENT_CATALOG: readonly ComponentCatalogEntry[] = [
+  // -- Layout ---------------------------------------------------------------
+  {
+    type: "Row",
+    category: "layout",
+    example: '{"id":"r1","component":"Row","children":["a","b"],"gap":"8px","justify":"spaceBetween","wrap":true}',
+  },
+  {
+    type: "Column",
+    category: "layout",
+    example: '{"id":"c1","component":"Column","children":["a","b"],"gap":"16px"}',
+  },
+  {
+    type: "List",
+    category: "layout",
+    example: '{"id":"l1","component":"List","children":["i1","i2"],"ordered":false}',
+  },
+  {
+    type: "Card",
+    category: "layout",
+    example: '{"id":"card1","component":"Card","children":["title","body"]}',
+  },
+  {
+    type: "Tabs",
+    category: "layout",
+    example: '{"id":"tabs1","component":"Tabs","tabs":[{"label":"Overview","children":["ov1"]},{"label":"Details","children":["d1"]}]}',
+  },
+  {
+    type: "Divider",
+    category: "layout",
+    example: '{"id":"div1","component":"Divider"}',
+  },
+  {
+    type: "Modal",
+    category: "layout",
+    example: '{"id":"m1","component":"Modal","child":"content","title":"Confirm","open":false}',
+  },
+  {
+    type: "Accordion",
+    category: "layout",
+    example: '{"id":"acc1","component":"Accordion","items":[{"title":"What is auto-scaling?","children":["acc-body1"]},{"title":"How do health checks work?","children":["acc-body2"]}],"collapsible":true,"multiple":true}',
+  },
+
+  // -- Content --------------------------------------------------------------
+  {
+    type: "Text",
+    category: "content",
+    example: '{"id":"t1","component":"Text","text":"Hello World","variant":"h1"}',
+    notes: "variants: h1, h2, h3, body, caption, code",
+  },
+  {
+    type: "Markdown",
+    category: "content",
+    example: '{"id":"md1","component":"Markdown","content":"### Features\\\\n- Auto-scaling\\\\n- Health checks\\\\n- Zero-downtime deploys"}',
+  },
+  {
+    type: "Image",
+    category: "content",
+    example: '{"id":"img1","component":"Image","src":"https://...","alt":"diagram"}',
+  },
+  {
+    type: "Icon",
+    category: "content",
+    example: '{"id":"ic1","component":"Icon","name":"check-circle","size":"24px"}',
+  },
+  {
+    type: "Badge",
+    category: "content",
+    example: '{"id":"b1","component":"Badge","text":"Recommended","color":"success","appearance":"filled"}',
+    notes: "colors: brand, danger, important, informative, severe, subtle, success, warning",
+  },
+
+  // -- Input ----------------------------------------------------------------
+  {
+    type: "Button",
+    category: "input",
+    example: '{"id":"btn1","component":"Button","label":"Select Node.js","variant":"primary","action":{"event":{"name":"select","context":{"label":"Select Node.js","value":"node"}}}}',
+    notes: 'Variants: primary, secondary, outline, danger, ghost. Use "label" for inline text.',
+  },
+  {
+    type: "TextField",
+    category: "input",
+    example: '{"id":"tf1","component":"TextField","label":"App Name","placeholder":"my-app","action":{"event":{"name":"set-name","context":{"label":"App Name"}}}}',
+  },
+  {
+    type: "CheckBox",
+    category: "input",
+    example: '{"id":"cb1","component":"CheckBox","label":"Enable auto-scaling","action":{"event":{"name":"toggle","context":{"label":"Enable auto-scaling"}}}}',
+  },
+  {
+    type: "ChoicePicker",
+    category: "input",
+    example: '{"id":"cp1","component":"ChoicePicker","label":"Runtime","options":[{"label":"Node.js","value":"node"},{"label":"Python","value":"python"},{"label":".NET","value":"dotnet"},{"label":"Java","value":"java"},{"label":"Go","value":"go"}],"action":{"event":{"name":"pick-runtime","context":{"label":"Runtime"}}}}',
+  },
+  {
+    type: "RadioGroup",
+    category: "input",
+    example: '{"id":"rg1","component":"RadioGroup","label":"Database","options":[{"label":"PostgreSQL","value":"postgres","description":"Best for relational data"},{"label":"Cosmos DB","value":"cosmos","description":"Best for document/NoSQL data","recommended":true}],"action":{"event":{"name":"pick-db","context":{"label":"Database"}}}}',
+  },
+  {
+    type: "Slider",
+    category: "input",
+    example: '{"id":"s1","component":"Slider","label":"Replicas","min":1,"max":10,"value":2,"action":{"event":{"name":"set-replicas","context":{"label":"Replicas"}}}}',
+  },
+  {
+    type: "Toggle",
+    category: "input",
+    example: '{"id":"tog1","component":"Toggle","label":"Enable public URL","checked":false}',
+  },
+  {
+    type: "ComboBox",
+    category: "input",
+    example: '{"id":"cb1","component":"ComboBox","label":"Azure Region","options":[{"text":"East US","value":"eastus"},{"text":"West Europe","value":"westeurope"}],"placeholder":"Search regions...","allowCustom":false}',
+  },
+  {
+    type: "MultiSelect",
+    category: "input",
+    example: '{"id":"ms1","component":"MultiSelect","label":"Features","options":[{"text":"Auto-scaling","value":"autoscale"},{"text":"Health checks","value":"health"},{"text":"CI/CD pipeline","value":"cicd"}],"placeholder":"Select features..."}',
+  },
+  {
+    type: "DateTimeInput",
+    category: "input",
+    example: '{"id":"dt1","component":"DateTimeInput","label":"Deploy after","value":"2025-01-01T09:00:00Z"}',
+  },
+
+  // -- Domain ---------------------------------------------------------------
+  {
+    type: "CostEstimate",
+    category: "domain",
+    example: '{"id":"cost1","component":"CostEstimate","items":[{"name":"App Platform","sku":"Standard","monthlyCost":116.80},{"name":"Database","sku":"PostgreSQL B1ms","monthlyCost":12.40}],"total":129.20,"currency":"USD"}',
+  },
+  {
+    type: "ArchitectureDiagram",
+    category: "domain",
+    example: '{"id":"arch1","component":"ArchitectureDiagram","nodes":[{"id":"api","label":"Web API","type":"compute"},{"id":"db","label":"PostgreSQL","type":"database"}],"edges":[{"from":"api","to":"db"}]}',
+    notes: "Node types: compute, database, cache, network, storage, ai, messaging",
+  },
+  {
+    type: "FileEditor",
+    category: "domain",
+    example: '{"id":"fe1","component":"FileEditor","filename":"Dockerfile","language":"dockerfile","content":"FROM node:20-alpine\\\\nWORKDIR /app\\\\nCOPY . .\\\\nRUN npm ci\\\\nCMD [\\\\"node\\\\",\\\\"server.js\\\\"]"}',
+  },
+  {
+    type: "AuthCard",
+    category: "domain",
+    example: '{"id":"auth1","component":"AuthCard","provider":"azure","title":"Sign in to Azure","description":"Connect your Azure account to deploy"}',
+  },
+  {
+    type: "DeploymentProgress",
+    category: "domain",
+    example: '{"id":"dp1","component":"DeploymentProgress","steps":[{"id":"s1","label":"Build image","status":"complete"},{"id":"s2","label":"Push to registry","status":"running"},{"id":"s3","label":"Deploy","status":"pending"}]}',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Category metadata
+// ---------------------------------------------------------------------------
+
+const CATEGORY_LABELS: Record<ComponentCategory, string> = {
+  layout: "Layout Components",
+  content: "Content Components",
+  input: "Input Components",
+  domain: "Kickstart Domain Components",
+};
+
+const CATEGORY_ORDER: readonly ComponentCategory[] = [
+  "layout",
+  "content",
+  "input",
+  "domain",
+];
+
+// ---------------------------------------------------------------------------
+// Catalog section generator
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a single catalog entry as a prompt line.
+ * Output: `- TypeName: {"id":...}` with optional trailing notes.
+ */
+function formatEntry(entry: ComponentCatalogEntry): string {
+  const line = `- ${entry.type}: ${entry.example}`;
+  return entry.notes ? `${line}\n  ${entry.notes}` : line;
+}
+
+/**
+ * Generate the section 5 "A2UI COMPONENT CATALOG" section of the system prompt
+ * from a set of catalog entries.
+ *
+ * @param baseCatalog   The built-in Kickstart component entries
+ * @param kitEntries    Additional entries contributed by IntegrationKits
+ * @returns The complete markdown section ready for prompt injection
+ */
+export function generateComponentCatalogSection(
+  baseCatalog: readonly ComponentCatalogEntry[] = BASE_COMPONENT_CATALOG,
+  kitEntries: readonly ComponentCatalogEntry[] = [],
+): string {
+  // Merge base + kit entries, deduplicating by type (kit wins on conflict)
+  const entryMap = new Map<string, ComponentCatalogEntry>();
+  for (const entry of baseCatalog) {
+    entryMap.set(entry.type, entry);
+  }
+  for (const entry of kitEntries) {
+    entryMap.set(entry.type, entry);
+  }
+
+  const allEntries = Array.from(entryMap.values());
+  const totalCount = allEntries.length;
+
+  // Group by category
+  const groups = new Map<ComponentCategory, ComponentCatalogEntry[]>();
+  for (const entry of allEntries) {
+    const list = groups.get(entry.category) ?? [];
+    list.push(entry);
+    groups.set(entry.category, list);
+  }
+
+  // Build the section
+  const lines: string[] = [
+    `## 5. A2UI COMPONENT CATALOG`,
+    "",
+    `You have ${totalCount} components. Use them aggressively \u2014 every turn should use 3-8 components for a rich experience.`,
+    "",
+  ];
+
+  for (const category of CATEGORY_ORDER) {
+    const entries = groups.get(category);
+    if (!entries?.length) continue;
+    lines.push(`### ${CATEGORY_LABELS[category]}`);
+    for (const entry of entries) {
+      lines.push(formatEntry(entry));
+    }
+    lines.push("");
+  }
+
+  // Handle any kit-contributed categories not in the standard order
+  for (const [category, entries] of groups) {
+    if ((CATEGORY_ORDER as readonly string[]).includes(category)) continue;
+    lines.push(`### ${CATEGORY_LABELS[category] ?? category}`);
+    for (const entry of entries) {
+      lines.push(formatEntry(entry));
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -11,6 +11,16 @@ export {
   sanitizePromptValue,
 } from "./system-prompt.js";
 
+export {
+  BASE_COMPONENT_CATALOG,
+  generateComponentCatalogSection,
+} from "./component-catalog.js";
+
+export type {
+  ComponentCatalogEntry,
+  ComponentCategory,
+} from "./component-catalog.js";
+
 export type {
   DeploymentSafeguard,
   SafeguardSeverity,

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -12,6 +12,11 @@
 import { Phase } from "../engine/types.js";
 import { getPhaseDefinition } from "../engine/phases.js";
 import type { AppDefinition, AzureContext, GitHubContext } from "../types.js";
+import {
+  generateComponentCatalogSection,
+  BASE_COMPONENT_CATALOG,
+} from "./component-catalog.js";
+import type { ComponentCatalogEntry } from "./component-catalog.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,6 +59,11 @@ export interface SystemPromptContext {
    * section after the phase-specific (Layer 3) instructions.
    */
   kitPrompts?: string[];
+  /**
+   * A2UI component catalog entries contributed by IntegrationKits.
+   * Merged with the base catalog when generating the §5 component catalog.
+   */
+  kitComponentEntries?: ComponentCatalogEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -158,47 +168,7 @@ When you show an AuthCard or DeploymentProgress (while actively running), it MUS
 ### No Pre-Selection
 Do NOT pre-select any option in ChoicePicker, CheckBox, or DateTimeInput components. Present all options with no default selected — let the user make the choice. Exception: Slider components MAY have a sensible default (e.g., replicas: 2) when the default aligns with a best practice you've stated in the message text.
 
-## 5. A2UI COMPONENT CATALOG
-
-You have 28 components. Use them aggressively — every turn should use 3-8 components for a rich experience.
-
-### Layout Components
-- Row: {"id":"r1","component":"Row","children":["a","b"],"gap":"8px","justify":"spaceBetween","wrap":true}
-- Column: {"id":"c1","component":"Column","children":["a","b"],"gap":"16px"}
-- List: {"id":"l1","component":"List","children":["i1","i2"],"ordered":false}
-- Card: {"id":"card1","component":"Card","children":["title","body"]}
-- Tabs: {"id":"tabs1","component":"Tabs","tabs":[{"label":"Overview","children":["ov1"]},{"label":"Details","children":["d1"]}]}
-- Divider: {"id":"div1","component":"Divider"}
-- Modal: {"id":"m1","component":"Modal","child":"content","title":"Confirm","open":false}
-- Accordion: {"id":"acc1","component":"Accordion","items":[{"title":"What is auto-scaling?","children":["acc-body1"]},{"title":"How do health checks work?","children":["acc-body2"]}],"collapsible":true,"multiple":true}
-
-### Content Components
-- Text: {"id":"t1","component":"Text","text":"Hello World","variant":"h1"} (variants: h1, h2, h3, body, caption, code)
-- Markdown: {"id":"md1","component":"Markdown","content":"### Features\\n- Auto-scaling\\n- Health checks\\n- Zero-downtime deploys"}
-- Image: {"id":"img1","component":"Image","src":"https://...","alt":"diagram"}
-- Icon: {"id":"ic1","component":"Icon","name":"check-circle","size":"24px"}
-- Badge: {"id":"b1","component":"Badge","text":"Recommended","color":"success","appearance":"filled"} (colors: brand, danger, important, informative, severe, subtle, success, warning)
-
-### Input Components
-- Button: {"id":"btn1","component":"Button","label":"Select Node.js","variant":"primary","action":{"event":{"name":"select","context":{"label":"Select Node.js","value":"node"}}}}
-  Variants: primary, secondary, outline, danger, ghost. Use "label" for inline text.
-- TextField: {"id":"tf1","component":"TextField","label":"App Name","placeholder":"my-app","action":{"event":{"name":"set-name","context":{"label":"App Name"}}}}
-- CheckBox: {"id":"cb1","component":"CheckBox","label":"Enable auto-scaling","action":{"event":{"name":"toggle","context":{"label":"Enable auto-scaling"}}}}
-- ChoicePicker: {"id":"cp1","component":"ChoicePicker","label":"Runtime","options":[{"label":"Node.js","value":"node"},{"label":"Python","value":"python"},{"label":".NET","value":"dotnet"},{"label":"Java","value":"java"},{"label":"Go","value":"go"}],"action":{"event":{"name":"pick-runtime","context":{"label":"Runtime"}}}}
-- RadioGroup: {"id":"rg1","component":"RadioGroup","label":"Database","options":[{"label":"PostgreSQL","value":"postgres","description":"Best for relational data"},{"label":"Cosmos DB","value":"cosmos","description":"Best for document/NoSQL data","recommended":true}],"action":{"event":{"name":"pick-db","context":{"label":"Database"}}}}
-- Slider: {"id":"s1","component":"Slider","label":"Replicas","min":1,"max":10,"value":2,"action":{"event":{"name":"set-replicas","context":{"label":"Replicas"}}}}
-- Toggle: {"id":"tog1","component":"Toggle","label":"Enable public URL","checked":false}
-- ComboBox: {"id":"cb1","component":"ComboBox","label":"Azure Region","options":[{"text":"East US","value":"eastus"},{"text":"West Europe","value":"westeurope"}],"placeholder":"Search regions...","allowCustom":false}
-- MultiSelect: {"id":"ms1","component":"MultiSelect","label":"Features","options":[{"text":"Auto-scaling","value":"autoscale"},{"text":"Health checks","value":"health"},{"text":"CI/CD pipeline","value":"cicd"}],"placeholder":"Select features..."}
-- DateTimeInput: {"id":"dt1","component":"DateTimeInput","label":"Deploy after","value":"2025-01-01T09:00:00Z"}
-
-### Kickstart Domain Components
-- CostEstimate: {"id":"cost1","component":"CostEstimate","items":[{"name":"App Platform","sku":"Standard","monthlyCost":116.80},{"name":"Database","sku":"PostgreSQL B1ms","monthlyCost":12.40}],"total":129.20,"currency":"USD"}
-- ArchitectureDiagram: {"id":"arch1","component":"ArchitectureDiagram","nodes":[{"id":"api","label":"Web API","type":"compute"},{"id":"db","label":"PostgreSQL","type":"database"}],"edges":[{"from":"api","to":"db"}]}
-  Node types: compute, database, cache, network, storage, ai, messaging
-- FileEditor: {"id":"fe1","component":"FileEditor","filename":"Dockerfile","language":"dockerfile","content":"FROM node:20-alpine\\nWORKDIR /app\\nCOPY . .\\nRUN npm ci\\nCMD [\\"node\\",\\"server.js\\"]"}
-- AuthCard: {"id":"auth1","component":"AuthCard","provider":"azure","title":"Sign in to Azure","description":"Connect your Azure account to deploy"}
-- DeploymentProgress: {"id":"dp1","component":"DeploymentProgress","steps":[{"id":"s1","label":"Build image","status":"complete"},{"id":"s2","label":"Push to registry","status":"running"},{"id":"s3","label":"Deploy","status":"pending"}]}
+{{componentCatalog}}
 
 ## 5a. COMPONENT SELECTION GUIDE — When to Use What
 
@@ -468,6 +438,10 @@ export function buildSystemPrompt(context: SystemPromptContext): string {
   // Assemble template variables from context
   const vars: Record<string, string> = {
     safeguards: formatSafeguards(DEPLOYMENT_SAFEGUARDS),
+    componentCatalog: generateComponentCatalogSection(
+      BASE_COMPONENT_CATALOG,
+      context.kitComponentEntries ?? [],
+    ),
     ...(context.templateVars
       ? Object.fromEntries(
           Object.entries(context.templateVars).map(([k, v]) => [


### PR DESCRIPTION
Closes #185

## Summary
Replace the hardcoded 28-component catalog in the system prompt (\u00a75) with a dynamically generated section composed at `buildSystemPrompt()` time. IntegrationKits that register components with `promptMeta` are now automatically documented in the prompt.

## Changes
- **New `component-catalog.ts`** \u2014 `ComponentCatalogEntry` type, `BASE_COMPONENT_CATALOG` data array (28 entries), and `generateComponentCatalogSection()` function
- **Extended `ComponentRegistration`** \u2014 optional `promptMeta` field (category, example JSON, notes) for kit-contributed prompt docs
- **New `IntegrationKitRegistry.getComponentCatalogEntries()`** \u2014 collects entries from loaded kits
- **Updated `SystemPromptContext`** \u2014 new `kitComponentEntries` field for kit injection
- **Refactored `KICKSTART_SYSTEM_PROMPT`** \u2014 replaced static catalog with `{{componentCatalog}}` placeholder
- **Updated barrel exports** in `prompts/index.ts` and `core/src/index.ts`

## Testing
- 20 new tests covering catalog generation, kit injection, deduplication, backward compat, and JSON integrity
- All 717 existing tests continue to pass
- `npx tsc --noEmit` clean on web package
- Lint clean (no new warnings)

\ud83e\udd16 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)