### PR TITLE
fix: browser back button + duplicate session bugs (#228, #229)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -319,7 +319,6 @@ export function App() {
     sessions.setActiveSessionId(sessionId);
     const session = sessions.sessions.find(s => s.id === sessionId);
     if (session) {
-      // Rehydrate A2UI surfaces from stored messages so components render after reload
       a2ui.reset();
       for (const msg of session.messages) {
         if (msg.a2uiMessages && msg.a2uiMessages.length > 0) {
@@ -416,6 +415,23 @@ export function App() {
   const handleDismissViewer = useCallback(() => {
     setViewerFile(undefined);
   }, []);
+
+  // Wire navigation handler (popstate / initial deep-link)
+  navHandlerRef.current = (state: NavState) => {
+    if (state.view === 'session' && state.sessionId) {
+      handleResumeSession(state.sessionId, false);
+    } else {
+      handleNewSession(false);
+    }
+  };
+
+  // Restore deep-link on mount (e.g. #session/<id>)
+  useEffect(() => {
+    const initial = nav.getInitialState();
+    if (initial.view === 'session' && initial.sessionId) {
+      handleResumeSession(initial.sessionId, false);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Playground mode — standalone A2UI test harness
   if (playgroundEnabled) {


### PR DESCRIPTION
## Summary

Fixes two frontend bugs in a single PR since they share the same code path in `App.tsx`.

### Bug #228 — Browser back button does not navigate from chat to homepage
**Root cause:** `useNavigation` hook existed but was never integrated into `App.tsx`. All view transitions happened via React state without `pushState`/`popstate`.

**Fix:** Integrated `useNavigation` into `App` with a ref-based callback pattern to break circular dependency. `handleStartChat`, `handleNewSession`, and `handleResumeSession` now push browser history entries. A `popstate` handler restores the correct view. Deep-link restore on mount via `nav.getInitialState()`.

### Bug #229 — Duplicate sessions in Recent list + "Surface already exists" crash
**Root causes:**
1. `handleStartChat` used `setTimeout(() => handleSendMessage(prompt), 100)` — the stale closure captured `handleSendMessage` where `sessions.activeSessionId` was still null, causing a second `createSession` call.
2. `processCreateSurfaceMessage` threw `A2uiStateError` when replaying persisted A2UI messages that tried to re-create an existing surface.

**Fixes:**
1. Removed `setTimeout`, added `explicitSessionId` parameter to `handleSendMessage` so `handleStartChat` passes the session ID directly.
2. Made `processCreateSurfaceMessage` idempotent — returns instead of throwing on duplicate surface.
3. Added defensive dedup-by-ID in `loadSessions()` to handle any corrupt localStorage data.

### Files changed
- `packages/web/src/App.tsx` — Navigation integration + stale-closure fix
- `packages/web/src/hooks/useSessions.ts` — Defensive session dedup
- `packages/web/src/vendor/a2ui/web_core/processing/message-processor.ts` — Idempotent surface creation

### Testing
- All 1016 existing tests pass
- TypeScript check: no new errors in changed files

Closes #228
Closes #229

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)
Working as Leela (Lead Engineer)