### PR TITLE
fix: rehydrate session from client history on cold start

### DIFF
--- a/packages/web/api/src/functions/action.ts
+++ b/packages/web/api/src/functions/action.ts
@@ -24,7 +24,8 @@ import {
 } from "@kickstart/core";
 import type { Phase, PhaseItem } from "@kickstart/core";
 import type { A2UIMessage } from "@kickstart/core";
-import { getSession, addMessage } from "../lib/session-store.js";
+import { getSession, hydrateSession, addMessage } from "../lib/session-store.js";
+import type { ClientMessage } from "../lib/session-store.js";
 import { chatCompletion, getChatDeploymentName } from "../lib/openai-client.js";
 import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
 import { safeErrorResponse } from "../lib/error-response.js";
@@ -49,6 +50,8 @@ interface ActionRequest {
     phase?: string;
     [key: string]: unknown;
   };
+  /** Client-side message history for session rehydration after cold starts. */
+  messages?: ClientMessage[];
 }
 
 interface ActionResponse {
@@ -206,20 +209,25 @@ app.http("action", {
         return { status: 400, jsonBody: { error: "action.name is required" } };
       }
 
-      // --- Resolve session ---
-      const session = getSession(body.sessionId);
+      // --- Resolve session (hydrate from client history on cold start) ---
+      let session = getSession(body.sessionId);
       if (!session) {
-        return {
-          status: 404,
-          jsonBody: { error: `Session not found: ${body.sessionId}` },
-        };
+        if (body.messages?.length) {
+          session = hydrateSession(body.messages);
+        } else {
+          return {
+            status: 404,
+            jsonBody: { error: `Session not found: ${body.sessionId}` },
+          };
+        }
       }
 
       const { engineState } = session;
+      const sessionId = session.state.sessionId;
       const category = categorize(body.action.name);
 
       context.log(
-        `[action] session=${body.sessionId} action="${body.action.name}" category=${category}`,
+        `[action] session=${sessionId} action="${body.action.name}" category=${category}`,
       );
 
       // --- Route by action category ---
@@ -242,7 +250,7 @@ app.http("action", {
         const navMessage = `${baseMessage} — User is requesting to navigate to the "${targetPhase}" phase. Please acknowledge and guide them accordingly.`;
 
         const llmResult = await callLLM(
-          body.sessionId,
+          sessionId,
           navMessage,
           engineState,
           context,
@@ -261,7 +269,7 @@ app.http("action", {
       // Default: reply — translate to message and re-prompt LLM
       const userMessage = actionToMessage(body.action);
       const llmResult = await callLLM(
-        body.sessionId,
+        sessionId,
         userMessage,
         engineState,
         context,

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -22,7 +22,8 @@ import {
   InMemoryArtifactStore,
 } from "@kickstart/core";
 import type { PhaseItem, ToolContext } from "@kickstart/core";
-import { getSession, createSession, addMessage } from "../lib/session-store.js";
+import { getSession, createSession, hydrateSession, addMessage } from "../lib/session-store.js";
+import type { ClientMessage } from "../lib/session-store.js";
 import { chatCompletion, chatCompletionWithTools, getChatDeploymentName } from "../lib/openai-client.js";
 import { checkContentSafety } from "../lib/content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
@@ -35,6 +36,8 @@ import type { DebugMetadata } from "../lib/debug-mode.js";
 interface ConverseRequest {
   sessionId?: string;
   message: string;
+  /** Client-side message history for session rehydration after cold starts. */
+  messages?: ClientMessage[];
 }
 
 interface ConverseResponse {
@@ -72,12 +75,16 @@ app.http("converse", {
         return { status: 400, jsonBody: { error: safetyResult.error } };
       }
 
-      // Get or create session
+      // Get or create session — if the in-memory session is gone but the
+      // client sent its message history, hydrate a new session from it so
+      // the LLM retains full conversational context across cold starts.
       let session = body.sessionId
         ? getSession(body.sessionId)
         : undefined;
       if (!session) {
-        session = createSession();
+        session = body.messages?.length
+          ? hydrateSession(body.messages)
+          : createSession();
       }
 
       const { state, engineState } = session;

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -77,6 +77,43 @@ export function createSession(): ApiSession {
   return session;
 }
 
+/**
+ * Client-provided message for session hydration.
+ * Only role + content — the server never trusts client timestamps or system prompts.
+ */
+export interface ClientMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Create a new session and seed it with client-provided conversation history.
+ * Used when the in-memory session has been lost (cold start / scale event)
+ * but the client still holds the message history in React state.
+ *
+ * System messages are always rebuilt server-side — client-sent system
+ * messages are silently dropped.
+ */
+export function hydrateSession(clientMessages: ClientMessage[]): ApiSession {
+  const session = createSession();
+  const now = new Date().toISOString();
+
+  for (const msg of clientMessages) {
+    // Only allow user/assistant — never trust client-sent system prompts
+    if (msg.role !== "user" && msg.role !== "assistant") continue;
+    if (!msg.content) continue;
+
+    session.state.messages.push({
+      role: msg.role,
+      content: msg.content,
+      timestamp: now,
+    });
+  }
+
+  session.state.updatedAt = now;
+  return session;
+}
+
 /** Append a message to the session's history. */
 export function addMessage(
   sessionId: string,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -260,7 +260,7 @@ export function App() {
           setMessages(prev => [...prev, errorMsg]);
           sessions.addMessage(sessionId!, errorMsg);
         },
-      }, debugEnabled);
+      }, debugEnabled, messages);
     }
   }, [sessions, streaming, mockStreaming, a2ui, isApiAvailable, resetConsecutiveCount, progressiveQueue, debugEnabled]);
 

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import type { StreamEvent, A2uiMsg, DebugMetadata } from '../types';
+import type { StreamEvent, A2uiMsg, DebugMetadata, ChatMessage } from '../types';
 import { apiFetch, SessionExpiredError } from '../services/api-client';
 
 interface StreamCallbacks {
@@ -69,6 +69,8 @@ export function useStreaming() {
     sessionId: string | undefined,
     callbacks: StreamCallbacks,
     debugMode?: boolean,
+    /** Full message history for session rehydration on cold starts. */
+    chatHistory?: ChatMessage[],
   ) => {
     setIsStreaming(true);
     setStreamText('');
@@ -86,13 +88,24 @@ export function useStreaming() {
     const renderDecisions: string[] = [];
 
     try {
+      // Build client message history for rehydration (strip system messages
+      // and A2UI JSON — the server builds its own system prompt).
+      const clientMessages = chatHistory
+        ?.filter((m) => m.role === 'user' || m.role === 'assistant')
+        .map((m) => ({ role: m.role, content: m.text }));
+
       const res = await apiFetch('/api/converse', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'text/event-stream',
         },
-        body: JSON.stringify({ sessionId, message, stream: true }),
+        body: JSON.stringify({
+          sessionId,
+          message,
+          stream: true,
+          ...(clientMessages?.length ? { messages: clientMessages } : {}),
+        }),
         signal: controller.signal,
       }, debugMode);
 


### PR DESCRIPTION
## Problem

Conversation context is lost between messages. When a user sends "now what?" after a multi-turn conversation, the LLM responds with a fresh welcome message because the in-memory session store (`Map<string, ApiSession>`) is wiped on serverless cold starts, scale events, and function restarts.

## Solution

Client-side conversation history rehydration. The frontend already maintains messages in React state — now it sends them with each request so the backend can rebuild the session on miss.

### Backend

- **`session-store.ts`**: New `hydrateSession()` function + `ClientMessage` type. Creates a fresh session seeded with client-provided user/assistant messages. System prompts are always rebuilt server-side (never trust the client).
- **`converse.ts`**: Accepts optional `messages` array in request body. When session lookup misses but `messages` is provided, hydrates instead of creating a blank session.
- **`action.ts`**: Same pattern. Uses hydrated session ID for all downstream `callLLM` calls.

### Frontend

- **`useStreaming.ts`**: Accepts `chatHistory` param, filters to user/assistant text-only messages, sends as `messages` in the request body.
- **`App.tsx`**: Passes current `messages` state to `streaming.send()`.

### How it works

1. Client sends `{ sessionId, message, messages: [...] }`
2. Server looks up `sessionId` in memory → found? Use it (fast path, no change)
3. Not found + `messages` provided → `hydrateSession()` creates new session with history
4. Not found + no `messages` → `createSession()` (blank, same as before)

### Constraints met

- ✅ Existing session flow unchanged — in-memory hit still wins
- ✅ System prompt stays server-side — client system messages silently dropped
- ✅ TypeScript: `npx tsc --noEmit` passes
- ✅ Tests: all 1023 tests pass

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)