### PR TITLE
fix: prevent UI freeze after A2UI component interaction

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -319,11 +319,12 @@ export function App() {
     );
   };
 
-  // Convert A2UI component actions into user messages sent back to the conversation
+  // Convert A2UI component actions into user messages sent back to the conversation.
+  // Fire-and-forget — never block the UI thread on the streaming response.
   const handleA2UIAction = useCallback((action: A2uiClientAction) => {
     const label = getSelectionLabel(action);
     const text = `[Selected: ${label}]`;
-    handleSendMessage(text);
+    void handleSendMessage(text).catch(() => {});
   }, [handleSendMessage]);
 
   const isStreaming = mockEnabled ? mockStreaming.isStreaming : streaming.isStreaming;

--- a/packages/web/src/components/A2UI/A2UISurfaceWrapper.tsx
+++ b/packages/web/src/components/A2UI/A2UISurfaceWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useCallback } from 'react';
 import { A2uiSurface } from '../../vendor/a2ui/react/index';
 import type { SurfaceModel } from '../../vendor/a2ui/web_core/index';
 import type { A2uiClientAction } from '../../vendor/a2ui/web_core/schema/client-to-server';
@@ -6,18 +6,28 @@ import type { ReactComponentImplementation } from '../../vendor/a2ui/react/adapt
 
 interface A2UISurfaceWrapperProps {
   surface: SurfaceModel<ReactComponentImplementation>;
-  /** When false, the surface is dimmed and non-interactive (past-turn isolation). Defaults to true. */
+  /** When false, the surface is visually dimmed (past-turn). Defaults to true. */
   isActive?: boolean;
   /** Optional callback invoked when any component in this surface dispatches an action. */
   onAction?: (action: A2uiClientAction) => void | Promise<void>;
 }
 
 export function A2UISurfaceWrapper({ surface, isActive = true, onAction }: A2UISurfaceWrapperProps) {
+  // Guard against double-firing: once an action dispatches, block further actions from this surface
+  const hasFiredRef = useRef(false);
+
+  const guardedOnAction = useCallback((action: A2uiClientAction) => {
+    if (hasFiredRef.current || !onAction) return;
+    hasFiredRef.current = true;
+    // Fire-and-forget — don't let errors or async streaming block the UI
+    try { void onAction(action); } catch { /* swallow */ }
+  }, [onAction]);
+
   useEffect(() => {
     if (!onAction) return;
-    const sub = surface.onAction.subscribe(onAction);
+    const sub = surface.onAction.subscribe(guardedOnAction);
     return () => sub.unsubscribe();
-  }, [surface, onAction]);
+  }, [surface, guardedOnAction, onAction]);
 
   return (
     <div
@@ -25,11 +35,8 @@ export function A2UISurfaceWrapper({ surface, isActive = true, onAction }: A2UIS
       style={{
         borderRadius: 'var(--radius-large, 8px)',
         overflow: 'hidden',
-        ...(isActive ? {} : {
-          opacity: 0.5,
-          pointerEvents: 'none',
-          userSelect: 'none',
-        }),
+        // Past-turn surfaces are visually dimmed but remain scrollable and selectable
+        ...(isActive ? {} : { opacity: 0.5 }),
       }}
     >
       <A2uiSurface surface={surface} />


### PR DESCRIPTION
## Problem
User cursor freezes after clicking a ChoicePicker or other interactive A2UI component. The entire UI becomes unresponsive.

## Root Cause
Three issues combined:

1. **`pointerEvents: 'none'` on past messages** — When a user clicks a component and a new message arrives, the old message becomes `isActive=false`, which applied `pointerEvents: 'none'` to the entire surface wrapper. The user's cursor is trapped over a dead zone that swallows all events.

2. **No double-fire guard** — Clicking a component could fire the action handler multiple times before state updates disabled the component.

3. **Unguarded async propagation** — `handleSendMessage` returns a Promise; if the EventEmitter awaited it, the dispatch call chain could block until streaming completed.

## Fix

- **Removed `pointerEvents: 'none'` and `userSelect: 'none'`** from past-turn surfaces in `A2UISurfaceWrapper`. Past messages are now visually dimmed (opacity 0.5) but remain scrollable and interactive.
- **Added a `hasFiredRef` guard** so each surface instance only dispatches one action — prevents re-triggering on rapid clicks.
- **Wrapped `handleA2UIAction` in `void ... .catch()`** so streaming errors never block the dispatch chain.

Closes #205

🤖 Working as Fry (Frontend Dev)
🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)