### PR TITLE
Move 'Restart Tour' from footer to a discoverable hero-area link

### DIFF
--- a/packages/web/css/landing.css
+++ b/packages/web/css/landing.css
@@ -255,6 +255,31 @@
   100% { transform: translateX(-100%); }
 }
 
+/* ---------- Tour Prompt ---------- */
+.landing-tour-prompt {
+  text-align: center;
+}
+
+.landing-tour-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  background: none;
+  border: none;
+  padding: var(--spacing-xs) var(--spacing-m);
+  border-radius: var(--radius-medium);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-200);
+  color: var(--color-neutral-foreground-3);
+  cursor: pointer;
+  transition: color var(--duration-fast), background var(--duration-fast);
+}
+
+.landing-tour-link:hover {
+  color: var(--color-brand-primary);
+  background: var(--color-neutral-background-1-hover, rgba(0,0,0,0.03));
+}
+
 /* ---------- Framework Section ---------- */
 .framework-section {
   display: flex;

--- a/packages/web/src/components/Landing.tsx
+++ b/packages/web/src/components/Landing.tsx
@@ -8,7 +8,7 @@ import {
   DialogActions,
   Button,
 } from '@fluentui/react-components';
-import { Sparkle24Regular } from '@fluentui/react-icons';
+import { Sparkle24Regular, Map16Regular } from '@fluentui/react-icons';
 import type { Session } from '../types';
 import { apiFetch } from '../services/api-client';
 import { OnboardingTour, resetOnboardingTour } from './OnboardingTour';
@@ -230,6 +230,14 @@ export function Landing({ onStartChat, recentSessions, onResumeSession, onDelete
           </div>
         </div>
 
+        {/* Tour prompt */}
+        <div className="landing-tour-prompt">
+          <button className="landing-tour-link" onClick={resetOnboardingTour}>
+            <Map16Regular />
+            New here? Take a tour
+          </button>
+        </div>
+
         {/* Track Cards */}
         <div className="landing-tracks">
           {TRACKS.map(track => (
@@ -330,7 +338,6 @@ export function Landing({ onStartChat, recentSessions, onResumeSession, onDelete
               >{__BUILD_SHA__}</a>
             </span>
             <a className="landing-footer-link" href="?playground">Playground</a>
-            <button className="landing-footer-link landing-footer-restart-tour" onClick={resetOnboardingTour}>Restart Tour</button>
           </div>
         </footer>
 


### PR DESCRIPTION
## What changed

Moved the **Restart Tour** button out of the footer metadata line (where it was wedged between version info and the Playground link) and into a more intentional, discoverable spot — a subtle **"New here? Take a tour"** link placed between the hero input and the track cards.

### Why

The old placement felt like an afterthought. This new position is:
- **Discoverable** — right in the main content flow where returning users will naturally look
- **Unobtrusive** — muted color, no border, doesn't compete with the primary CTAs
- **Intentional** — uses a Fluent UI `Map16Regular` icon for visual affinity with the tour concept

### Changes
- `packages/web/src/components/Landing.tsx` — moved the tour button to a new `.landing-tour-prompt` section below the hero input; removed it from the footer
- `packages/web/css/landing.css` — added styles for the new tour link

### Verification
- ✅ TypeScript passes (`npx tsc --noEmit`)
- ✅ All 1016 tests pass (`npx vitest run`)
- ✅ `resetOnboardingTour()` still wired correctly on click

---
🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)