### PR TITLE
feat: Copilot skills registry and system prompt integration (#186)

### DIFF
--- a/packages/core/src/__tests__/copilot-skills-registry.test.ts
+++ b/packages/core/src/__tests__/copilot-skills-registry.test.ts
@@ -1,0 +1,310 @@
+/**
+ * B-186 — Copilot Skills Registry
+ *
+ * Tests for:
+ *   • CopilotSkillsRegistry — register, unregister, get, getAll, resolve
+ *   • AZURE_COPILOT_SKILLS — default skill set
+ *   • formatCopilotSkillsPrompt — prompt formatting
+ *   • buildSystemPrompt copilotSkillsPrompt injection
+ *   • defaultCopilotSkillsRegistry — pre-loaded instance
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  CopilotSkillsRegistry,
+  defaultCopilotSkillsRegistry,
+  AZURE_COPILOT_SKILLS,
+  formatCopilotSkillsPrompt,
+} from "../engine/copilot-skills-registry.js";
+import type { CopilotSkill } from "../engine/copilot-skills-registry.js";
+import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import { Phase } from "../engine/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSkill(id: string, overrides: Partial<CopilotSkill> = {}): CopilotSkill {
+  return {
+    id,
+    name: `Skill ${id}`,
+    description: `Description for ${id}`,
+    triggerKeywords: [id],
+    documentationUrl: `https://example.com/${id}`,
+    extensionName: "Test Extension",
+    ...overrides,
+  };
+}
+
+// ── Registry CRUD ────────────────────────────────────────────────────────────
+
+describe("CopilotSkillsRegistry — CRUD", () => {
+  let registry: CopilotSkillsRegistry;
+
+  beforeEach(() => {
+    registry = new CopilotSkillsRegistry();
+  });
+
+  it("starts empty", () => {
+    expect(registry.size).toBe(0);
+    expect(registry.getAll()).toEqual([]);
+  });
+
+  it("registers and retrieves a skill", () => {
+    const skill = makeSkill("test-1");
+    registry.register(skill);
+    expect(registry.size).toBe(1);
+    expect(registry.get("test-1")).toEqual(skill);
+  });
+
+  it("overwrites existing skill with same ID", () => {
+    registry.register(makeSkill("dup", { name: "Original" }));
+    registry.register(makeSkill("dup", { name: "Updated" }));
+    expect(registry.size).toBe(1);
+    expect(registry.get("dup")!.name).toBe("Updated");
+  });
+
+  it("registerAll adds multiple skills", () => {
+    registry.registerAll([makeSkill("a"), makeSkill("b"), makeSkill("c")]);
+    expect(registry.size).toBe(3);
+  });
+
+  it("unregister removes a skill", () => {
+    registry.register(makeSkill("to-remove"));
+    expect(registry.unregister("to-remove")).toBe(true);
+    expect(registry.size).toBe(0);
+    expect(registry.get("to-remove")).toBeUndefined();
+  });
+
+  it("unregister returns false for non-existent ID", () => {
+    expect(registry.unregister("nope")).toBe(false);
+  });
+
+  it("clear removes all skills", () => {
+    registry.registerAll([makeSkill("x"), makeSkill("y")]);
+    registry.clear();
+    expect(registry.size).toBe(0);
+  });
+});
+
+// ── Registry resolve ─────────────────────────────────────────────────────────
+
+describe("CopilotSkillsRegistry — resolve", () => {
+  let registry: CopilotSkillsRegistry;
+
+  beforeEach(() => {
+    registry = new CopilotSkillsRegistry();
+    registry.registerAll([
+      makeSkill("aks", { triggerKeywords: ["kubernetes", "aks", "cluster"] }),
+      makeSkill("sql", { triggerKeywords: ["sql database", "azure sql"] }),
+      makeSkill("functions", { triggerKeywords: ["serverless", "azure functions"] }),
+    ]);
+  });
+
+  it("returns empty when no conversation history", () => {
+    const result = registry.resolve();
+    expect(result.matched).toEqual([]);
+    expect(result.promptSection).toBe("");
+  });
+
+  it("returns empty when conversation history is empty array", () => {
+    const result = registry.resolve([]);
+    expect(result.matched).toEqual([]);
+  });
+
+  it("matches skills by keyword in conversation", () => {
+    const result = registry.resolve(["I want to deploy to a kubernetes cluster"]);
+    expect(result.matched.length).toBe(1);
+    expect(result.matched[0].id).toBe("aks");
+  });
+
+  it("matches multiple skills when multiple keywords hit", () => {
+    const result = registry.resolve([
+      "I need a kubernetes cluster with an azure sql database",
+    ]);
+    expect(result.matched.length).toBe(2);
+    const ids = result.matched.map((s) => s.id);
+    expect(ids).toContain("aks");
+    expect(ids).toContain("sql");
+  });
+
+  it("keyword matching is case-insensitive", () => {
+    const result = registry.resolve(["Deploy to AKS cluster"]);
+    expect(result.matched.length).toBe(1);
+    expect(result.matched[0].id).toBe("aks");
+  });
+
+  it("no match returns empty matched array", () => {
+    const result = registry.resolve(["I want to build a React app"]);
+    expect(result.matched).toEqual([]);
+    expect(result.promptSection).toBe("");
+  });
+
+  it("scans across multiple conversation messages", () => {
+    const result = registry.resolve([
+      "First, set up the backend",
+      "I'll use serverless functions",
+    ]);
+    expect(result.matched.length).toBe(1);
+    expect(result.matched[0].id).toBe("functions");
+  });
+});
+
+// ── formatCopilotSkillsPrompt ────────────────────────────────────────────────
+
+describe("formatCopilotSkillsPrompt", () => {
+  it("returns empty string for empty skills array", () => {
+    expect(formatCopilotSkillsPrompt([])).toBe("");
+  });
+
+  it("formats skills into a markdown section", () => {
+    const prompt = formatCopilotSkillsPrompt([
+      makeSkill("test", {
+        name: "Test Skill",
+        extensionName: "Test Extension",
+        description: "Does testing things",
+        documentationUrl: "https://example.com/test",
+      }),
+    ]);
+
+    expect(prompt).toContain("## Copilot Extensions");
+    expect(prompt).toContain("**Test Skill**");
+    expect(prompt).toContain("Test Extension");
+    expect(prompt).toContain("Does testing things");
+    expect(prompt).toContain("https://example.com/test");
+    expect(prompt).toContain("Do NOT attempt to invoke");
+  });
+
+  it("lists multiple skills", () => {
+    const prompt = formatCopilotSkillsPrompt([
+      makeSkill("a", { name: "Skill A" }),
+      makeSkill("b", { name: "Skill B" }),
+    ]);
+
+    expect(prompt).toContain("**Skill A**");
+    expect(prompt).toContain("**Skill B**");
+  });
+});
+
+// ── AZURE_COPILOT_SKILLS ─────────────────────────────────────────────────────
+
+describe("AZURE_COPILOT_SKILLS", () => {
+  it("contains at least 5 skills", () => {
+    expect(AZURE_COPILOT_SKILLS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("all skills have required fields", () => {
+    for (const skill of AZURE_COPILOT_SKILLS) {
+      expect(skill.id).toBeTruthy();
+      expect(skill.name).toBeTruthy();
+      expect(skill.description).toBeTruthy();
+      expect(skill.triggerKeywords.length).toBeGreaterThan(0);
+      expect(skill.documentationUrl).toMatch(/^https:\/\//);
+      expect(skill.extensionName).toBe("GitHub Copilot for Azure");
+    }
+  });
+
+  it("has unique IDs", () => {
+    const ids = AZURE_COPILOT_SKILLS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("includes AKS skill", () => {
+    const aks = AZURE_COPILOT_SKILLS.find((s) => s.id === "copilot-azure-aks");
+    expect(aks).toBeDefined();
+    expect(aks!.triggerKeywords).toContain("kubernetes");
+  });
+
+  it("includes App Service skill", () => {
+    const appService = AZURE_COPILOT_SKILLS.find(
+      (s) => s.id === "copilot-azure-app-service",
+    );
+    expect(appService).toBeDefined();
+  });
+
+  it("includes Azure Functions skill", () => {
+    const functions = AZURE_COPILOT_SKILLS.find(
+      (s) => s.id === "copilot-azure-functions",
+    );
+    expect(functions).toBeDefined();
+    expect(functions!.triggerKeywords).toContain("serverless");
+  });
+
+  it("includes Container Apps skill", () => {
+    const aca = AZURE_COPILOT_SKILLS.find(
+      (s) => s.id === "copilot-azure-container-apps",
+    );
+    expect(aca).toBeDefined();
+  });
+
+  it("includes Azure SQL skill", () => {
+    const sql = AZURE_COPILOT_SKILLS.find(
+      (s) => s.id === "copilot-azure-sql",
+    );
+    expect(sql).toBeDefined();
+  });
+});
+
+// ── defaultCopilotSkillsRegistry ─────────────────────────────────────────────
+
+describe("defaultCopilotSkillsRegistry", () => {
+  it("is pre-loaded with Azure skills", () => {
+    expect(defaultCopilotSkillsRegistry.size).toBe(AZURE_COPILOT_SKILLS.length);
+  });
+
+  it("resolves AKS skill from kubernetes conversation", () => {
+    const result = defaultCopilotSkillsRegistry.resolve([
+      "I need to deploy my app to kubernetes",
+    ]);
+    expect(result.matched.some((s) => s.id === "copilot-azure-aks")).toBe(true);
+    expect(result.promptSection).toContain("## Copilot Extensions");
+  });
+});
+
+// ── buildSystemPrompt integration ────────────────────────────────────────────
+
+describe("buildSystemPrompt with copilotSkillsPrompt", () => {
+  it("injects Copilot Extensions section when copilotSkillsPrompt is provided", () => {
+    const skillsPrompt = formatCopilotSkillsPrompt([
+      makeSkill("test", { name: "Test Copilot Skill" }),
+    ]);
+    const prompt = buildSystemPrompt({
+      phase: Phase.Design,
+      copilotSkillsPrompt: skillsPrompt,
+    });
+
+    expect(prompt).toContain("## Copilot Extensions");
+    expect(prompt).toContain("Test Copilot Skill");
+  });
+
+  it("does not inject section when copilotSkillsPrompt is empty string", () => {
+    const prompt = buildSystemPrompt({
+      phase: Phase.Design,
+      copilotSkillsPrompt: "",
+    });
+
+    expect(prompt).not.toContain("## Copilot Extensions");
+  });
+
+  it("does not inject section when copilotSkillsPrompt is undefined", () => {
+    const prompt = buildSystemPrompt({
+      phase: Phase.Design,
+    });
+
+    expect(prompt).not.toContain("## Copilot Extensions");
+  });
+
+  it("places Copilot Extensions after Available Capabilities", () => {
+    const skillsPrompt = formatCopilotSkillsPrompt([
+      makeSkill("test", { name: "Ext Skill" }),
+    ]);
+    const prompt = buildSystemPrompt({
+      phase: Phase.Design,
+      kitPrompts: ["Some kit capability"],
+      copilotSkillsPrompt: skillsPrompt,
+    });
+
+    const capIdx = prompt.indexOf("## Available Capabilities");
+    const extIdx = prompt.indexOf("## Copilot Extensions");
+    expect(capIdx).toBeGreaterThan(-1);
+    expect(extIdx).toBeGreaterThan(capIdx);
+  });
+});

--- a/packages/core/src/engine/copilot-skills-registry.ts
+++ b/packages/core/src/engine/copilot-skills-registry.ts
@@ -1,0 +1,267 @@
+/**
+ * @module @kickstart/core/engine/copilot-skills-registry
+ *
+ * CopilotSkillsRegistry — catalogs publicly available Copilot extension
+ * skills (e.g. "GitHub Copilot for Azure") so the LLM can suggest them
+ * when the conversation touches a relevant domain.
+ *
+ * These are NOT the same as IntegrationKit skills (internal domain
+ * knowledge). Copilot skills are external extensions the user can invoke
+ * in their IDE or enable in their environment. The registry only provides
+ * awareness — no actual invocation happens here.
+ *
+ * Security: skill metadata is static, first-party data. No user input is
+ * stored in the registry. The generated prompt text contains only
+ * pre-defined strings — no injection vectors.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A publicly available Copilot extension skill. */
+export interface CopilotSkill {
+  /** Unique identifier, e.g. "copilot-azure-aks" */
+  id: string;
+  /** Human-readable name shown in suggestions */
+  name: string;
+  /** Short description of what this skill does */
+  description: string;
+  /** Keywords that trigger this skill suggestion when found in conversation */
+  triggerKeywords: string[];
+  /** URL to the skill's documentation or marketplace page */
+  documentationUrl: string;
+  /** The Copilot extension that provides this skill */
+  extensionName: string;
+  /** Optional icon hint for UI rendering */
+  icon?: string;
+}
+
+/** Result of resolving copilot skills against conversation context. */
+export interface ResolvedCopilotSkills {
+  /** Skills matched by keyword analysis */
+  matched: CopilotSkill[];
+  /** Formatted prompt section ready for system prompt injection */
+  promptSection: string;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Registry of publicly available Copilot extension skills.
+ *
+ * Thread-safe for reads (immutable after construction in practice).
+ * Skills are registered at startup and queried per-conversation-turn.
+ */
+export class CopilotSkillsRegistry {
+  private readonly skills = new Map<string, CopilotSkill>();
+
+  /** Register a skill. Overwrites if the ID already exists. */
+  register(skill: CopilotSkill): void {
+    this.skills.set(skill.id, skill);
+  }
+
+  /** Register multiple skills at once. */
+  registerAll(skills: CopilotSkill[]): void {
+    for (const skill of skills) {
+      this.register(skill);
+    }
+  }
+
+  /** Unregister a skill by ID. */
+  unregister(id: string): boolean {
+    return this.skills.delete(id);
+  }
+
+  /** Get a skill by ID. */
+  get(id: string): CopilotSkill | undefined {
+    return this.skills.get(id);
+  }
+
+  /** Get all registered skills. */
+  getAll(): CopilotSkill[] {
+    return Array.from(this.skills.values());
+  }
+
+  /** Number of registered skills. */
+  get size(): number {
+    return this.skills.size;
+  }
+
+  /** Remove all registered skills. */
+  clear(): void {
+    this.skills.clear();
+  }
+
+  /**
+   * Resolve which Copilot skills are relevant to the current conversation
+   * by scanning conversation history for trigger keywords.
+   *
+   * Returns matched skills and a formatted prompt section for injection
+   * into the system prompt.
+   */
+  resolve(conversationHistory?: string[]): ResolvedCopilotSkills {
+    if (!conversationHistory || conversationHistory.length === 0) {
+      return { matched: [], promptSection: "" };
+    }
+
+    const combined = conversationHistory.join(" ").toLowerCase();
+    const matched: CopilotSkill[] = [];
+
+    for (const skill of this.skills.values()) {
+      const hit = skill.triggerKeywords.some((kw) =>
+        combined.includes(kw.toLowerCase()),
+      );
+      if (hit) {
+        matched.push(skill);
+      }
+    }
+
+    return {
+      matched,
+      promptSection: formatCopilotSkillsPrompt(matched),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format matched Copilot skills into a system prompt section.
+ *
+ * The prompt instructs the LLM to mention the relevant Copilot extension
+ * when the conversation topic matches — giving users actionable guidance
+ * without the LLM attempting to invoke the extension itself.
+ */
+export function formatCopilotSkillsPrompt(skills: CopilotSkill[]): string {
+  if (skills.length === 0) return "";
+
+  const entries = skills
+    .map(
+      (s) =>
+        `- **${s.name}** (${s.extensionName}): ${s.description}\n  Docs: ${s.documentationUrl}`,
+    )
+    .join("\n");
+
+  return [
+    "## Copilot Extensions",
+    "",
+    "The following Copilot extensions can help the user with their current scenario.",
+    "When the conversation touches these domains, mention the relevant extension",
+    "and suggest the user invoke it (e.g. `@azure` in their IDE) for deeper assistance.",
+    "Do NOT attempt to invoke these extensions yourself — just make the user aware.",
+    "",
+    entries,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Default registry with Azure skills
+// ---------------------------------------------------------------------------
+
+/** Pre-configured Azure Copilot skills. */
+export const AZURE_COPILOT_SKILLS: CopilotSkill[] = [
+  {
+    id: "copilot-azure-aks",
+    name: "Azure Kubernetes Service",
+    description:
+      "Deploy, manage, and troubleshoot AKS clusters. Get help with kubectl commands, scaling, networking, and cluster diagnostics.",
+    triggerKeywords: [
+      "aks",
+      "kubernetes",
+      "kubectl",
+      "cluster",
+      "helm",
+      "k8s",
+      "container orchestration",
+      "node pool",
+      "ingress controller",
+    ],
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/azure/aks/copilot",
+    extensionName: "GitHub Copilot for Azure",
+    icon: "aks",
+  },
+  {
+    id: "copilot-azure-app-service",
+    name: "Azure App Service",
+    description:
+      "Deploy and manage web apps, REST APIs, and backends. Get help with deployment slots, scaling, custom domains, and diagnostics.",
+    triggerKeywords: [
+      "app service",
+      "web app",
+      "webapp",
+      "deployment slot",
+      "app service plan",
+      "paas",
+    ],
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/azure/app-service/copilot",
+    extensionName: "GitHub Copilot for Azure",
+    icon: "app-service",
+  },
+  {
+    id: "copilot-azure-functions",
+    name: "Azure Functions",
+    description:
+      "Build and deploy serverless functions. Get help with triggers, bindings, Durable Functions, and function app configuration.",
+    triggerKeywords: [
+      "azure functions",
+      "serverless",
+      "function app",
+      "durable functions",
+      "trigger",
+      "bindings",
+      "consumption plan",
+    ],
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/azure/azure-functions/copilot",
+    extensionName: "GitHub Copilot for Azure",
+    icon: "functions",
+  },
+  {
+    id: "copilot-azure-container-apps",
+    name: "Azure Container Apps",
+    description:
+      "Deploy and manage containerized microservices. Get help with Dapr integration, scaling rules, revisions, and ingress configuration.",
+    triggerKeywords: [
+      "container apps",
+      "container app",
+      "aca",
+      "dapr",
+      "microservices",
+      "revision",
+      "containerized",
+    ],
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/azure/container-apps/copilot",
+    extensionName: "GitHub Copilot for Azure",
+    icon: "container-apps",
+  },
+  {
+    id: "copilot-azure-sql",
+    name: "Azure SQL",
+    description:
+      "Manage Azure SQL databases and query optimization. Get help with performance tuning, security configuration, and migration strategies.",
+    triggerKeywords: [
+      "azure sql",
+      "sql database",
+      "sql server",
+      "azure database",
+      "sql managed instance",
+      "database migration",
+    ],
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/azure/azure-sql/copilot/copilot-azure-sql-overview",
+    extensionName: "GitHub Copilot for Azure",
+    icon: "sql",
+  },
+];
+
+/** Default registry pre-loaded with Azure Copilot skills. */
+export const defaultCopilotSkillsRegistry = new CopilotSkillsRegistry();
+defaultCopilotSkillsRegistry.registerAll(AZURE_COPILOT_SKILLS);

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -31,6 +31,14 @@ export {
 export type { ResolvedSkills, SkillResolverMiddleware } from "./skill-resolver.js";
 
 export {
+  CopilotSkillsRegistry,
+  defaultCopilotSkillsRegistry,
+  AZURE_COPILOT_SKILLS,
+  formatCopilotSkillsPrompt,
+} from "./copilot-skills-registry.js";
+export type { CopilotSkill, ResolvedCopilotSkills } from "./copilot-skills-registry.js";
+
+export {
   resolveDataPath,
   resolveChainedPointer,
   interpolateTemplate,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,10 @@ export {
   interpolateTemplate,
   createDefaultValues,
   interpolateA2UIMessage,
+  CopilotSkillsRegistry,
+  defaultCopilotSkillsRegistry,
+  AZURE_COPILOT_SKILLS,
+  formatCopilotSkillsPrompt,
 } from "./engine/index.js";
 export type {
   PhaseStatus,
@@ -76,6 +80,8 @@ export type {
   Skill,
   SkillResolverContext,
   SkillResolverMiddleware,
+  CopilotSkill,
+  ResolvedCopilotSkills,
 } from "./engine/index.js";
 
 // Generators

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -64,6 +64,12 @@ export interface SystemPromptContext {
    * Merged with the base catalog when generating the §5 component catalog.
    */
   kitComponentEntries?: ComponentCatalogEntry[];
+  /**
+   * Pre-formatted Copilot extension skills prompt section.
+   * When non-empty, appended after Available Capabilities so the LLM
+   * can suggest relevant public Copilot extensions to the user.
+   */
+  copilotSkillsPrompt?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -506,6 +512,11 @@ export function buildSystemPrompt(context: SystemPromptContext): string {
   if (context.kitPrompts && context.kitPrompts.length > 0) {
     const capabilities = context.kitPrompts.map((p) => p.trim()).join("\n\n");
     parts.push(`\n## Available Capabilities\n\n${capabilities}`);
+  }
+
+  // Copilot extension skills — suggest public extensions when relevant
+  if (context.copilotSkillsPrompt) {
+    parts.push(`\n${context.copilotSkillsPrompt}`);
   }
 
   return parts.join("\n\n");


### PR DESCRIPTION
Closes #186

## What

Adds a `CopilotSkillsRegistry` in `packages/core` that catalogs publicly available Copilot extension skills (e.g. GitHub Copilot for Azure). When the conversation touches a relevant domain, the LLM can suggest the user invoke the appropriate Copilot extension.

## Changes

- **`copilot-skills-registry.ts`** — `CopilotSkill` type, `CopilotSkillsRegistry` class, `formatCopilotSkillsPrompt()`, 5 pre-configured Azure skills (AKS, App Service, Functions, Container Apps, Azure SQL)
- **`system-prompt.ts`** — `copilotSkillsPrompt` field on `SystemPromptContext`; injected after Available Capabilities
- **`engine/index.ts` + `index.ts`** — public exports
- **`copilot-skills-registry.test.ts`** — 31 tests covering CRUD, resolve, formatting, and system prompt injection

## Design

- Awareness only — no actual extension invocation. The LLM mentions relevant extensions and suggests the user invoke them.
- Keyword-based resolution scans conversation history, same pattern as the existing skill resolver.
- Separate from `IntegrationKit.skills` (internal domain knowledge) — Copilot skills represent external extensions.
- Static, first-party metadata only — no injection vectors.

## Testing

- `npx tsc --noEmit` passes in both `core` and `web`
- 31 new tests pass
- All 952 existing tests pass

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)
Working as Bender (Backend Dev)