### PR TITLE
fix: clean up user display in topbar — friendly name + dropdown sign-out

### DIFF
--- a/packages/web/css/core.css
+++ b/packages/web/css/core.css
@@ -174,15 +174,18 @@ html, body {
 }
 
 .topbar-avatar {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border-radius: var(--radius-circular);
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.2);
+  border: 1.5px solid rgba(255, 255, 255, 0.35);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-200);
   font-weight: var(--font-weight-semibold);
+  color: inherit;
+  flex-shrink: 0;
 }
 
 .topbar-avatar-img {
@@ -197,6 +200,78 @@ html, body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* ── Authenticated user menu ──────────────────────────────────────── */
+.topbar-user-menu {
+  position: relative;
+}
+
+.topbar-user-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 4px 10px 4px 4px;
+  border: none;
+  border-radius: var(--radius-circular);
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--duration-fast) var(--easing-ease);
+}
+
+.topbar-user-trigger:hover,
+.topbar-user-trigger:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.topbar-user-trigger:active {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.topbar-user-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  min-width: 180px;
+  padding: var(--spacing-s) 0;
+  border-radius: var(--radius-medium);
+  background: var(--color-neutral-background-1);
+  color: var(--color-neutral-foreground-1);
+  box-shadow: var(--shadow-16);
+  border: 1px solid var(--color-neutral-stroke-2);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar-user-dropdown-email {
+  padding: var(--spacing-xs) var(--spacing-m);
+  font-size: var(--font-size-100);
+  color: var(--color-neutral-foreground-3);
+  border-bottom: 1px solid var(--color-neutral-stroke-2);
+  margin-bottom: var(--spacing-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topbar-user-dropdown-signout {
+  padding: var(--spacing-xs) var(--spacing-m);
+  font-size: var(--font-size-200);
+  color: var(--color-neutral-foreground-1);
+  text-decoration: none;
+  border-radius: 0;
+  transition: background var(--duration-fast) var(--easing-ease);
+}
+
+.topbar-user-dropdown-signout:hover {
+  background: var(--color-neutral-background-1-hover, rgba(0, 0, 0, 0.04));
+  color: var(--color-brand-primary);
 }
 
 /* --- Main layout (three-column) --- */

--- a/packages/web/src/components/Topbar.tsx
+++ b/packages/web/src/components/Topbar.tsx
@@ -1,10 +1,27 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { ThemeToggle } from './ThemeToggle';
 import { useDebug } from '../contexts/DebugContext';
 
 interface AuthUser {
   userDetails: string;
   identityProvider: string;
+}
+
+/** Extract a display-friendly name from an email or raw identifier. */
+function getDisplayName(userDetails: string): string {
+  const local = userDetails.includes('@')
+    ? userDetails.split('@')[0]
+    : userDetails;
+  return local
+    .replace(/[._-]/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase())
+    .trim();
+}
+
+/** First letter for the avatar circle. */
+function getInitial(userDetails: string): string {
+  const name = getDisplayName(userDetails);
+  return name.charAt(0).toUpperCase();
 }
 
 interface TopbarProps {
@@ -95,19 +112,7 @@ export function Topbar({
         )}
         <ThemeToggle />
         {user ? (
-          <div className="topbar-signin" role="group" aria-label="User menu">
-            <span className="topbar-avatar" aria-hidden="true">
-              {user.userDetails.charAt(0).toUpperCase()}
-            </span>
-            <span className="topbar-user-name">{user.userDetails}</span>
-            <a
-              href="/.auth/logout?post_logout_redirect_uri=/"
-              className="topbar-signout-link"
-              aria-label="Sign out"
-            >
-              Sign out
-            </a>
-          </div>
+          <UserMenu user={user} />
         ) : (
           <button
             className="topbar-signin"
@@ -134,5 +139,51 @@ export function Topbar({
         )}
       </div>
     </header>
+  );
+}
+
+/* ── Authenticated user menu ─────────────────────────────────────────── */
+function UserMenu({ user }: { user: AuthUser }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const displayName = getDisplayName(user.userDetails);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div className="topbar-user-menu" ref={ref}>
+      <button
+        className="topbar-user-trigger"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={`User menu for ${displayName}`}
+        onClick={() => setOpen(o => !o)}
+      >
+        <span className="topbar-avatar" aria-hidden="true">
+          {getInitial(user.userDetails)}
+        </span>
+        <span className="topbar-user-name">{displayName}</span>
+      </button>
+
+      {open && (
+        <div className="topbar-user-dropdown" role="menu">
+          <span className="topbar-user-dropdown-email">{user.userDetails}</span>
+          <a
+            href="/.auth/logout?post_logout_redirect_uri=/"
+            className="topbar-user-dropdown-signout"
+            role="menuitem"
+          >
+            Sign out
+          </a>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## What changed

- **Display name instead of raw email** — extracts the local part before `@` and title-cases it (e.g. `asabbour@microsoft.com` → `Asabbour`). If `userDetails` has no `@`, it's used as-is.
- **Dropdown sign-out** — replaced the always-visible "Sign out" text link with a click-to-open dropdown menu. The trigger is the polished avatar + short name pill.
- **Polished avatar** — 30px circle with subtle translucent border, proper contrast on the brand-colored topbar.
- **Full email in dropdown** — still shown as context inside the menu, above the sign-out link.
- **Click-outside-to-close** — dropdown dismisses on any outside click.
- **Light & dark theme** — dropdown uses semantic design tokens, works in both themes.

## Verification

- `npx tsc --noEmit` ✅ (0 errors)
- `npx vitest run` ✅ (1016 tests pass)

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)