### PR TITLE
fix: LLM announces next phase instead of producing content

### DIFF
--- a/packages/core/src/engine/auto-continue.ts
+++ b/packages/core/src/engine/auto-continue.ts
@@ -78,8 +78,8 @@ export function synthesizeNavigationPrompt(
   }
 
   if (contextParts.length > 0) {
-    return `User is ready to move to ${phase} (${contextParts.join(", ")}). Continue the conversation.`;
+    return `User is ready to move to ${phase} (${contextParts.join(", ")}). Produce the first ${phase} phase content now — do NOT announce the phase, just start it.`;
   }
 
-  return `User is ready to move to ${phase}. Continue the conversation.`;
+  return `User is ready to move to ${phase}. Produce the first ${phase} phase content now — do NOT announce the phase, just start it.`;
 }

--- a/packages/core/src/engine/phases.ts
+++ b/packages/core/src/engine/phases.ts
@@ -36,7 +36,7 @@ Ask ONE question at a time, in this priority:
 
 If the user gives you enough info in one message, skip redundant questions.
 Do NOT acknowledge or summarize the user's previous answer — just move directly to the next question.
-When all 3 are answered, summarize what you know in a Card with Markdown, then say you're moving to Design.
+When all 3 are answered, summarize what you know in a Card with Markdown, then include a primary Button labeled "Continue to architecture design" with action {"event":{"name":"complete:navigate:design","context":{"label":"Continue to architecture design"}}}. Do NOT just announce the next phase — produce the summary Card AND the Button in the same response.
 
 RESPONSE STRUCTURE (every turn):
 - Column as root, containing 1 Card

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -101,6 +101,13 @@ Progressive discovery over multiple turns:
 Use conversational text to EXPLAIN, then ask. When the user is vague, pick the best default and explain WHY.
 Ask 1-2 focused follow-up questions per turn. Never a long checklist.
 
+PHASE TRANSITIONS — PRODUCE, DON'T NARRATE:
+NEVER respond with just an announcement like "Now let's move to the design phase" or "I'll design the architecture next." Every response MUST include actionable A2UI content — a question, a component, or a Button to advance. When a phase is complete:
+- Summarize what was gathered/decided in a Card.
+- Include a primary Button with a complete:navigate:{nextPhase} action so the user can proceed.
+- NEVER leave the user in a dead-end requiring them to manually prompt "go ahead."
+A response that only narrates intent without producing content or an interactive component is a critical failure.
+
 ## 2a. ARCHITECT MINDSET
 
 Every generated project MUST include a GitHub Actions workflow for build, test, and deploy. Never generate app code without a deployment pipeline.

--- a/packages/web/e2e/playground.spec.ts
+++ b/packages/web/e2e/playground.spec.ts
@@ -81,14 +81,14 @@ test.describe('Playground', () => {
       await page.getByRole('dialog').waitFor({ timeout: 5000 });
 
       await expect(page.getByRole('tab', { name: 'Preview' })).toBeVisible();
-      await expect(page.getByRole('tab', { name: 'JSON' })).toBeVisible();
+      await expect(page.getByRole('tab', { name: 'JSON', exact: true })).toBeVisible();
     });
 
     test('dialog JSON tab shows valid JSON', async ({ page }) => {
       await page.locator('.playground-gallery > div').first().click();
       await page.getByRole('dialog').waitFor({ timeout: 5000 });
 
-      await page.getByRole('tab', { name: 'JSON' }).click();
+      await page.getByRole('tab', { name: 'JSON', exact: true }).click();
       // The JSON code block renders A2UI message JSON — check it contains "version"
       await expect(page.getByRole('dialog').getByText(/version/)).toBeVisible({ timeout: 3000 });
     });


### PR DESCRIPTION
Closes #222

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)

## Summary

Fixed the LLM dead-end behavior where it announces phase transitions ("I'll design the architecture next") instead of producing actionable A2UI content.

## Root Cause

The Discover phase prompt explicitly told the LLM to "say you're moving to Design" — which the model interpreted as a narration instruction, producing responses with no interactive components.

## Changes

- **`packages/core/src/engine/phases.ts`** — Replaced "say you're moving to Design" with an explicit instruction to produce a summary Card + a "Continue to architecture design" Button with a `complete:navigate:design` action
- **`packages/core/src/prompts/system-prompt.ts`** — Added "PHASE TRANSITIONS — PRODUCE, DON'T NARRATE" rule to conversation rules (§2). Every response must include actionable content; narration-only responses are flagged as critical failures
- **`packages/core/src/engine/auto-continue.ts`** — Strengthened navigation continuation prompts from vague "Continue the conversation" to "Produce the first {phase} phase content now — do NOT announce the phase, just start it"

## Testing

All 1016 tests pass across 34 test files (phases.test.ts, system-prompt-boundary.test.ts confirmed).