### PR TITLE
fix: add github-token to heartbeat workflow

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -51,6 +51,7 @@ jobs:
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const path = 'triage-results.json';


### PR DESCRIPTION
Fixes heartbeat workflow failure caused by missing github-token input.

## Problem
The 'Ralph — Apply triage decisions' step in squad-heartbeat.yml was failing with:
```
Error: Input required and not supplied: github-token
```

The `actions/github-script@v7` action requires explicit `github-token` input, but this step was missing it.

## Solution
Added explicit `github-token: ${{ secrets.GITHUB_TOKEN }}` input to the github-script action.

Note: The other github-script steps in the workflow (lines 102 and 161) already had this input configured correctly.

🤖 Created by Fry (Frontend Dev)