### PR TITLE
release: v0.5.7

### DIFF
--- a/.changeset/a2ui-wire-format.md
+++ b/.changeset/a2ui-wire-format.md
@@ -1,7 +1,0 @@
----
-"@kickstart/core": minor
-"@kickstart/web": patch
-"@kickstart/mcp-server": patch
----
-
-Adopt official A2UI v0.9 nested wire format end-to-end. The `A2UIMessage` type shape changed from flat `{type, surfaceId, ...}` to nested `{version: "v0.9", createSurface: {...}}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 This project uses [@changesets/cli](https://github.com/changesets/changesets) for versioning.
 
+## [0.5.7] - 2026-04-14
+
+### Added
+
+- **Continuous SWA deployment** — Merge to `main` now auto-deploys to Azure Static Web Apps; version-SHA footer link added (#177)
+
+### Fixed
+
+- **A2UI v0.9 wire format (P0)** — Adopted official nested wire format (`{version:"v0.9", createSurface:{...}}`) end-to-end, fixing all A2UI component rendering (#166, #184)
+- **A2UI interactivity** — Interactive components (ChoicePicker, CheckBox, Toggle, ComboBox, MultiSelect) now fire action events via `ActionSchema`; `onAction` callback wired through component chain (#192, #195)
+- **SSE event parsing** — Fixed sticky `eventType` bug, JSON envelope extraction, and duplicate A2UI message accumulation (#179, #180)
+- **Integration Kit visibility** — Kit card carousel animation and debug panel fixes (#168, #170, #175)
+- **Version SHA footer** — Topbar footer now shows clickable commit SHA linking to GitHub (#181)
+- **Auth-aware sign-in** — Sign-in button reflects authentication state (#169)
+- **Clear All confirmation** — Added confirmation dialog before clearing all sessions (#172)
+- **Folder icon** — Restored files/folder icon in sidebar (#171)
+- **Phase indicator** — Added visual phase progress indicator (#182)
+
 ## [0.5.6] - 2026-04-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kickstart",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "AI-guided onboarding for deploying apps to AKS",
   "license": "MIT",
   "workspaces": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kickstart/core
 
+## 0.5.7
+
+### Patch Changes
+
+- [#184](https://github.com/sabbour/kickstart/pull/184) [`566dbd6`](https://github.com/sabbour/kickstart/commit/566dbd6b0168af8a33e5758ddacbf81b85cd8548) Thanks [@sabbour](https://github.com/sabbour)! - Adopt official A2UI v0.9 nested wire format end-to-end. The `A2UIMessage` type shape changed from flat `{type, surfaceId, ...}` to nested `{version: "v0.9", createSurface: {...}}`.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/core",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Kickstart conversation engine, A2UI catalog, and code generators",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @kickstart/mcp-server
 
+## 0.5.7
+
+### Patch Changes
+
+- [#184](https://github.com/sabbour/kickstart/pull/184) [`566dbd6`](https://github.com/sabbour/kickstart/commit/566dbd6b0168af8a33e5758ddacbf81b85cd8548) Thanks [@sabbour](https://github.com/sabbour)! - Adopt official A2UI v0.9 nested wire format end-to-end. The `A2UIMessage` type shape changed from flat `{type, surfaceId, ...}` to nested `{version: "v0.9", createSurface: {...}}`.
+
+- Updated dependencies [[`566dbd6`](https://github.com/sabbour/kickstart/commit/566dbd6b0168af8a33e5758ddacbf81b85cd8548)]:
+  - @kickstart/core@0.5.7
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.7",
   "description": "MCP server for AKS Kickstart — exposes conversation tools and A2UI responses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kickstart/web
 
+## 0.5.7
+
+### Patch Changes
+
+- [#184](https://github.com/sabbour/kickstart/pull/184) [`566dbd6`](https://github.com/sabbour/kickstart/commit/566dbd6b0168af8a33e5758ddacbf81b85cd8548) Thanks [@sabbour](https://github.com/sabbour)! - Adopt official A2UI v0.9 nested wire format end-to-end. The `A2UIMessage` type shape changed from flat `{type, surfaceId, ...}` to nested `{version: "v0.9", createSurface: {...}}`.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/web",
-  "version": "0.4.0",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "description": "Kickstart web frontend — Azure Portal-style UX for AI-guided AKS deployment",


### PR DESCRIPTION
## Release v0.5.7

Bumps all packages to v0.5.7. Changeset consumed, changelogs updated.

### What's in this release (since v0.5.6)

**Added:**
- Continuous SWA deployment from `main` + version-SHA footer link (#177)

**Fixed:**
- **A2UI v0.9 wire format (P0)** — Official nested wire format end-to-end (#166, #184)
- **A2UI interactivity** — Interactive components fire action events via ActionSchema (#192, #195)
- **SSE event parsing** — Sticky eventType, JSON envelope, duplicate A2UI accumulation (#179, #180)
- **Integration Kit visibility** — Carousel animation, debug panel (#168, #170, #175)
- **Version SHA footer** — Clickable commit SHA in topbar (#181)
- **Auth-aware sign-in** — Button reflects auth state (#169)
- **Clear All confirmation** — Confirmation dialog before clearing sessions (#172)
- **Folder icon** — Restored in sidebar (#171)
- **Phase indicator** — Visual phase progress (#182)

After merge, tag `v0.5.7` and push to trigger deploy.