### PR TITLE
feat: Azure Retail Pricing API integration for CostEstimate (#189)

### DIFF
--- a/packages/core/src/__tests__/pricing-connector.test.ts
+++ b/packages/core/src/__tests__/pricing-connector.test.ts
@@ -1,0 +1,386 @@
+/**
+ * @module @kickstart/core/__tests__/pricing-connector
+ *
+ * Tests for PricingConnector — retail price fetching, caching,
+ * VM price lookup, and stub fallback.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  PricingConnector,
+  _stubEstimate,
+  HOURS_PER_MONTH,
+} from "../connectors/PricingConnector.js";
+import type {
+  RetailPricesResponse,
+  ResourceCostInput,
+} from "../connectors/PricingConnector.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makePricingResponse(
+  items: RetailPricesResponse["Items"],
+  nextPageLink: string | null = null,
+): RetailPricesResponse {
+  return {
+    BillingCurrency: "USD",
+    CustomerEntityId: "Default",
+    CustomerEntityType: "Retail",
+    Items: items,
+    NextPageLink: nextPageLink,
+    Count: items.length,
+  };
+}
+
+function makeVmItem(overrides: Partial<RetailPricesResponse["Items"][0]> = {}) {
+  return {
+    currencyCode: "USD",
+    tierMinimumUnits: 0,
+    retailPrice: 0.192,
+    unitPrice: 0.192,
+    armRegionName: "eastus",
+    location: "US East",
+    effectiveStartDate: "2017-12-15T00:00:00Z",
+    meterId: "test-meter-id",
+    meterName: "D4s v3",
+    productId: "DZH318Z0BQ50",
+    skuId: "DZH318Z0BQ50/00RD",
+    productName: "Virtual Machines DSv3 Series",
+    skuName: "D4s v3",
+    serviceName: "Virtual Machines",
+    serviceId: "DZH313Z7MMC8",
+    serviceFamily: "Compute",
+    unitOfMeasure: "1 Hour",
+    type: "Consumption",
+    isPrimaryMeterRegion: true,
+    armSkuName: "Standard_D4s_v3",
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PricingConnector", () => {
+  let connector: PricingConnector;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    connector = new PricingConnector(
+      { auth: { kind: 'none' }, retry: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0, jitterFactor: 0, retryableStatuses: [] } },
+      5000,
+    );
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    connector.clearCache();
+  });
+
+  // ── stubEstimate ──────────────────────────────────────────────────────────
+
+  describe("stubEstimate", () => {
+    it("returns correct stub for known resource type and SKU", () => {
+      const input: ResourceCostInput = {
+        type: "Microsoft.Compute/virtualMachineScaleSets",
+        location: "eastus",
+        sku: "Standard_D4s_v3",
+        quantity: 3,
+      };
+      const result = _stubEstimate(input);
+      expect(result.unitCostPerHour).toBe(0.192);
+      expect(result.monthlyCost).toBe(
+        Math.round(0.192 * 3 * HOURS_PER_MONTH * 100) / 100,
+      );
+      expect(result.currency).toBe("USD");
+    });
+
+    it("falls back to default pricing for unknown type", () => {
+      const input: ResourceCostInput = {
+        type: "Microsoft.SomeUnknown/service",
+        location: "westus",
+      };
+      const result = _stubEstimate(input);
+      expect(result.unitCostPerHour).toBe(0.05);
+      expect(result.sku).toBe("default");
+      expect(result.quantity).toBe(1);
+    });
+  });
+
+  // ── fetchRetailPrices ─────────────────────────────────────────────────────
+
+  describe("fetchRetailPrices", () => {
+    it("fetches and returns items from the API", async () => {
+      const items = [makeVmItem()];
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await connector.fetchRetailPrices({
+        filter: "serviceName eq 'Virtual Machines'",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].retailPrice).toBe(0.192);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches results and returns from cache on second call", async () => {
+      const items = [makeVmItem()];
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const filter = "serviceName eq 'Virtual Machines' and armRegionName eq 'eastus'";
+      const first = await connector.fetchRetailPrices({ filter });
+      const second = await connector.fetchRetailPrices({ filter });
+
+      expect(first).toEqual(second);
+      // Only one fetch call — second was served from cache
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("follows NextPageLink for pagination", async () => {
+      const page1Items = [makeVmItem({ meterName: "D4s v3" })];
+      const page2Items = [makeVmItem({ meterName: "D8s v3", retailPrice: 0.384 })];
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify(
+              makePricingResponse(page1Items, "https://prices.azure.com/api/retail/prices?next=2"),
+            ),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(makePricingResponse(page2Items)), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+
+      const result = await connector.fetchRetailPrices({
+        filter: "serviceName eq 'Virtual Machines'",
+        maxPages: 2,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws on non-OK response", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response("Internal Server Error", {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      );
+
+      await expect(
+        connector.fetchRetailPrices({
+          filter: "serviceName eq 'Virtual Machines'",
+        }),
+      ).rejects.toThrow("Azure Pricing API returned 500");
+    });
+  });
+
+  // ── lookupVmPrice ─────────────────────────────────────────────────────────
+
+  describe("lookupVmPrice", () => {
+    it("returns pay-as-you-go price for a Linux VM", async () => {
+      const items = [
+        makeVmItem({ type: "Consumption", retailPrice: 0.192 }),
+      ];
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await connector.lookupVmPrice("Standard_D4s_v3", "eastus");
+      expect(result).not.toBeNull();
+      expect(result!.payAsYouGo).toBe(0.192);
+      expect(result!.vmSize).toBe("Standard_D4s_v3");
+      expect(result!.region).toBe("eastus");
+    });
+
+    it("includes reservation prices when available", async () => {
+      const items = [
+        makeVmItem({ type: "Consumption", retailPrice: 0.192 }),
+        makeVmItem({
+          type: "Reservation",
+          retailPrice: 0.12,
+          reservationTerm: "1 Year",
+        }),
+        makeVmItem({
+          type: "Reservation",
+          retailPrice: 0.08,
+          reservationTerm: "3 Years",
+        }),
+      ];
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await connector.lookupVmPrice("Standard_D4s_v3", "eastus");
+      expect(result!.reserved1Year).toBe(0.12);
+      expect(result!.reserved3Years).toBe(0.08);
+    });
+
+    it("filters out Windows VMs", async () => {
+      const items = [
+        makeVmItem({
+          productName: "Virtual Machines DSv3 Series Windows",
+          type: "Consumption",
+        }),
+      ];
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await connector.lookupVmPrice("Standard_D4s_v3", "eastus");
+      expect(result).toBeNull();
+    });
+
+    it("returns null on fetch failure", async () => {
+      fetchSpy.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await connector.lookupVmPrice("Standard_D4s_v3", "eastus");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── lookupServicePrice ────────────────────────────────────────────────────
+
+  describe("lookupServicePrice", () => {
+    it("returns items for a service name and region", async () => {
+      const items = [
+        makeVmItem({
+          serviceName: "Azure Kubernetes Service",
+          skuName: "Standard",
+          retailPrice: 0.1,
+        }),
+      ];
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await connector.lookupServicePrice(
+        "Azure Kubernetes Service",
+        "eastus",
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].retailPrice).toBe(0.1);
+    });
+
+    it("returns empty array on failure", async () => {
+      fetchSpy.mockRejectedValueOnce(new Error("timeout"));
+
+      const result = await connector.lookupServicePrice(
+        "Azure Kubernetes Service",
+        "eastus",
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── estimateCost ──────────────────────────────────────────────────────────
+
+  describe("estimateCost", () => {
+    it("returns stub estimates when API call fails", async () => {
+      fetchSpy.mockRejectedValue(new Error("offline"));
+
+      const result = await connector.estimateCost([
+        {
+          type: "Microsoft.ContainerService/managedClusters",
+          location: "eastus",
+          sku: "standard",
+        },
+      ]);
+
+      expect(result.source).toBe("stub");
+      expect(result.resources).toHaveLength(1);
+      expect(result.currency).toBe("USD");
+    });
+
+    it("returns live estimates when API responds for VMSS", async () => {
+      const items = [makeVmItem({ retailPrice: 0.192, type: "Consumption" })];
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await connector.estimateCost([
+        {
+          type: "Microsoft.Compute/virtualMachineScaleSets",
+          location: "eastus",
+          sku: "Standard_D4s_v3",
+          quantity: 3,
+        },
+      ]);
+
+      expect(result.source).toBe("live");
+      expect(result.resources[0].unitCostPerHour).toBe(0.192);
+      expect(result.resources[0].monthlyCost).toBe(
+        Math.round(0.192 * 3 * HOURS_PER_MONTH * 100) / 100,
+      );
+    });
+
+    it("includes estimatedAt timestamp", async () => {
+      fetchSpy.mockRejectedValue(new Error("offline"));
+
+      const result = await connector.estimateCost([
+        { type: "Microsoft.Network/publicIPAddresses", location: "eastus" },
+      ]);
+
+      expect(result.estimatedAt).toBeDefined();
+      expect(() => new Date(result.estimatedAt)).not.toThrow();
+    });
+  });
+
+  // ── Cache management ──────────────────────────────────────────────────────
+
+  describe("clearCache", () => {
+    it("forces re-fetch after cache is cleared", async () => {
+      const items = [makeVmItem()];
+      const makeResponse = () =>
+        new Response(JSON.stringify(makePricingResponse(items)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      fetchSpy.mockResolvedValueOnce(makeResponse());
+      fetchSpy.mockResolvedValueOnce(makeResponse());
+
+      const filter = "test-filter";
+      await connector.fetchRetailPrices({ filter });
+      connector.clearCache();
+      await connector.fetchRetailPrices({ filter });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/core/src/__tests__/tools.test.ts
+++ b/packages/core/src/__tests__/tools.test.ts
@@ -237,7 +237,7 @@ describe("estimate_cost tool", () => {
     expect(result.breakdown).toBeDefined();
     expect(typeof result.estimatedMonthlyTotal).toBe("number");
     expect((result.estimatedMonthlyTotal as number)).toBeGreaterThan(0);
-    expect(result._stub).toBe(true);
+    expect(result.source).toBe("stub");
   });
 
   it("adds database cost when needsDatabase is true", async () => {

--- a/packages/core/src/connectors/PricingConnector.ts
+++ b/packages/core/src/connectors/PricingConnector.ts
@@ -1,6 +1,8 @@
 import type { ConnectorConfig } from './types.js';
 import { BaseConnector } from './BaseConnector.js';
 
+// ── Public types ──────────────────────────────────────────────────────────────
+
 export interface ResourceCostInput {
   /** Azure resource type, e.g. "Microsoft.ContainerService/managedClusters" */
   type: string;
@@ -28,36 +30,250 @@ export interface CostEstimateResult {
   currency: 'USD';
   /** ISO 8601 timestamp of when this estimate was generated. */
   estimatedAt: string;
+  /** Whether the result used live API data or fell back to stubs. */
+  source: 'live' | 'stub';
 }
 
+/** A single price item from the Azure Retail Prices API. */
+export interface RetailPriceItem {
+  currencyCode: string;
+  retailPrice: number;
+  unitPrice: number;
+  armRegionName: string;
+  location: string;
+  meterName: string;
+  productId: string;
+  skuId: string;
+  productName: string;
+  skuName: string;
+  serviceName: string;
+  serviceFamily: string;
+  unitOfMeasure: string;
+  type: string; // "Consumption" | "Reservation"
+  isPrimaryMeterRegion: boolean;
+  armSkuName: string;
+  effectiveStartDate: string;
+  tierMinimumUnits: number;
+  reservationTerm?: string; // "1 Year" | "3 Years"
+}
+
+/** Response envelope from the Azure Retail Prices API. */
+export interface RetailPricesResponse {
+  BillingCurrency: string;
+  CustomerEntityId: string;
+  CustomerEntityType: string;
+  Items: RetailPriceItem[];
+  NextPageLink: string | null;
+  Count: number;
+}
+
+export interface RetailPriceQuery {
+  /** OData $filter expression. */
+  filter: string;
+  /** Max pages to fetch (default: 1). */
+  maxPages?: number;
+}
+
+/** Resolved price for a VM SKU with optional reservation tiers. */
+export interface VmPriceResult {
+  vmSize: string;
+  region: string;
+  payAsYouGo: number;
+  reserved1Year?: number;
+  reserved3Years?: number;
+  currency: string;
+}
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+/** Default cache TTL — 30 minutes. Pricing data changes infrequently. */
+const DEFAULT_CACHE_TTL_MS = 30 * 60 * 1000;
+
 /**
- * Connector for the Azure Pricing REST API.
+ * Connector for the Azure Retail Pricing REST API.
  *
  * No auth required — the Azure pricing API is public.
  * Auth strategy defaults to "none".
  *
- * `estimateCost()` currently returns stub data. Real pricing calls
- * will query https://prices.azure.com/api/retail/prices.
+ * Provides:
+ * - `fetchRetailPrices()` — raw API query with pagination + caching
+ * - `lookupVmPrice()` — convenience for VM hourly cost by SKU + region
+ * - `estimateCost()` — high-level cost estimation with live API fallback to stubs
  */
 export class PricingConnector extends BaseConnector {
   readonly name = 'pricing';
+
+  /** In-memory cache keyed by OData filter string. */
+  private readonly _cache = new Map<string, CacheEntry<RetailPriceItem[]>>();
+  private readonly _cacheTtlMs: number;
 
   protected get defaultBaseUrl(): string {
     return 'https://prices.azure.com';
   }
 
-  constructor(config?: ConnectorConfig) {
+  constructor(config?: ConnectorConfig, cacheTtlMs?: number) {
     super(config ?? { auth: { kind: 'none' } });
+    this._cacheTtlMs = cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  }
+
+  // ── Raw API ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Query the Azure Retail Prices API with an OData filter.
+   * Results are cached in memory for the session duration (configurable TTL).
+   * Follows NextPageLink for pagination up to `maxPages`.
+   */
+  async fetchRetailPrices(query: RetailPriceQuery): Promise<RetailPriceItem[]> {
+    const cached = this._cache.get(query.filter);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data;
+    }
+
+    const maxPages = query.maxPages ?? 1;
+    const allItems: RetailPriceItem[] = [];
+    let nextUrl: string | null = null;
+    let page = 0;
+
+    // Build initial URL
+    const initialPath = `/api/retail/prices?$filter=${encodeURIComponent(query.filter)}`;
+
+    while (page < maxPages) {
+      const response = page === 0
+        ? await this.request('GET', initialPath)
+        : await this.requestUrl('GET', nextUrl!);
+
+      if (!response.ok) {
+        throw new Error(`Azure Pricing API returned ${response.status}: ${response.statusText}`);
+      }
+
+      const body = (await response.json()) as RetailPricesResponse;
+      allItems.push(...body.Items);
+      nextUrl = body.NextPageLink;
+
+      if (!nextUrl) break;
+      page++;
+    }
+
+    this._cache.set(query.filter, {
+      data: allItems,
+      expiresAt: Date.now() + this._cacheTtlMs,
+    });
+
+    return allItems;
+  }
+
+  // ── Convenience lookups ─────────────────────────────────────────────────────
+
+  /**
+   * Look up hourly cost for a VM size in a given region.
+   * Returns pay-as-you-go and optional reservation prices.
+   * Returns `null` if the API call fails (caller should fall back to stubs).
+   */
+  async lookupVmPrice(vmSize: string, region: string): Promise<VmPriceResult | null> {
+    // Map Standard_D4s_v3 → D4s v3 (API skuName format)
+    const skuName = vmSize.replace(/^Standard_/, '').replace(/_/g, ' ');
+
+    const filter = [
+      `serviceName eq 'Virtual Machines'`,
+      `armRegionName eq '${region}'`,
+      `skuName eq '${skuName}'`,
+      `isPrimaryMeterRegion eq true`,
+    ].join(' and ');
+
+    try {
+      const items = await this.fetchRetailPrices({ filter, maxPages: 1 });
+
+      // Find Linux (non-Windows) consumption price
+      const consumption = items.find(
+        (i) =>
+          i.type === 'Consumption' &&
+          !i.productName.includes('Windows') &&
+          !i.productName.includes('Spot') &&
+          i.armSkuName === vmSize,
+      );
+
+      if (!consumption) return null;
+
+      // Find reservation prices
+      const reservations = items.filter(
+        (i) =>
+          i.type === 'Reservation' &&
+          !i.productName.includes('Windows') &&
+          !i.productName.includes('Spot') &&
+          i.armSkuName === vmSize,
+      );
+
+      const reserved1yr = reservations.find((r) => r.reservationTerm === '1 Year');
+      const reserved3yr = reservations.find((r) => r.reservationTerm === '3 Years');
+
+      return {
+        vmSize,
+        region,
+        payAsYouGo: consumption.retailPrice,
+        reserved1Year: reserved1yr ? reserved1yr.retailPrice : undefined,
+        reserved3Years: reserved3yr ? reserved3yr.retailPrice : undefined,
+        currency: consumption.currencyCode,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Look up pricing for an Azure service by name, region, and optional SKU.
+   * Returns matching retail price items or empty array on failure.
+   */
+  async lookupServicePrice(
+    serviceName: string,
+    region: string,
+    skuName?: string,
+  ): Promise<RetailPriceItem[]> {
+    const parts = [
+      `serviceName eq '${serviceName}'`,
+      `armRegionName eq '${region}'`,
+    ];
+    if (skuName) parts.push(`skuName eq '${skuName}'`);
+    parts.push(`isPrimaryMeterRegion eq true`);
+
+    const filter = parts.join(' and ');
+
+    try {
+      return await this.fetchRetailPrices({ filter, maxPages: 1 });
+    } catch {
+      return [];
+    }
+  }
+
+  /** Clear the in-memory cache. */
+  clearCache(): void {
+    this._cache.clear();
   }
 
   // ── Domain methods ─────────────────────────────────────────────────────────
 
   /**
    * Estimate monthly cost for a list of Azure resources.
-   * Returns stub pricing until the real pricing API is wired up.
+   * Tries real pricing API first; falls back to stub data on failure.
    */
   async estimateCost(resources: ResourceCostInput[]): Promise<CostEstimateResult> {
-    const estimates = resources.map((r) => stubEstimate(r));
+    let source: 'live' | 'stub' = 'stub';
+    const estimates: ResourceCostEstimate[] = [];
+
+    for (const r of resources) {
+      const live = await this.tryLiveEstimate(r);
+      if (live) {
+        estimates.push(live);
+        source = 'live';
+      } else {
+        estimates.push(stubEstimate(r));
+      }
+    }
+
     const totalMonthlyCost = estimates.reduce((sum, e) => sum + e.monthlyCost, 0);
 
     return {
@@ -65,11 +281,72 @@ export class PricingConnector extends BaseConnector {
       totalMonthlyCost: Math.round(totalMonthlyCost * 100) / 100,
       currency: 'USD',
       estimatedAt: new Date().toISOString(),
+      source,
     };
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  /** Attempt a live price lookup for a resource; returns null on any failure. */
+  private async tryLiveEstimate(input: ResourceCostInput): Promise<ResourceCostEstimate | null> {
+    try {
+      // VM scale sets → look up VM price
+      if (input.type === 'Microsoft.Compute/virtualMachineScaleSets' && input.sku) {
+        const price = await this.lookupVmPrice(input.sku, input.location);
+        if (price) {
+          const quantity = input.quantity ?? 1;
+          return {
+            type: input.type,
+            sku: input.sku,
+            location: input.location,
+            quantity,
+            unitCostPerHour: price.payAsYouGo,
+            monthlyCost: Math.round(price.payAsYouGo * quantity * HOURS_PER_MONTH * 100) / 100,
+            currency: 'USD',
+          };
+        }
+      }
+
+      // AKS clusters → look up AKS service pricing
+      if (input.type === 'Microsoft.ContainerService/managedClusters') {
+        const items = await this.lookupServicePrice(
+          'Azure Kubernetes Service',
+          input.location,
+          input.sku,
+        );
+        const match = items.find((i) => i.type === 'Consumption');
+        if (match) {
+          const quantity = input.quantity ?? 1;
+          return {
+            type: input.type,
+            sku: input.sku ?? match.skuName,
+            location: input.location,
+            quantity,
+            unitCostPerHour: match.retailPrice,
+            monthlyCost: Math.round(match.retailPrice * quantity * HOURS_PER_MONTH * 100) / 100,
+            currency: 'USD',
+          };
+        }
+      }
+    } catch {
+      // Fall through to null
+    }
+    return null;
+  }
+
+  /**
+   * Make a GET request to a full URL (for NextPageLink pagination).
+   * Uses raw fetch to bypass BaseConnector path resolution.
+   */
+  private async requestUrl(method: 'GET', url: string): Promise<Response> {
+    return fetch(url, {
+      method,
+      headers: { Accept: 'application/json' },
+    });
   }
 }
 
-// ── Stub pricing table ────────────────────────────────────────────────────────
+// ── Stub pricing table (fallback) ─────────────────────────────────────────────
 
 const HOURS_PER_MONTH = 730;
 
@@ -118,3 +395,6 @@ function stubEstimate(input: ResourceCostInput): ResourceCostEstimate {
     currency: 'USD',
   };
 }
+
+// Re-export stubEstimate for testing
+export { stubEstimate as _stubEstimate, HOURS_PER_MONTH };

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -37,7 +37,15 @@ export type { AzureResource, AzureResourceGroup, AzureSubscription, AzureLocatio
 export { GitHubConnector } from './GitHubConnector.js';
 export type { GitHubRepo, GitHubBranch, GitHubRepoOptions, GitHubUser, GitHubDeviceCodeResponse, GitHubPullRequest, GitHubTree, GitHubTreeEntry, GitHubFileContent } from './GitHubConnector.js';
 export { PricingConnector } from './PricingConnector.js';
-export type { ResourceCostInput, ResourceCostEstimate, CostEstimateResult } from './PricingConnector.js';
+export type {
+  ResourceCostInput,
+  ResourceCostEstimate,
+  CostEstimateResult,
+  RetailPriceItem,
+  RetailPricesResponse,
+  RetailPriceQuery,
+  VmPriceResult,
+} from './PricingConnector.js';
 
 // Rate-limit tracker
 export { gitHubRateLimiter } from './github-rate-limit.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -164,7 +164,15 @@ export type { AzureResource, AzureResourceGroup, AzureSubscription, AzureLocatio
 export { GitHubConnector } from "./connectors/index.js";
 export type { GitHubRepo, GitHubBranch, GitHubRepoOptions, GitHubUser, GitHubDeviceCodeResponse, GitHubPullRequest } from "./connectors/index.js";
 export { PricingConnector } from "./connectors/index.js";
-export type { ResourceCostInput, ResourceCostEstimate, CostEstimateResult } from "./connectors/index.js";
+export type {
+  ResourceCostInput,
+  ResourceCostEstimate,
+  CostEstimateResult,
+  RetailPriceItem,
+  RetailPricesResponse,
+  RetailPriceQuery,
+  VmPriceResult,
+} from "./connectors/index.js";
 
 // IntegrationKit system — composable bundles of tools, connectors, prompts, components
 export type { IntegrationKit, ComponentRegistration, KitAuthRequirement } from "./kits/index.js";

--- a/packages/core/src/prompts/component-catalog.ts
+++ b/packages/core/src/prompts/component-catalog.ts
@@ -169,7 +169,7 @@ export const BASE_COMPONENT_CATALOG: readonly ComponentCatalogEntry[] = [
   {
     type: "CostEstimate",
     category: "domain",
-    example: '{"id":"cost1","component":"CostEstimate","items":[{"name":"App Platform","sku":"Standard","monthlyCost":116.80},{"name":"Database","sku":"PostgreSQL B1ms","monthlyCost":12.40}],"total":129.20,"currency":"USD"}',
+    example: '{"id":"cost1","component":"CostEstimate","resources":[{"name":"App Platform","sku":"Standard","monthlyEstimate":116.80,"pricingTiers":[{"label":"Reserved 1yr","monthlyEstimate":80.30},{"label":"Reserved 3yr","monthlyEstimate":55.48}]},{"name":"Database","sku":"PostgreSQL B1ms","monthlyEstimate":12.40}],"total":129.20,"currency":"USD","source":"live"}',
   },
   {
     type: "ArchitectureDiagram",

--- a/packages/core/src/tools/estimate-cost.ts
+++ b/packages/core/src/tools/estimate-cost.ts
@@ -2,10 +2,13 @@
  * @module @kickstart/core/tools/estimate-cost
  *
  * Estimate monthly Azure cost for an AKS deployment configuration.
- * Stub implementation — real pricing calls wired by APIConnector (B-11).
+ * Queries the Azure Retail Prices API via PricingConnector for live pricing,
+ * falling back to stubs when the API is unreachable.
  */
 
 import type { Tool, ToolContext } from "../types.js";
+import { defaultConnectorRegistry } from "../connectors/index.js";
+import type { PricingConnector, VmPriceResult } from "../connectors/PricingConnector.js";
 
 interface EstimateCostArgs {
   region: string;
@@ -17,7 +20,15 @@ interface EstimateCostArgs {
   needsIngress?: boolean;
 }
 
-/** VM size → approximate hourly USD cost (stub pricing table) */
+interface CostLineItem {
+  description: string;
+  monthlyCost: number;
+  payAsYouGo?: number;
+  reserved1Year?: number;
+  reserved3Years?: number;
+}
+
+/** VM size → approximate hourly USD cost (stub pricing table — fallback only) */
 const VM_HOURLY_COST: Record<string, number> = {
   Standard_B2s: 0.048,
   Standard_B4ms: 0.192,
@@ -36,10 +47,12 @@ const DATABASE_MONTHLY_COST: Record<string, number> = {
   cosmosdb: 25,
 };
 
+const HOURS_PER_MONTH = 730;
+
 export const estimateCost: Tool<EstimateCostArgs> = {
   name: "estimate_cost",
   description:
-    "Estimate the monthly Azure cost for an AKS cluster configuration. Returns a cost breakdown by service (compute, networking, storage, database). Use this to give users a budget estimate before deployment.",
+    "Estimate the monthly Azure cost for an AKS cluster configuration. Returns a cost breakdown by service (compute, networking, storage, database) using live Azure pricing when available. Use this to give users a budget estimate before deployment.",
   parameters: {
     type: "object",
     properties: {
@@ -78,24 +91,55 @@ export const estimateCost: Tool<EstimateCostArgs> = {
   },
 
   async execute(args: EstimateCostArgs, _context: ToolContext): Promise<unknown> {
-    // Stub — APIConnector (B-11) will replace with real Azure Pricing API calls
-    const hourlyVm = VM_HOURLY_COST[args.vmSize] ?? 0.192;
-    const monthlyCompute = hourlyVm * args.nodeCount * 730; // 730h/month
-    const monthlyLb = args.needsIngress ? 18.25 : 0; // standard LB
+    const pricing = defaultConnectorRegistry.get("pricing") as PricingConnector | undefined;
+
+    // Attempt live VM pricing
+    let vmPrice: VmPriceResult | null = null;
+    let source: "live" | "stub" = "stub";
+
+    if (pricing) {
+      try {
+        vmPrice = await pricing.lookupVmPrice(args.vmSize, args.region);
+        if (vmPrice) source = "live";
+      } catch {
+        // Fall through to stub
+      }
+    }
+
+    const hourlyVm = vmPrice?.payAsYouGo ?? VM_HOURLY_COST[args.vmSize] ?? 0.192;
+    const monthlyCompute = hourlyVm * args.nodeCount * HOURS_PER_MONTH;
+    const monthlyLb = args.needsIngress ? 18.25 : 0;
     const monthlyDatabase = args.needsDatabase && args.databaseType
       ? (DATABASE_MONTHLY_COST[args.databaseType] ?? 50)
       : 0;
-    const monthlyStorage = args.nodeCount * 5; // ~5 USD per node for OS disk
+    const monthlyStorage = args.nodeCount * 5;
     const monthlyTotal = monthlyCompute + monthlyLb + monthlyDatabase + monthlyStorage;
+
+    // Build compute line item with pricing tiers
+    const compute: CostLineItem = {
+      description: `${args.nodeCount}x ${args.vmSize} nodes`,
+      monthlyCost: Math.round(monthlyCompute * 100) / 100,
+    };
+    if (vmPrice) {
+      compute.payAsYouGo = Math.round(monthlyCompute * 100) / 100;
+      if (vmPrice.reserved1Year != null) {
+        compute.reserved1Year = Math.round(
+          vmPrice.reserved1Year * args.nodeCount * HOURS_PER_MONTH * 100,
+        ) / 100;
+      }
+      if (vmPrice.reserved3Years != null) {
+        compute.reserved3Years = Math.round(
+          vmPrice.reserved3Years * args.nodeCount * HOURS_PER_MONTH * 100,
+        ) / 100;
+      }
+    }
 
     return {
       region: args.region,
       currency: "USD",
+      source,
       breakdown: {
-        compute: {
-          description: `${args.nodeCount}x ${args.vmSize} nodes`,
-          monthlyCost: Math.round(monthlyCompute * 100) / 100,
-        },
+        compute,
         networking: {
           description: args.needsIngress ? "Standard Load Balancer" : "No public LB",
           monthlyCost: monthlyLb,
@@ -112,7 +156,6 @@ export const estimateCost: Tool<EstimateCostArgs> = {
         },
       },
       estimatedMonthlyTotal: Math.round(monthlyTotal * 100) / 100,
-      _stub: true,
     };
   },
 };

--- a/packages/web/src/catalog/components/CostEstimate.tsx
+++ b/packages/web/src/catalog/components/CostEstimate.tsx
@@ -22,11 +22,17 @@ const SkuOptionSchema = z.object({
   monthlyEstimate: z.number(),
 });
 
+const PricingTierSchema = z.object({
+  label: DynamicStringSchema,
+  monthlyEstimate: z.number(),
+}).strict();
+
 const ResourceRowSchema = z.object({
   name: DynamicStringSchema,
   sku: DynamicStringSchema.optional(),
   monthlyEstimate: z.number(),
   skuOptions: z.array(SkuOptionSchema).optional(),
+  pricingTiers: z.array(PricingTierSchema).optional(),
 });
 
 const CostEstimateApi = {
@@ -38,6 +44,7 @@ const CostEstimateApi = {
     title: DynamicStringSchema.optional(),
     projectionMonths: z.number().optional(),
     showProjectionSlider: z.boolean().optional(),
+    source: z.enum(['live', 'stub']).optional(),
   }).strict(),
 };
 
@@ -159,6 +166,22 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
     textAlign: 'center' as const,
   },
+  pricingTiers: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalXS,
+    flexWrap: 'wrap' as const,
+    marginTop: tokens.spacingVerticalXXS,
+  },
+  tierBadge: {
+    fontSize: tokens.fontSizeBase100,
+    color: tokens.colorNeutralForeground3,
+    fontFamily: tokens.fontFamilyMonospace,
+  },
+  sourceLabel: {
+    fontSize: tokens.fontSizeBase100,
+    color: tokens.colorNeutralForeground3,
+    marginLeft: 'auto',
+  },
 });
 
 export const CostEstimate = createReactComponent(CostEstimateApi, ({ props, context }) => {
@@ -227,6 +250,11 @@ export const CostEstimate = createReactComponent(CostEstimateApi, ({ props, cont
       <div className={classes.header}>
         <MoneyRegular />
         <Subtitle2>{props.title ?? 'Estimated Monthly Cost'}</Subtitle2>
+        {props.source && (
+          <Caption1 className={classes.sourceLabel}>
+            {props.source === 'live' ? '● Live pricing' : '○ Estimated'}
+          </Caption1>
+        )}
       </div>
 
       {resources.length === 0 ? (
@@ -281,6 +309,15 @@ export const CostEstimate = createReactComponent(CostEstimateApi, ({ props, cont
                   )}
                   <td className={`${classes.td} ${classes.tdRight}`}>
                     {formatCost(resource.monthlyEstimate)}
+                    {origResource?.pricingTiers && origResource.pricingTiers.length > 0 && (
+                      <div className={classes.pricingTiers}>
+                        {origResource.pricingTiers.map((tier, j) => (
+                          <span key={j} className={classes.tierBadge}>
+                            {typeof tier.label === 'string' ? tier.label : ''}: {formatCost(tier.monthlyEstimate)}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
Closes #189

## Summary

Wires the `PricingConnector` to the live [Azure Retail Prices API](https://prices.azure.com/api/retail/prices) so that `estimate_cost` returns real pricing data instead of hardcoded stubs.

## Changes

### PricingConnector (`packages/core/src/connectors/PricingConnector.ts`)
- **`fetchRetailPrices()`** — queries the Azure Retail Prices API with OData filters, follows `NextPageLink` pagination, caches results in memory (30-minute TTL)
- **`lookupVmPrice()`** — convenience method for VM SKU pricing by size + region; returns pay-as-you-go, reserved 1-year, and reserved 3-year prices
- **`lookupServicePrice()`** — generic service pricing lookup by name/region/SKU
- **`estimateCost()`** — now tries live API first, falls back to stubs on failure; reports `source: 'live' | 'stub'` in results
- **`clearCache()`** — for session management

### estimate_cost tool (`packages/core/src/tools/estimate-cost.ts`)
- Fetches `PricingConnector` from `defaultConnectorRegistry`
- Calls `lookupVmPrice()` for real VM pricing with reservation tiers
- Reports `source: 'live' | 'stub'` in output
- Removed `_stub: true` flag (replaced by `source` field)

### CostEstimate component (`packages/web/src/catalog/components/CostEstimate.tsx`)
- Added `pricingTiers` support per resource row (e.g., Reserved 1yr, Reserved 3yr)
- Added `source` indicator in header (● Live pricing / ○ Estimated)
- Schema updated with `PricingTierSchema` and `source` enum

### Component catalog (`packages/core/src/prompts/component-catalog.ts`)
- Updated CostEstimate example to use `resources` (not `items`), include `pricingTiers`, and `source`

## Testing

- 16 new unit tests covering: stub fallback, API fetch, caching, pagination, VM lookup, service lookup, reservation tiers, Windows VM filtering, error handling, cache clearing
- All 914 tests pass (`npx vitest run --reporter=dot`)
- TypeScript: `tsc --noEmit` passes for both `packages/core` and `packages/web`

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)