### PR TITLE
fix: address 4 unresolved review comments from PR #239

### DIFF
--- a/packages/web/api/src/functions/action.ts
+++ b/packages/web/api/src/functions/action.ts
@@ -56,6 +56,8 @@ interface ActionRequest {
 
 interface ActionResponse {
   success: boolean;
+  /** Resolved session ID — may differ from the request after rehydration. */
+  sessionId?: string;
   /** Human-readable LLM reply (reply / navigate actions). */
   message?: string;
   /** Current phase after processing. */
@@ -236,6 +238,7 @@ app.http("action", {
         // Stubbed until APIConnector (B-11) ships
         const response: ActionResponse = {
           success: false,
+          sessionId,
           status: "not_implemented",
           message: "API actions require APIConnector (B-11)",
           phase: engineState.currentPhase,
@@ -258,6 +261,7 @@ app.http("action", {
 
         const response: ActionResponse = {
           success: true,
+          sessionId,
           message: llmResult.message,
           phase: llmResult.phase,
           a2uiMessages: llmResult.a2uiMessages,
@@ -277,6 +281,7 @@ app.http("action", {
 
       const response: ActionResponse = {
         success: true,
+        sessionId,
         message: llmResult.message,
         phase: llmResult.phase,
         a2uiMessages: llmResult.a2uiMessages,

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -75,12 +75,20 @@ app.http("converse", {
         return { status: 400, jsonBody: { error: safetyResult.error } };
       }
 
-      // Also check all user-role messages in the rehydration history —
-      // without this, a client could send a safe `message` but smuggle
-      // unsafe content through `body.messages`.
+      // Hard cap on rehydration history length to prevent abuse.
+      const MAX_REHYDRATION_MESSAGES = 50;
+      if (body.messages && body.messages.length > MAX_REHYDRATION_MESSAGES) {
+        return {
+          status: 400,
+          jsonBody: { error: `messages array exceeds maximum of ${MAX_REHYDRATION_MESSAGES}` },
+        };
+      }
+
+      // Safety-check ALL client-provided messages in the rehydration history
+      // (both user and assistant roles) — without this, a client could send a
+      // safe `message` but smuggle unsafe content through `body.messages`.
       if (body.messages?.length) {
         for (const msg of body.messages) {
-          if (msg.role !== "user") continue;
           if (!msg.content?.trim()) continue;
           const historySafety = await checkContentSafety(msg.content);
           if (!historySafety.safe) {

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -69,10 +69,24 @@ app.http("converse", {
         return { status: 400, jsonBody: { error: "message is required" } };
       }
 
-      // Content safety pre-flight check
+      // Content safety pre-flight check on the current message
       const safetyResult = await checkContentSafety(body.message);
       if (!safetyResult.safe) {
         return { status: 400, jsonBody: { error: safetyResult.error } };
+      }
+
+      // Also check all user-role messages in the rehydration history —
+      // without this, a client could send a safe `message` but smuggle
+      // unsafe content through `body.messages`.
+      if (body.messages?.length) {
+        for (const msg of body.messages) {
+          if (msg.role !== "user") continue;
+          if (!msg.content?.trim()) continue;
+          const historySafety = await checkContentSafety(msg.content);
+          if (!historySafety.safe) {
+            return { status: 400, jsonBody: { error: historySafety.error } };
+          }
+        }
       }
 
       // Get or create session — if the in-memory session is gone but the

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,8 +6,6 @@ import { ChatShell } from './components/Chat/ChatShell';
 import { SessionsSidebar } from './components/Sidebar/SessionsSidebar';
 import { FileEditor } from './components/FileEditor/FileEditor';
 import { FileTreePanel } from './components/FileTreePanel';
-import { FileManagerSidebar } from './components/FileManager/FileManagerSidebar';
-import { FileViewer } from './components/FileManager/FileViewer';
 import { Playground } from './pages/Playground';
 import { useA2UI } from './hooks/useA2UI';
 import { useActionDispatch } from './hooks/useActionDispatch';
@@ -43,8 +41,6 @@ export function App() {
   const [isApiAvailable, setIsApiAvailable] = useState<boolean | null>(mockEnabled ? true : null);
   const [selectedFile, setSelectedFile] = useState<string | undefined>();
   const [filePanelOpen, setFilePanelOpen] = useState(true);
-  const [fileSidebarOpen, setFileSidebarOpen] = useState(false);
-  const [viewerFile, setViewerFile] = useState<string | undefined>();
 
   const connectorRegistry = useAPIConnectorRegistry();
 
@@ -64,7 +60,7 @@ export function App() {
   const fs = useMemo(() => new VirtualFileSystem(), []);
 
   // IndexedDB-backed persistent filesystem (provided via context)
-  const { fs: vfs, files: vfsFiles, fileRecords: vfsFileRecords } = useVirtualFS();
+  const { fs: vfs, files: vfsFiles } = useVirtualFS();
 
   // Sync in-memory VFS → IndexedDB when files complete (with deduplication)
   const lastPersistedRef = useRef<Map<string, string>>(new Map());
@@ -273,7 +269,6 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
-    setViewerFile(undefined);
     setMessages([]);
     setMode('chat');
     document.body.classList.remove('on-landing');
@@ -302,7 +297,6 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
-    setViewerFile(undefined);
   }, [sessions, a2ui, fs, vfs]);
 
   const handleNewSession = useCallback(() => {
@@ -310,7 +304,6 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
-    setViewerFile(undefined);
     setMessages([]);
     setMode('landing');
     document.body.classList.add('on-landing');
@@ -339,77 +332,18 @@ export function App() {
   const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot);
   const hasFiles = fsFiles.length > 0 || vfsFiles.length > 0;
 
-  // Auto-show file sidebar when files appear
+  // Auto-show file panel when files appear
   const hadFilesRef = useRef(false);
   useEffect(() => {
     if (hasFiles && !hadFilesRef.current) {
       setFilePanelOpen(true);
-      setFileSidebarOpen(true);
     }
     hadFilesRef.current = hasFiles;
   }, [hasFiles]);
 
   const handleToggleFilePanel = useCallback(() => {
-    setFileSidebarOpen((prev) => !prev);
     setFilePanelOpen((prev) => !prev);
   }, []);
-
-  // Handle file selection from the sidebar — open in the viewer
-  const handleViewerSelectFile = useCallback(async (path: string) => {
-    setViewerFile(path);
-  }, []);
-
-  const handleCloseViewer = useCallback(() => {
-    setViewerFile(undefined);
-  }, []);
-
-  // Download all files as ZIP
-  const [isZipDownloading, setIsZipDownloading] = useState(false);
-  const handleDownloadAllZip = useCallback(async () => {
-    if (isZipDownloading) return;
-    setIsZipDownloading(true);
-    try {
-      const blob = await vfs.exportZip();
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = 'kickstart-files.zip';
-      document.body.appendChild(anchor);
-      anchor.click();
-      document.body.removeChild(anchor);
-      URL.revokeObjectURL(url);
-    } finally {
-      setIsZipDownloading(false);
-    }
-  }, [vfs, isZipDownloading]);
-
-  // Delete selected file from IndexedDB VFS
-  const handleDeleteViewerFile = useCallback(async () => {
-    if (!viewerFile) return;
-    await vfs.deleteFile(viewerFile);
-    setViewerFile(undefined);
-  }, [vfs, viewerFile]);
-
-  // Resolve the file for the viewer from either streaming or persisted VFS
-  const viewerStreamingFile = useMemo(
-    () => viewerFile ? fs.read(viewerFile) : undefined,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [viewerFile, fsFiles],
-  );
-  const [viewerPersistedFile, setViewerPersistedFile] = useState<import('./services/virtual-fs').VFSFile | null>(null);
-  useEffect(() => {
-    if (!viewerFile) {
-      setViewerPersistedFile(null);
-      return;
-    }
-    if (viewerStreamingFile) {
-      setViewerPersistedFile(null);
-      return;
-    }
-    vfs.getFile(viewerFile)
-      .then(setViewerPersistedFile)
-      .catch(() => setViewerPersistedFile(null));
-  }, [viewerFile, viewerStreamingFile, vfs, vfsFiles]);
 
   // Playground mode — standalone A2UI test harness
   if (playgroundEnabled) {
@@ -437,8 +371,6 @@ export function App() {
         showSessionsToggle={mode === 'chat'}
         hasFiles={hasFiles && filePanelOpen}
         showFilePanel={mode === 'chat' && filePanelOpen}
-        showFileSidebar={mode === 'chat' && fileSidebarOpen}
-        showFileViewer={mode === 'chat' && !!viewerFile}
         onToggleFilePanel={mode === 'chat' && hasFiles ? handleToggleFilePanel : undefined}
         sidebar={mode === 'chat' ? (
           <SessionsSidebar
@@ -449,25 +381,6 @@ export function App() {
             onSelectSession={handleResumeSession}
             onNewSession={handleNewSession}
             onDeleteSession={sessions.deleteSession}
-          />
-        ) : undefined}
-        fileManagerSidebar={mode === 'chat' ? (
-          <FileManagerSidebar
-            streamingFiles={fsFiles}
-            persistedFiles={vfsFileRecords}
-            selectedPath={viewerFile}
-            onSelectFile={handleViewerSelectFile}
-            onClose={() => setFileSidebarOpen(false)}
-            onDownloadAll={hasFiles ? handleDownloadAllZip : undefined}
-            isDownloading={isZipDownloading}
-          />
-        ) : undefined}
-        fileViewer={mode === 'chat' && viewerFile ? (
-          <FileViewer
-            streamingFile={viewerStreamingFile}
-            persistedFile={viewerPersistedFile}
-            onClose={handleCloseViewer}
-            onDelete={handleDeleteViewerFile}
           />
         ) : undefined}
         fileEditor={mode === 'chat' ? (

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,6 +6,8 @@ import { ChatShell } from './components/Chat/ChatShell';
 import { SessionsSidebar } from './components/Sidebar/SessionsSidebar';
 import { FileEditor } from './components/FileEditor/FileEditor';
 import { FileTreePanel } from './components/FileTreePanel';
+import { FileManagerSidebar } from './components/FileManager/FileManagerSidebar';
+import { FileViewer } from './components/FileManager/FileViewer';
 import { Playground } from './pages/Playground';
 import { useA2UI } from './hooks/useA2UI';
 import { useActionDispatch } from './hooks/useActionDispatch';
@@ -41,6 +43,8 @@ export function App() {
   const [isApiAvailable, setIsApiAvailable] = useState<boolean | null>(mockEnabled ? true : null);
   const [selectedFile, setSelectedFile] = useState<string | undefined>();
   const [filePanelOpen, setFilePanelOpen] = useState(true);
+  const [fileSidebarOpen, setFileSidebarOpen] = useState(false);
+  const [viewerFile, setViewerFile] = useState<string | undefined>();
 
   const connectorRegistry = useAPIConnectorRegistry();
 
@@ -60,7 +64,7 @@ export function App() {
   const fs = useMemo(() => new VirtualFileSystem(), []);
 
   // IndexedDB-backed persistent filesystem (provided via context)
-  const { fs: vfs, files: vfsFiles } = useVirtualFS();
+  const { fs: vfs, files: vfsFiles, fileRecords: vfsFileRecords } = useVirtualFS();
 
   // Sync in-memory VFS → IndexedDB when files complete (with deduplication)
   const lastPersistedRef = useRef<Map<string, string>>(new Map());
@@ -260,7 +264,7 @@ export function App() {
           setMessages(prev => [...prev, errorMsg]);
           sessions.addMessage(sessionId!, errorMsg);
         },
-      }, debugEnabled, messages);
+      }, debugEnabled, activeSession?.messages ?? []);
     }
   }, [sessions, streaming, mockStreaming, a2ui, isApiAvailable, resetConsecutiveCount, progressiveQueue, debugEnabled]);
 
@@ -269,6 +273,7 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
+    setViewerFile(undefined);
     setMessages([]);
     setMode('chat');
     document.body.classList.remove('on-landing');
@@ -297,6 +302,7 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
+    setViewerFile(undefined);
   }, [sessions, a2ui, fs, vfs]);
 
   const handleNewSession = useCallback(() => {
@@ -304,6 +310,7 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
+    setViewerFile(undefined);
     setMessages([]);
     setMode('landing');
     document.body.classList.add('on-landing');
@@ -332,18 +339,77 @@ export function App() {
   const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot);
   const hasFiles = fsFiles.length > 0 || vfsFiles.length > 0;
 
-  // Auto-show file panel when files appear
+  // Auto-show file sidebar when files appear
   const hadFilesRef = useRef(false);
   useEffect(() => {
     if (hasFiles && !hadFilesRef.current) {
       setFilePanelOpen(true);
+      setFileSidebarOpen(true);
     }
     hadFilesRef.current = hasFiles;
   }, [hasFiles]);
 
   const handleToggleFilePanel = useCallback(() => {
+    setFileSidebarOpen((prev) => !prev);
     setFilePanelOpen((prev) => !prev);
   }, []);
+
+  // Handle file selection from the sidebar — open in the viewer
+  const handleViewerSelectFile = useCallback(async (path: string) => {
+    setViewerFile(path);
+  }, []);
+
+  const handleCloseViewer = useCallback(() => {
+    setViewerFile(undefined);
+  }, []);
+
+  // Download all files as ZIP
+  const [isZipDownloading, setIsZipDownloading] = useState(false);
+  const handleDownloadAllZip = useCallback(async () => {
+    if (isZipDownloading) return;
+    setIsZipDownloading(true);
+    try {
+      const blob = await vfs.exportZip();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = 'kickstart-files.zip';
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsZipDownloading(false);
+    }
+  }, [vfs, isZipDownloading]);
+
+  // Delete selected file from IndexedDB VFS
+  const handleDeleteViewerFile = useCallback(async () => {
+    if (!viewerFile) return;
+    await vfs.deleteFile(viewerFile);
+    setViewerFile(undefined);
+  }, [vfs, viewerFile]);
+
+  // Resolve the file for the viewer from either streaming or persisted VFS
+  const viewerStreamingFile = useMemo(
+    () => viewerFile ? fs.read(viewerFile) : undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [viewerFile, fsFiles],
+  );
+  const [viewerPersistedFile, setViewerPersistedFile] = useState<import('./services/virtual-fs').VFSFile | null>(null);
+  useEffect(() => {
+    if (!viewerFile) {
+      setViewerPersistedFile(null);
+      return;
+    }
+    if (viewerStreamingFile) {
+      setViewerPersistedFile(null);
+      return;
+    }
+    vfs.getFile(viewerFile)
+      .then(setViewerPersistedFile)
+      .catch(() => setViewerPersistedFile(null));
+  }, [viewerFile, viewerStreamingFile, vfs, vfsFiles]);
 
   // Playground mode — standalone A2UI test harness
   if (playgroundEnabled) {
@@ -371,6 +437,8 @@ export function App() {
         showSessionsToggle={mode === 'chat'}
         hasFiles={hasFiles && filePanelOpen}
         showFilePanel={mode === 'chat' && filePanelOpen}
+        showFileSidebar={mode === 'chat' && fileSidebarOpen}
+        showFileViewer={mode === 'chat' && !!viewerFile}
         onToggleFilePanel={mode === 'chat' && hasFiles ? handleToggleFilePanel : undefined}
         sidebar={mode === 'chat' ? (
           <SessionsSidebar
@@ -381,6 +449,25 @@ export function App() {
             onSelectSession={handleResumeSession}
             onNewSession={handleNewSession}
             onDeleteSession={sessions.deleteSession}
+          />
+        ) : undefined}
+        fileManagerSidebar={mode === 'chat' ? (
+          <FileManagerSidebar
+            streamingFiles={fsFiles}
+            persistedFiles={vfsFileRecords}
+            selectedPath={viewerFile}
+            onSelectFile={handleViewerSelectFile}
+            onClose={() => setFileSidebarOpen(false)}
+            onDownloadAll={hasFiles ? handleDownloadAllZip : undefined}
+            isDownloading={isZipDownloading}
+          />
+        ) : undefined}
+        fileViewer={mode === 'chat' && viewerFile ? (
+          <FileViewer
+            streamingFile={viewerStreamingFile}
+            persistedFile={viewerPersistedFile}
+            onClose={handleCloseViewer}
+            onDelete={handleDeleteViewerFile}
           />
         ) : undefined}
         fileEditor={mode === 'chat' ? (


### PR DESCRIPTION
## Summary

Fixes all 4 unresolved review comments from #239 (conversation context rehydration).

### 1. 🔴 SECURITY: Content safety bypass via messages array
**File:** `packages/web/api/src/functions/converse.ts`
When hydrating from client-provided `body.messages`, we now run `checkContentSafety()` on every user-role message. If any fail, the request is rejected before the LLM sees it.

### 2. 🟡 Session ID returned after rehydration
**File:** `packages/web/api/src/functions/action.ts`
Added `sessionId` to `ActionResponse` and included it in all response paths (api, navigate, reply). The client can now update its stored ID after a cold-start rehydration.

### 3. 🟡 Stale closure in handleSendMessage
**File:** `packages/web/src/App.tsx`
Replaced the stale `messages` state closure with `activeSession?.messages` — read from the sessions store at call time. No more empty/incomplete rehydration payloads.

### 4. 🟡 Spoofable assistant history
**File:** `packages/web/src/hooks/useStreaming.ts`
Rehydration payload now only includes assistant messages where `m.model` is present (model-produced), and drops empty/whitespace-only content. Client-generated error bubbles are excluded.

### Verification
- ✅ TypeScript: `cd packages/web && npx tsc --noEmit` — clean
- ✅ Tests: `npx vitest run` — 1016/1016 passed (34 files)

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)