### PR TITLE
fix: restore A2UI on session reload + FileEditor highlighting (#193, #200)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,7 +20,7 @@ import { useVirtualFS } from './contexts/VirtualFSContext';
 import { healthCheck } from './services/api-client';
 import { isMockMode, isPlaygroundMode } from './services/mock-streaming';
 import { VirtualFileSystem } from './services/virtual-fs';
-import type { AppMode, ChatMessage } from './types';
+import type { AppMode, ChatMessage, A2uiMsg } from './types';
 import type { A2uiClientAction } from './vendor/a2ui/web_core/schema/client-to-server';
 
 const mockEnabled = isMockMode();
@@ -92,6 +92,9 @@ export function App() {
   // Surface IDs revealed progressively via the queue
   const streamingSurfaceIdsRef = useRef<string[]>([]);
 
+  // Raw A2UI messages accumulated during streaming (for session persistence)
+  const streamingA2UIMessagesRef = useRef<A2uiMsg[]>([]);
+
   // Check API availability on mount (skip in mock mode — already true)
   useEffect(() => {
     if (!mockEnabled) {
@@ -145,6 +148,7 @@ export function App() {
 
     // Reset streaming surface IDs for the new turn
     streamingSurfaceIdsRef.current = [];
+    streamingA2UIMessagesRef.current = [];
     progressiveQueue.reset();
 
     // Use mock streaming when ?mock is active, real streaming otherwise
@@ -152,6 +156,7 @@ export function App() {
       mockStreaming.send(text, sessionId, {
         onDelta: () => {},
         onA2UI: (msgs) => {
+          streamingA2UIMessagesRef.current = [...streamingA2UIMessagesRef.current, ...msgs];
           const newIds = a2ui.processMessages(msgs);
           if (newIds.length > 0) {
             streamingSurfaceIdsRef.current = [...streamingSurfaceIdsRef.current, ...newIds];
@@ -166,7 +171,9 @@ export function App() {
           progressiveQueue.flush();
           const collectedIds = streamingSurfaceIdsRef.current;
           const surfaceIds = collectedIds.length > 0 ? collectedIds : undefined;
+          const a2uiMessages = streamingA2UIMessagesRef.current.length > 0 ? [...streamingA2UIMessagesRef.current] : undefined;
           streamingSurfaceIdsRef.current = [];
+          streamingA2UIMessagesRef.current = [];
           progressiveQueue.reset();
           const assistantMsg: ChatMessage = {
             id: `msg-${Date.now()}-assistant`,
@@ -176,12 +183,14 @@ export function App() {
             surfaceIds,
             phase,
             timestamp: Date.now(),
+            a2uiMessages,
           };
           setMessages(prev => [...prev, assistantMsg]);
           sessions.addMessage(sessionId!, assistantMsg);
         },
         onError: (error) => {
           streamingSurfaceIdsRef.current = [];
+          streamingA2UIMessagesRef.current = [];
           progressiveQueue.reset();
           const errorMsg: ChatMessage = {
             id: `msg-${Date.now()}-error`,
@@ -201,6 +210,7 @@ export function App() {
       streaming.send(text, backendSessionId, {
         onDelta: () => {},
         onA2UI: (msgs) => {
+          streamingA2UIMessagesRef.current = [...streamingA2UIMessagesRef.current, ...msgs];
           const newIds = a2ui.processMessages(msgs);
           if (newIds.length > 0) {
             streamingSurfaceIdsRef.current = [...streamingSurfaceIdsRef.current, ...newIds];
@@ -219,7 +229,9 @@ export function App() {
           progressiveQueue.flush();
           const collectedIds = streamingSurfaceIdsRef.current;
           const surfaceIds = collectedIds.length > 0 ? collectedIds : undefined;
+          const a2uiMessages = streamingA2UIMessagesRef.current.length > 0 ? [...streamingA2UIMessagesRef.current] : undefined;
           streamingSurfaceIdsRef.current = [];
+          streamingA2UIMessagesRef.current = [];
           progressiveQueue.reset();
           const assistantMsg: ChatMessage = {
             id: `msg-${Date.now()}-assistant`,
@@ -230,12 +242,14 @@ export function App() {
             phase,
             timestamp: Date.now(),
             debugInfo,
+            a2uiMessages,
           };
           setMessages(prev => [...prev, assistantMsg]);
           sessions.addMessage(sessionId!, assistantMsg);
         },
         onError: (error) => {
           streamingSurfaceIdsRef.current = [];
+          streamingA2UIMessagesRef.current = [];
           progressiveQueue.reset();
           const errorMsg: ChatMessage = {
             id: `msg-${Date.now()}-error`,
@@ -300,11 +314,18 @@ export function App() {
     sessions.setActiveSessionId(sessionId);
     const session = sessions.sessions.find(s => s.id === sessionId);
     if (session) {
+      // Rehydrate A2UI surfaces from stored messages so components render after reload
+      a2ui.reset();
+      for (const msg of session.messages) {
+        if (msg.a2uiMessages && msg.a2uiMessages.length > 0) {
+          a2ui.processMessages(msg.a2uiMessages);
+        }
+      }
       setMessages(session.messages);
       setMode('chat');
       document.body.classList.remove('on-landing');
     }
-  }, [sessions]);
+  }, [sessions, a2ui]);
 
   // Extract a human-readable label from an A2UI action, checking context then data as fallback
   const getSelectionLabel = (action: A2uiClientAction): string => {

--- a/packages/web/src/components/FileEditor/CodeView.tsx
+++ b/packages/web/src/components/FileEditor/CodeView.tsx
@@ -1,5 +1,42 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import type { VirtualFile } from '../../services/virtual-fs';
+import { sanitizeHtml } from '../../utils/sanitize';
+import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript';
+import typescript from 'highlight.js/lib/languages/typescript';
+import python from 'highlight.js/lib/languages/python';
+import java from 'highlight.js/lib/languages/java';
+import csharp from 'highlight.js/lib/languages/csharp';
+import json from 'highlight.js/lib/languages/json';
+import xml from 'highlight.js/lib/languages/xml';
+import css from 'highlight.js/lib/languages/css';
+import bashLang from 'highlight.js/lib/languages/bash';
+import markdown from 'highlight.js/lib/languages/markdown';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import yaml from 'highlight.js/lib/languages/yaml';
+import go from 'highlight.js/lib/languages/go';
+import 'highlight.js/styles/github-dark.css';
+
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('js', javascript);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('ts', typescript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('csharp', csharp);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('html', xml);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('bash', bashLang);
+hljs.registerLanguage('shell', bashLang);
+hljs.registerLanguage('sh', bashLang);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('md', markdown);
+hljs.registerLanguage('dockerfile', dockerfile);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('yml', yaml);
+hljs.registerLanguage('go', go);
 
 interface CodeViewProps {
   file?: VirtualFile;
@@ -54,6 +91,19 @@ export function CodeView({ file }: CodeViewProps) {
   const lines = file.content.split('\n');
   const isGenerating = file.status === 'generating';
 
+  const highlightedHtml = useMemo(() => {
+    try {
+      if (file.language && hljs.getLanguage(file.language)) {
+        return hljs.highlight(file.content, { language: file.language }).value;
+      }
+      return hljs.highlightAuto(file.content).value;
+    } catch {
+      return escapeHtml(file.content);
+    }
+  }, [file.content, file.language]);
+
+  const highlightedLines = highlightedHtml.split('\n');
+
   return (
     <div className={`code-view${isGenerating ? ' generating' : ''}`}>
       <div className="code-view-header">
@@ -82,11 +132,11 @@ export function CodeView({ file }: CodeViewProps) {
       </div>
       <div className="code-view-body">
         <pre className="code-view-pre">
-          <code>
-            {lines.map((line, i) => (
+          <code className="hljs">
+            {highlightedLines.map((lineHtml, i) => (
               <div key={i} className="code-line">
                 <span className="code-line-number">{i + 1}</span>
-                <span className="code-line-content">{line}</span>
+                <span className="code-line-content" dangerouslySetInnerHTML={{ __html: sanitizeHtml(lineHtml) }} />
               </div>
             ))}
           </code>
@@ -100,4 +150,11 @@ export function CodeView({ file }: CodeViewProps) {
       )}
     </div>
   );
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -24,6 +24,8 @@ export interface ChatMessage {
   isAutoContinue?: boolean;
   /** Debug metadata captured when debug mode is active. */
   debugInfo?: DebugMetadata;
+  /** Raw A2UI messages that produced the surfaces for this message (used to rehydrate on reload). */
+  a2uiMessages?: A2uiMsg[];
 }
 
 export interface Session {


### PR DESCRIPTION
Closes #193, Closes #200

## What changed

### Bug #193 — A2UI surfaces lost on session reload
Raw A2UI messages are now persisted on each `ChatMessage` (`a2uiMessages` field) and replayed through the `MessageProcessor` when resuming a session via `handleResumeSession`. This rebuilds surface models that were previously lost on page reload.

### Bug #200 — FileEditor CodeView lacks syntax highlighting
Added highlight.js to `CodeView.tsx` (same language set as `ChatMarkdown`), rendering code with `dangerouslySetInnerHTML` + `sanitizeHtml` while preserving line numbers.

### Files changed
- `packages/web/src/types.ts` — added `a2uiMessages?` to `ChatMessage`
- `packages/web/src/App.tsx` — accumulate & store A2UI messages during streaming; replay on resume
- `packages/web/src/components/FileEditor/CodeView.tsx` — highlight.js integration

### Testing
- `tsc --noEmit` ✅
- `vitest run` — 891/891 tests pass ✅

🤖 Working as Fry (Frontend Dev)