### PR TITLE
fix: ChoicePicker visual selection + single clean message (#208)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -21,7 +21,7 @@ import { healthCheck } from './services/api-client';
 import { isMockMode, isPlaygroundMode } from './services/mock-streaming';
 import { VirtualFileSystem } from './services/virtual-fs';
 import type { AppMode, ChatMessage, A2uiMsg } from './types';
-import type { A2uiClientAction } from './vendor/a2ui/web_core/schema/client-to-server';
+// A2uiClientAction type no longer needed — actions route through useActionDispatch only
 
 const mockEnabled = isMockMode();
 const playgroundEnabled = isPlaygroundMode();
@@ -327,27 +327,6 @@ export function App() {
     }
   }, [sessions, a2ui]);
 
-  // Extract a human-readable label from an A2UI action, checking context then data as fallback
-  const getSelectionLabel = (action: A2uiClientAction): string => {
-    const ctx = action.context as Record<string, unknown> | undefined;
-    const data = (action as Record<string, unknown>).data as Record<string, unknown> | undefined;
-    return (
-      (ctx?.label as string) ??
-      (ctx?.value as string) ??
-      (data?.label as string) ??
-      (data?.value as string) ??
-      action.name
-    );
-  };
-
-  // Convert A2UI component actions into user messages sent back to the conversation.
-  // Fire-and-forget — never block the UI thread on the streaming response.
-  const handleA2UIAction = useCallback((action: A2uiClientAction) => {
-    const label = getSelectionLabel(action);
-    const text = `[Selected: ${label}]`;
-    void handleSendMessage(text).catch(() => {});
-  }, [handleSendMessage]);
-
   const isStreaming = mockEnabled ? mockStreaming.isStreaming : streaming.isStreaming;
   const currentStreamText = mockEnabled ? mockStreaming.streamText : streaming.streamText;
   const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot);
@@ -432,7 +411,6 @@ export function App() {
             currentPhase={currentPhase}
             onSend={handleSendMessage}
             getSurface={a2ui.getSurface}
-            onAction={handleA2UIAction}
             debugEnabled={debugEnabled}
           />
         )}

--- a/packages/web/src/catalog/fluent-components/ChoicePicker.tsx
+++ b/packages/web/src/catalog/fluent-components/ChoicePicker.tsx
@@ -112,6 +112,7 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
   const [filter, setFilter] = useState('');
   const [showContinue, setShowContinue] = useState(false);
   const hasFiredContinueRef = useRef(false);
+  const hasFiredActionRef = useRef(false);
   const classes = useStyles();
   const messageText = useMessageText();
 
@@ -120,7 +121,15 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
   const isMutuallyExclusive = variant === 'mutuallyExclusive';
   const hasAction = typeof props.action === 'function';
 
+  // Local selection state — gives immediate visual feedback before the data
+  // model round-trips and the surface is dimmed by the action handler.
+  const [localValues, setLocalValues] = useState<string[]>(values);
+  useEffect(() => { setLocalValues(values); }, [values.join(',')]);
+  const displayValues = hasFiredActionRef.current ? localValues : values;
+
   const fireAction = () => {
+    if (hasFiredActionRef.current) return;
+    hasFiredActionRef.current = true;
     if (typeof props.action === 'function') {
       (props.action as () => void)();
     }
@@ -128,17 +137,20 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
 
   const onToggle = (val: string) => {
     if (isMutuallyExclusive) {
+      setLocalValues([val]);
       props.setValue([val]);
     } else {
       const newValues = values.includes(val)
         ? values.filter((v: string) => v !== val)
         : [...values, val];
+      setLocalValues(newValues);
       props.setValue(newValues);
     }
     fireAction();
   };
 
   const onRadioChange = (_e: unknown, data: { value: string }) => {
+    setLocalValues([data.value]);
     props.setValue([data.value]);
     fireAction();
   };
@@ -165,9 +177,10 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
   const bestGuessLabel = bestGuessIdx >= 0 ? String(options[bestGuessIdx]?.label ?? '') : '';
 
   const handleContinue = () => {
-    if (hasFiredContinueRef.current || bestGuessIdx < 0) return;
+    if (hasFiredContinueRef.current || hasFiredActionRef.current || bestGuessIdx < 0) return;
     hasFiredContinueRef.current = true;
     const chosen = options[bestGuessIdx];
+    setLocalValues([chosen.value]);
     props.setValue([chosen.value]);
     fireAction();
   };
@@ -187,7 +200,7 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
       {props.displayStyle === 'chips' ? (
         <div className={classes.chipContainer}>
           {options.map((opt: _Option, i: number) => {
-            const isSelected = values.includes(opt.value);
+            const isSelected = displayValues.includes(opt.value);
             return (
               <ToggleButton
                 key={i}
@@ -203,7 +216,7 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
         </div>
       ) : isMutuallyExclusive ? (
         <FluentRadioGroup
-          value={values[0] || ''}
+          value={displayValues[0] || ''}
           onChange={onRadioChange}
         >
           {options.map((opt: _Option, i: number) => (
@@ -215,7 +228,7 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
           {options.map((opt: _Option, i: number) => (
             <Checkbox
               key={i}
-              checked={values.includes(opt.value)}
+              checked={displayValues.includes(opt.value)}
               label={opt.label}
               onChange={() => onToggle(opt.value)}
             />

--- a/packages/web/src/components/A2UI/A2UISurfaceWrapper.tsx
+++ b/packages/web/src/components/A2UI/A2UISurfaceWrapper.tsx
@@ -1,41 +1,21 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import React from 'react';
 import { A2uiSurface } from '../../vendor/a2ui/react/index';
 import type { SurfaceModel } from '../../vendor/a2ui/web_core/index';
-import type { A2uiClientAction } from '../../vendor/a2ui/web_core/schema/client-to-server';
 import type { ReactComponentImplementation } from '../../vendor/a2ui/react/adapter';
 
 interface A2UISurfaceWrapperProps {
   surface: SurfaceModel<ReactComponentImplementation>;
   /** When false, the surface is visually dimmed (past-turn). Defaults to true. */
   isActive?: boolean;
-  /** Optional callback invoked when any component in this surface dispatches an action. */
-  onAction?: (action: A2uiClientAction) => void | Promise<void>;
 }
 
-export function A2UISurfaceWrapper({ surface, isActive = true, onAction }: A2UISurfaceWrapperProps) {
-  // Guard against double-firing: once an action dispatches, block further actions from this surface
-  const hasFiredRef = useRef(false);
-
-  const guardedOnAction = useCallback((action: A2uiClientAction) => {
-    if (hasFiredRef.current || !onAction) return;
-    hasFiredRef.current = true;
-    // Fire-and-forget — don't let errors or async streaming block the UI
-    try { void onAction(action); } catch { /* swallow */ }
-  }, [onAction]);
-
-  useEffect(() => {
-    if (!onAction) return;
-    const sub = surface.onAction.subscribe(guardedOnAction);
-    return () => sub.unsubscribe();
-  }, [surface, guardedOnAction, onAction]);
-
+export function A2UISurfaceWrapper({ surface, isActive = true }: A2UISurfaceWrapperProps) {
   return (
     <div
       className="a2ui-surface-wrapper"
       style={{
         borderRadius: 'var(--radius-large, 8px)',
         overflow: 'hidden',
-        // Past-turn surfaces are visually dimmed but remain scrollable and selectable
         ...(isActive ? {} : { opacity: 0.5 }),
       }}
     >

--- a/packages/web/src/components/Chat/ChatMessage.tsx
+++ b/packages/web/src/components/Chat/ChatMessage.tsx
@@ -6,21 +6,16 @@ import { MessageTextProvider } from '../../contexts/MessageTextContext';
 import { sanitizeHtml } from '../../utils/sanitize';
 import type { ChatMessage as ChatMessageType } from '../../types';
 import type { SurfaceModel } from '../../vendor/a2ui/web_core/index';
-import type { A2uiClientAction } from '../../vendor/a2ui/web_core/schema/client-to-server';
 import type { ReactComponentImplementation } from '../../vendor/a2ui/react/adapter';
 
 interface ChatMessageProps {
   message: ChatMessageType;
   getSurface: (id: string) => SurfaceModel<ReactComponentImplementation> | undefined;
-  /** When false, A2UI surfaces in this message are dimmed and non-interactive. Defaults to true. */
   isActive?: boolean;
-  /** Optional callback invoked when any component in this message dispatches an action. */
-  onAction?: (action: A2uiClientAction) => void | Promise<void>;
-  /** When true, show the debug panel below assistant messages. */
   debugEnabled?: boolean;
 }
 
-export function ChatMessage({ message, getSurface, isActive = true, onAction, debugEnabled = false }: ChatMessageProps) {
+export function ChatMessage({ message, getSurface, isActive = true, debugEnabled = false }: ChatMessageProps) {
   if (message.role === 'user') {
     if (message.isAutoContinue) {
       return (
@@ -57,7 +52,7 @@ export function ChatMessage({ message, getSurface, isActive = true, onAction, de
             if (!surface) return null;
             return (
               <div key={surfaceId} className="a2ui-component">
-                <A2UISurfaceWrapper surface={surface} isActive={isActive} onAction={onAction} />
+                <A2UISurfaceWrapper surface={surface} isActive={isActive} />
               </div>
             );
           })}

--- a/packages/web/src/components/Chat/ChatShell.tsx
+++ b/packages/web/src/components/Chat/ChatShell.tsx
@@ -3,7 +3,6 @@ import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import type { ChatMessage } from '../../types';
 import type { SurfaceModel } from '../../vendor/a2ui/web_core/index';
-import type { A2uiClientAction } from '../../vendor/a2ui/web_core/schema/client-to-server';
 import type { ReactComponentImplementation } from '../../vendor/a2ui/react/adapter';
 
 const PHASE_LABELS: Record<string, string> = {
@@ -24,11 +23,10 @@ interface ChatShellProps {
   currentPhase?: string | null;
   onSend: (text: string) => void;
   getSurface: (id: string) => SurfaceModel<ReactComponentImplementation> | undefined;
-  onAction?: (action: A2uiClientAction) => void | Promise<void>;
   debugEnabled?: boolean;
 }
 
-export function ChatShell({ messages, isStreaming, streamingText, streamingSurfaceIds, currentPhase, onSend, getSurface, onAction, debugEnabled }: ChatShellProps) {
+export function ChatShell({ messages, isStreaming, streamingText, streamingSurfaceIds, currentPhase, onSend, getSurface, debugEnabled }: ChatShellProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to bottom on new messages or streaming updates
@@ -63,7 +61,6 @@ export function ChatShell({ messages, isStreaming, streamingText, streamingSurfa
             streamingText={streamingText}
             streamingSurfaceIds={streamingSurfaceIds}
             getSurface={getSurface}
-            onAction={onAction}
             debugEnabled={debugEnabled}
           />
           <div ref={messagesEndRef} />

--- a/packages/web/src/components/Chat/MessageList.tsx
+++ b/packages/web/src/components/Chat/MessageList.tsx
@@ -4,7 +4,6 @@ import { TypingIndicator } from './TypingIndicator';
 import { A2UISurfaceWrapper } from '../A2UI/A2UISurfaceWrapper';
 import type { ChatMessage as ChatMessageType } from '../../types';
 import type { SurfaceModel } from '../../vendor/a2ui/web_core/index';
-import type { A2uiClientAction } from '../../vendor/a2ui/web_core/schema/client-to-server';
 import type { ReactComponentImplementation } from '../../vendor/a2ui/react/adapter';
 
 interface MessageListProps {
@@ -13,11 +12,10 @@ interface MessageListProps {
   streamingText: string;
   streamingSurfaceIds?: string[];
   getSurface: (id: string) => SurfaceModel<ReactComponentImplementation> | undefined;
-  onAction?: (action: A2uiClientAction) => void | Promise<void>;
   debugEnabled?: boolean;
 }
 
-export function MessageList({ messages, isStreaming, streamingText, streamingSurfaceIds, getSurface, onAction, debugEnabled }: MessageListProps) {
+export function MessageList({ messages, isStreaming, streamingText, streamingSurfaceIds, getSurface, debugEnabled }: MessageListProps) {
   const lastIndex = messages.length - 1;
   const hasStreamingSurfaces = (streamingSurfaceIds?.length ?? 0) > 0;
 
@@ -29,7 +27,6 @@ export function MessageList({ messages, isStreaming, streamingText, streamingSur
           message={msg}
           getSurface={getSurface}
           isActive={index === lastIndex}
-          onAction={onAction}
           debugEnabled={debugEnabled}
         />
       ))}
@@ -60,7 +57,7 @@ export function MessageList({ messages, isStreaming, streamingText, streamingSur
                   className="a2ui-component a2ui-component--entering"
                   style={{ '--enter-index': index } as React.CSSProperties}
                 >
-                  <A2UISurfaceWrapper surface={surface} isActive={true} onAction={onAction} />
+                  <A2UISurfaceWrapper surface={surface} isActive={true} />
                 </div>
               );
             })}

--- a/packages/web/src/hooks/useActionDispatch.ts
+++ b/packages/web/src/hooks/useActionDispatch.ts
@@ -39,7 +39,8 @@ function categorize(actionName: string): ActionCategory {
 
 /**
  * Translates an A2UI action into a human-readable message suitable for
- * re-prompting the LLM. The LLM stays in full control of state transitions.
+ * re-prompting the LLM. Prefers showing the selected value over raw
+ * action metadata so the chat bubble reads naturally (e.g. "Selected: Web API").
  */
 function actionToMessage(action: A2uiClientAction): string {
   const { name, context } = action;
@@ -47,18 +48,27 @@ function actionToMessage(action: A2uiClientAction): string {
   // Strip any routing prefix for the message
   const cleanName = name.replace(/^(navigate:|nav:|api:)/, '');
 
-  // Build context summary from key-value pairs
-  const contextParts: string[] = [];
+  // Try to extract a meaningful selection value from context
   if (context && typeof context === 'object') {
+    // Prefer 'value' (the user's actual selection) over 'label' (component title)
+    const rawValue = context.value ?? context.selectedValue;
+    if (rawValue !== undefined && rawValue !== null && rawValue !== '') {
+      const valueStr = Array.isArray(rawValue) ? rawValue.join(', ') : String(rawValue);
+      if (valueStr) {
+        return `[Selected: ${valueStr}]`;
+      }
+    }
+
+    // Fallback: build context summary from all key-value pairs
+    const contextParts: string[] = [];
     for (const [key, value] of Object.entries(context)) {
       if (value !== undefined && value !== null && value !== '') {
         contextParts.push(`${key}: ${String(value)}`);
       }
     }
-  }
-
-  if (contextParts.length > 0) {
-    return `[Action: ${cleanName}] ${contextParts.join(', ')}`;
+    if (contextParts.length > 0) {
+      return `[Action: ${cleanName}] ${contextParts.join(', ')}`;
+    }
   }
 
   return `[Action: ${cleanName}]`;


### PR DESCRIPTION
Closes #208

## What changed

### Bug 1: Duplicate user messages → Single clean message
Removed the second action→message path (`handleA2UIAction` + `onAction` prop chain through `ChatShell`/`MessageList`/`ChatMessage`/`A2UISurfaceWrapper`). Actions now route exclusively through the `MessageProcessor` → `useActionDispatch` handler.

The `actionToMessage` helper now prefers `context.value` (the actual selection) over `context.label` (the component title), producing `[Selected: ...]` instead of raw `[Action: ...]` echoes.

### Bug 2: Radio buttons don't visually fill → Immediate feedback
Added local selection state (`localValues`/`displayValues`) in `ChoicePicker` so radio buttons, checkboxes, and chips show the chosen option immediately, before the data-model round-trip and surface dimming. Also guards `fireAction` with `hasFiredActionRef` to prevent duplicate dispatches from rapid clicks.

## Files changed
- `App.tsx` — removed `handleA2UIAction`, `getSelectionLabel`, `onAction` prop
- `A2UISurfaceWrapper.tsx` — removed `onAction` prop + subscription (simplified)
- `ChatShell.tsx`, `MessageList.tsx`, `ChatMessage.tsx` — removed `onAction` prop forwarding
- `ChoicePicker.tsx` — local visual state + action guard
- `useActionDispatch.ts` — `actionToMessage` prefers `context.value`

🤖 Working as Fry (Frontend Dev)