### PR TITLE
fix: A2UI Markdown shows [Loading...] — 18 missing component types in backend validator

### DIFF
--- a/packages/core/src/__tests__/a2ui-schema.test.ts
+++ b/packages/core/src/__tests__/a2ui-schema.test.ts
@@ -58,18 +58,21 @@ describe("PAYLOAD_LIMITS", () => {
 // ---------------------------------------------------------------------------
 
 describe("KNOWN_COMPONENT_TYPES", () => {
-  it("contains exactly 28 types", () => {
-    expect(KNOWN_COMPONENT_TYPES.size).toBe(28);
+  it("contains exactly 46 types", () => {
+    expect(KNOWN_COMPONENT_TYPES.size).toBe(46);
   });
 
   it("includes all expected component types", () => {
     const expected = [
-      "Accordion", "ArchitectureDiagram", "AudioPlayer", "AuthCard",
-      "Badge", "Button", "Card", "CheckBox", "ChoicePicker", "Column",
-      "ComboBox", "CostEstimate", "DateTimeInput", "DeploymentProgress",
-      "Divider", "FileEditor", "Icon", "Image", "List", "Modal",
-      "MultiSelect", "Row", "Slider", "Tabs", "Text", "TextField",
-      "Toggle", "Video",
+      "Accordion", "Alert", "ArchitectureDiagram", "AudioPlayer", "AuthCard",
+      "AzureAction", "AzureLoginCard", "AzureResourceForm", "AzureResourcePicker",
+      "Badge", "Button", "Card", "CheckBox", "ChoicePicker", "CodeBlock",
+      "Column", "ComboBox", "CostEstimate", "DateTimeInput", "DeploymentProgress",
+      "Divider", "FileEditor", "FormGroup", "GitHubAction", "GitHubCommit",
+      "GitHubLoginCard", "GitHubRepoPicker", "Icon", "Image", "Link", "List",
+      "Markdown", "Modal", "MultiSelect", "ProgressSteps", "Questionnaire",
+      "RadioGroup", "Row", "Slider", "SteppedCarousel", "Tabs", "Table",
+      "Text", "TextField", "Toggle", "Video",
     ];
     for (const t of expected) {
       expect(KNOWN_COMPONENT_TYPES.has(t as never)).toBe(true);
@@ -229,6 +232,76 @@ describe("COMPONENT_SCHEMA_REGISTRY", () => {
       component: "AuthCard",
       provider: "azure",
       title: "Sign in",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates Markdown component", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["Markdown"].safeParse({
+      id: "md1",
+      component: "Markdown",
+      content: "**Bold** text with *italics*",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects Markdown without required content", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["Markdown"].safeParse({
+      id: "md1",
+      component: "Markdown",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates CodeBlock component", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["CodeBlock"].safeParse({
+      id: "cb1",
+      component: "CodeBlock",
+      code: "console.log('hello')",
+      language: "javascript",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates Table component", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["Table"].safeParse({
+      id: "tbl1",
+      component: "Table",
+      columns: ["Name", "Value"],
+      rows: [["key", "val"]],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates Alert component", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["Alert"].safeParse({
+      id: "alert1",
+      component: "Alert",
+      message: "Something happened",
+      severity: "warning",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates Link component", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["Link"].safeParse({
+      id: "lnk1",
+      component: "Link",
+      text: "Click here",
+      url: "https://example.com",
+      external: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates ProgressSteps component", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["ProgressSteps"].safeParse({
+      id: "ps1",
+      component: "ProgressSteps",
+      steps: [
+        { id: "s1", label: "Init", status: "complete" },
+        { id: "s2", label: "Build", status: "active" },
+      ],
     });
     expect(result.success).toBe(true);
   });

--- a/packages/core/src/__tests__/response-processor.test.ts
+++ b/packages/core/src/__tests__/response-processor.test.ts
@@ -215,6 +215,37 @@ describe("processResponse", () => {
     expect((comps[1] as Record<string, unknown>).component).toBe("Divider");
   });
 
+  it("preserves Markdown components in updateComponents (regression)", () => {
+    const json = JSON.stringify({
+      message: "Thanks for the info!",
+      a2ui: [
+        { version: "v0.9", createSurface: { surfaceId: "msg-4", catalogId: "kickstart" } },
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "msg-4",
+            components: [
+              { id: "root", component: "Column", children: ["summary-card"], gap: "16px" },
+              { id: "summary-card", component: "Card", children: ["summary-col"] },
+              { id: "summary-col", component: "Column", children: ["title", "summary-md"] },
+              { id: "title", component: "Text", text: "Application summary", variant: "h2" },
+              { id: "summary-md", component: "Markdown", content: "**App type:** Full-stack web application" },
+            ],
+          },
+        },
+      ],
+      actions: [],
+    });
+
+    const result = processResponse(json);
+    expect(result.a2uiMessages).toHaveLength(2);
+    const comps = result.a2uiMessages[1].updateComponents!.components as Record<string, unknown>[];
+    expect(comps).toHaveLength(5);
+    const markdownComp = comps.find(c => c.component === "Markdown");
+    expect(markdownComp).toBeDefined();
+    expect(markdownComp!.content).toBe("**App type:** Full-stack web application");
+  });
+
   it("strips unknown props from validated components", () => {
     const json = JSON.stringify({
       message: "test",

--- a/packages/core/src/services/a2ui-schema.ts
+++ b/packages/core/src/services/a2ui-schema.ts
@@ -55,14 +55,20 @@ export function checkDepth(
 
 export const KNOWN_COMPONENT_TYPES = new Set([
   "Accordion",
+  "Alert",
   "ArchitectureDiagram",
   "AudioPlayer",
   "AuthCard",
+  "AzureAction",
+  "AzureLoginCard",
+  "AzureResourceForm",
+  "AzureResourcePicker",
   "Badge",
   "Button",
   "Card",
   "CheckBox",
   "ChoicePicker",
+  "CodeBlock",
   "Column",
   "ComboBox",
   "CostEstimate",
@@ -70,14 +76,26 @@ export const KNOWN_COMPONENT_TYPES = new Set([
   "DeploymentProgress",
   "Divider",
   "FileEditor",
+  "FormGroup",
+  "GitHubAction",
+  "GitHubCommit",
+  "GitHubLoginCard",
+  "GitHubRepoPicker",
   "Icon",
   "Image",
+  "Link",
   "List",
+  "Markdown",
   "Modal",
   "MultiSelect",
+  "ProgressSteps",
+  "Questionnaire",
+  "RadioGroup",
   "Row",
   "Slider",
+  "SteppedCarousel",
   "Tabs",
+  "Table",
   "Text",
   "TextField",
   "Toggle",
@@ -393,6 +411,236 @@ const DeploymentProgressPropsSchema = z
   })
   .strip();
 
+// Basic catalog components (missing from original set)
+
+const AlertPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("Alert"),
+    message: dynamicString,
+    severity: z.enum(["info", "warning", "error", "success"]).optional(),
+    dismissible: z.boolean().optional(),
+    action: actionSchema.optional(),
+  })
+  .strip();
+
+const LinkPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("Link"),
+    text: dynamicString,
+    url: dynamicString,
+    external: z.boolean().optional(),
+  })
+  .strip();
+
+const TablePropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("Table"),
+    columns: z.array(dynamicString),
+    rows: z.array(z.array(dynamicString)).optional(),
+    caption: dynamicString.optional(),
+  })
+  .strip();
+
+// Custom Kickstart components (missing from original set)
+
+const MarkdownPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("Markdown"),
+    content: dynamicString,
+  })
+  .strip();
+
+const CodeBlockPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("CodeBlock"),
+    code: dynamicString,
+    language: dynamicString.optional(),
+    filename: dynamicString.optional(),
+  })
+  .strip();
+
+const ProgressStepsPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("ProgressSteps"),
+    steps: z.array(
+      z.object({
+        id: boundedString,
+        label: dynamicString,
+        status: z.enum(["pending", "active", "complete", "error"]),
+      }),
+    ),
+  })
+  .strip();
+
+const RadioGroupPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("RadioGroup"),
+    options: z.array(
+      z.object({
+        id: boundedString,
+        label: dynamicString,
+        description: dynamicString.optional(),
+        recommended: z.boolean().optional(),
+      }),
+    ),
+    value: dynamicString.optional(),
+    action: actionSchema,
+  })
+  .strip();
+
+const FormGroupPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("FormGroup"),
+    title: dynamicString,
+    step: z.number().optional(),
+    child: boundedString,
+  })
+  .strip();
+
+const GitHubLoginCardPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("GitHubLoginCard"),
+    username: dynamicString.optional(),
+    avatarUrl: dynamicString.optional(),
+    onSignIn: actionSchema.optional(),
+    onSignOut: actionSchema.optional(),
+  })
+  .strip();
+
+const GitHubRepoPickerPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("GitHubRepoPicker"),
+    placeholder: dynamicString.optional(),
+    selectedRepo: dynamicString.optional(),
+    onSelect: actionSchema.optional(),
+  })
+  .strip();
+
+const GitHubActionPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("GitHubAction"),
+    title: dynamicString,
+    description: dynamicString.optional(),
+    method: z.enum(["POST", "PUT", "PATCH", "DELETE"]),
+    path: dynamicString,
+    operationType: dynamicString,
+    body: z.record(z.unknown()).optional(),
+    confirmLabel: dynamicString.optional(),
+    onSuccess: actionSchema.optional(),
+    onError: actionSchema.optional(),
+  })
+  .strip();
+
+const GitHubCommitPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("GitHubCommit"),
+    repoFullName: dynamicString.optional(),
+    defaultBranch: dynamicString.optional(),
+    suggestedBranchName: dynamicString.optional(),
+    suggestedTitle: dynamicString.optional(),
+    suggestedBody: dynamicString.optional(),
+    onSuccess: actionSchema.optional(),
+    onError: actionSchema.optional(),
+  })
+  .strip();
+
+const AzureLoginCardPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("AzureLoginCard"),
+    displayName: dynamicString.optional(),
+    showTokenInfo: z.boolean().optional(),
+    onSignIn: actionSchema.optional(),
+    onSignOut: actionSchema.optional(),
+  })
+  .strip();
+
+const AzureResourcePickerPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("AzureResourcePicker"),
+    subscriptionId: dynamicString.optional(),
+    resourceGroup: dynamicString.optional(),
+    resourceType: dynamicString.optional(),
+    label: dynamicString.optional(),
+    onSelect: actionSchema.optional(),
+  })
+  .strip();
+
+const AzureResourceFormPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("AzureResourceForm"),
+    title: dynamicString.optional(),
+    subscriptionId: dynamicString.optional(),
+    resourceGroup: dynamicString.optional(),
+    resourceType: dynamicString.optional(),
+    apiVersion: dynamicString.optional(),
+  })
+  .strip();
+
+const AzureActionPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("AzureAction"),
+    title: dynamicString,
+    description: dynamicString.optional(),
+    method: z.enum(["PUT", "POST", "PATCH", "DELETE"]),
+    path: dynamicString,
+    body: z.record(z.unknown()).optional(),
+    apiVersion: dynamicString.optional(),
+    confirmLabel: dynamicString.optional(),
+    onSuccess: actionSchema.optional(),
+    onError: actionSchema.optional(),
+  })
+  .strip();
+
+const SteppedCarouselStepSchema = z.object({
+  title: dynamicString,
+  child: boundedString,
+});
+
+const SteppedCarouselPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("SteppedCarousel"),
+    steps: z.array(SteppedCarouselStepSchema),
+    activeStep: z.number().optional(),
+  })
+  .strip();
+
+const QuestionDefSchema = z.object({
+  id: boundedString,
+  label: dynamicString,
+  type: z.enum(["text", "choice", "multiChoice"]).optional(),
+  choices: z
+    .array(z.object({ id: boundedString, label: dynamicString }))
+    .optional(),
+  required: z.boolean().optional(),
+});
+
+const QuestionnairePropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("Questionnaire"),
+    questions: z.array(QuestionDefSchema),
+    submitLabel: dynamicString.optional(),
+    onSubmit: actionSchema.optional(),
+  })
+  .strip();
+
 // New Fluent Components (5)
 
 const BadgePropsSchema = z
@@ -496,14 +744,20 @@ const MultiSelectPropsSchema = z
  */
 export const COMPONENT_SCHEMA_REGISTRY: Record<string, z.ZodType> = {
   Accordion: AccordionPropsSchema,
+  Alert: AlertPropsSchema,
   ArchitectureDiagram: ArchitectureDiagramPropsSchema,
   AudioPlayer: AudioPlayerPropsSchema,
   AuthCard: AuthCardPropsSchema,
+  AzureAction: AzureActionPropsSchema,
+  AzureLoginCard: AzureLoginCardPropsSchema,
+  AzureResourceForm: AzureResourceFormPropsSchema,
+  AzureResourcePicker: AzureResourcePickerPropsSchema,
   Badge: BadgePropsSchema,
   Button: ButtonPropsSchema,
   Card: CardPropsSchema,
   CheckBox: CheckBoxPropsSchema,
   ChoicePicker: ChoicePickerPropsSchema,
+  CodeBlock: CodeBlockPropsSchema,
   Column: ColumnPropsSchema,
   ComboBox: ComboBoxPropsSchema,
   CostEstimate: CostEstimatePropsSchema,
@@ -511,14 +765,26 @@ export const COMPONENT_SCHEMA_REGISTRY: Record<string, z.ZodType> = {
   DeploymentProgress: DeploymentProgressPropsSchema,
   Divider: DividerPropsSchema,
   FileEditor: FileEditorPropsSchema,
+  FormGroup: FormGroupPropsSchema,
+  GitHubAction: GitHubActionPropsSchema,
+  GitHubCommit: GitHubCommitPropsSchema,
+  GitHubLoginCard: GitHubLoginCardPropsSchema,
+  GitHubRepoPicker: GitHubRepoPickerPropsSchema,
   Icon: IconPropsSchema,
   Image: ImagePropsSchema,
+  Link: LinkPropsSchema,
   List: ListPropsSchema,
+  Markdown: MarkdownPropsSchema,
   Modal: ModalPropsSchema,
   MultiSelect: MultiSelectPropsSchema,
+  ProgressSteps: ProgressStepsPropsSchema,
+  Questionnaire: QuestionnairePropsSchema,
+  RadioGroup: RadioGroupPropsSchema,
   Row: RowPropsSchema,
   Slider: SliderPropsSchema,
+  SteppedCarousel: SteppedCarouselPropsSchema,
   Tabs: TabsPropsSchema,
+  Table: TablePropsSchema,
   Text: TextPropsSchema,
   TextField: TextFieldPropsSchema,
   Toggle: TogglePropsSchema,

--- a/packages/web/e2e/playground.spec.ts
+++ b/packages/web/e2e/playground.spec.ts
@@ -81,14 +81,14 @@ test.describe('Playground', () => {
       await page.getByRole('dialog').waitFor({ timeout: 5000 });
 
       await expect(page.getByRole('tab', { name: 'Preview' })).toBeVisible();
-      await expect(page.getByRole('tab', { name: 'JSON' })).toBeVisible();
+      await expect(page.getByRole('tab', { name: 'JSON', exact: true })).toBeVisible();
     });
 
     test('dialog JSON tab shows valid JSON', async ({ page }) => {
       await page.locator('.playground-gallery > div').first().click();
       await page.getByRole('dialog').waitFor({ timeout: 5000 });
 
-      await page.getByRole('tab', { name: 'JSON' }).click();
+      await page.getByRole('tab', { name: 'JSON', exact: true }).click();
       // The JSON code block renders A2UI message JSON — check it contains "version"
       await expect(page.getByRole('dialog').getByText(/version/)).toBeVisible({ timeout: 3000 });
     });


### PR DESCRIPTION
## Bug

`[Loading summary-md...]` appeared instead of rendered Markdown content, even though the raw LLM response contained the full component data.

## Root Cause

The backend response processor (`packages/core/src/services/a2ui-schema.ts`) maintains a `KNOWN_COMPONENT_TYPES` set used to validate components before forwarding them to the frontend. **"Markdown" was not in this set** — along with 17 other frontend catalog types — so `validateComponentsInMessage()` silently dropped it as an "unknown/hallucinated" component.

The frontend renderer then mounted a `DeferredChild` for the missing component ID and fell through to the `[Loading {id}...]` placeholder.

## Fix

- Added all 18 missing component types to `KNOWN_COMPONENT_TYPES` (28 → 46)
- Added Zod prop schemas for each new type to `COMPONENT_SCHEMA_REGISTRY`
- Added regression test reproducing the exact Markdown + Column + Card bug scenario
- Added schema validation tests for Markdown, CodeBlock, Table, Alert, Link, ProgressSteps

### Missing types added
`Alert`, `AzureAction`, `AzureLoginCard`, `AzureResourceForm`, `AzureResourcePicker`, `CodeBlock`, `FormGroup`, `GitHubAction`, `GitHubCommit`, `GitHubLoginCard`, `GitHubRepoPicker`, `Link`, `Markdown`, `ProgressSteps`, `Questionnaire`, `RadioGroup`, `SteppedCarousel`, `Table`

## Testing

- `npx vitest run` — 1024/1024 tests pass ✅
- `cd packages/web && npx tsc --noEmit` — clean ✅

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)