### PR TITLE
feat: file manager sidebar with tree view and file viewer (#201)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,6 +6,7 @@ import { ChatShell } from './components/Chat/ChatShell';
 import { SessionsSidebar } from './components/Sidebar/SessionsSidebar';
 import { FileEditor } from './components/FileEditor/FileEditor';
 import { FileTreePanel } from './components/FileTreePanel';
+import { FileManagerSidebar, FileViewer } from './components/FileManager';
 import { Playground } from './pages/Playground';
 import { useA2UI } from './hooks/useA2UI';
 import { useActionDispatch } from './hooks/useActionDispatch';
@@ -20,6 +21,7 @@ import { useVirtualFS } from './contexts/VirtualFSContext';
 import { healthCheck } from './services/api-client';
 import { isMockMode, isPlaygroundMode } from './services/mock-streaming';
 import { VirtualFileSystem } from './services/virtual-fs';
+import type { VFSFile } from './services/virtual-fs';
 import type { AppMode, ChatMessage, A2uiMsg } from './types';
 // A2uiClientAction type no longer needed — actions route through useActionDispatch only
 
@@ -41,6 +43,8 @@ export function App() {
   const [isApiAvailable, setIsApiAvailable] = useState<boolean | null>(mockEnabled ? true : null);
   const [selectedFile, setSelectedFile] = useState<string | undefined>();
   const [filePanelOpen, setFilePanelOpen] = useState(true);
+  const [fileSidebarOpen, setFileSidebarOpen] = useState(true);
+  const [viewerFile, setViewerFile] = useState<string | undefined>();
 
   const connectorRegistry = useAPIConnectorRegistry();
 
@@ -60,7 +64,7 @@ export function App() {
   const fs = useMemo(() => new VirtualFileSystem(), []);
 
   // IndexedDB-backed persistent filesystem (provided via context)
-  const { fs: vfs, files: vfsFiles } = useVirtualFS();
+  const { fs: vfs, files: vfsFiles, fileRecords: vfsFileRecords } = useVirtualFS();
 
   // Sync in-memory VFS → IndexedDB when files complete (with deduplication)
   const lastPersistedRef = useRef<Map<string, string>>(new Map());
@@ -269,6 +273,7 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
+    setViewerFile(undefined);
     setMessages([]);
     setMode('chat');
     document.body.classList.remove('on-landing');
@@ -297,6 +302,7 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
+    setViewerFile(undefined);
   }, [sessions, a2ui, fs, vfs]);
 
   const handleNewSession = useCallback(() => {
@@ -304,6 +310,7 @@ export function App() {
     fs.clear();
     void vfs.clear();
     setSelectedFile(undefined);
+    setViewerFile(undefined);
     setMessages([]);
     setMode('landing');
     document.body.classList.add('on-landing');
@@ -332,17 +339,58 @@ export function App() {
   const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot);
   const hasFiles = fsFiles.length > 0 || vfsFiles.length > 0;
 
-  // Auto-show file panel when files appear
+  // Auto-show file panel and sidebar when files appear
   const hadFilesRef = useRef(false);
   useEffect(() => {
     if (hasFiles && !hadFilesRef.current) {
       setFilePanelOpen(true);
+      setFileSidebarOpen(true);
     }
     hadFilesRef.current = hasFiles;
   }, [hasFiles]);
 
   const handleToggleFilePanel = useCallback(() => {
     setFilePanelOpen((prev) => !prev);
+    setFileSidebarOpen((prev) => !prev);
+  }, []);
+
+  // --- File Manager sidebar / viewer handlers ---
+  const handleSelectViewerFile = useCallback((path: string) => {
+    setViewerFile(path);
+  }, []);
+
+  const handleDownloadZip = useCallback(async () => {
+    try {
+      const blob = await vfs.exportZip();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'kickstart-files.zip';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('[FileManager] ZIP export failed:', err);
+    }
+  }, [vfs]);
+
+  const handleDeleteViewerFile = useCallback(async (path: string) => {
+    try {
+      await vfs.deleteFile(path);
+    } catch {
+      // file may not exist in IndexedDB
+    }
+    fs.delete(path);
+    if (viewerFile === path) setViewerFile(undefined);
+    if (selectedFile === path) setSelectedFile(undefined);
+    setViewerFile(undefined);
+  }, [vfs, fs, viewerFile, selectedFile]);
+
+  const handleDismissSidebar = useCallback(() => {
+    setFileSidebarOpen(false);
+  }, []);
+
+  const handleDismissViewer = useCallback(() => {
+    setViewerFile(undefined);
   }, []);
 
   // Playground mode — standalone A2UI test harness
@@ -371,6 +419,8 @@ export function App() {
         showSessionsToggle={mode === 'chat'}
         hasFiles={hasFiles && filePanelOpen}
         showFilePanel={mode === 'chat' && filePanelOpen}
+        showFileSidebar={mode === 'chat' && fileSidebarOpen && hasFiles}
+        showFileViewer={mode === 'chat' && !!viewerFile}
         onToggleFilePanel={mode === 'chat' && hasFiles ? handleToggleFilePanel : undefined}
         sidebar={mode === 'chat' ? (
           <SessionsSidebar
@@ -392,6 +442,25 @@ export function App() {
             />
             <FileTreePanel />
           </>
+        ) : undefined}
+        fileManagerSidebar={mode === 'chat' ? (
+          <FileManagerSidebar
+            streamingFiles={fsFiles}
+            persistedFiles={vfsFileRecords}
+            selectedPath={viewerFile}
+            onSelectFile={handleSelectViewerFile}
+            onDownloadZip={handleDownloadZip}
+            onDismiss={handleDismissSidebar}
+          />
+        ) : undefined}
+        fileViewer={mode === 'chat' ? (
+          <FileViewer
+            filePath={viewerFile}
+            streamingFiles={fsFiles}
+            vfs={vfs}
+            onDeleteFile={handleDeleteViewerFile}
+            onDismiss={handleDismissViewer}
+          />
         ) : undefined}
       >
         {mode === 'landing' ? (

--- a/packages/web/src/components/FileManager/FileManagerSidebar.tsx
+++ b/packages/web/src/components/FileManager/FileManagerSidebar.tsx
@@ -1,0 +1,378 @@
+/**
+ * @module FileManagerSidebar
+ *
+ * Left-side collapsible sidebar that displays a unified file tree
+ * combining in-memory streaming files (VirtualFileSystem) and
+ * IndexedDB-backed persisted files (VirtualFS).
+ *
+ * Streaming files take precedence (they carry real-time generating status).
+ */
+
+import React, { useMemo, useCallback } from 'react';
+import {
+  makeStyles,
+  tokens,
+  shorthands,
+  Button,
+  Text,
+  Spinner,
+  mergeClasses,
+} from '@fluentui/react-components';
+import {
+  FolderRegular,
+  FolderOpenRegular,
+  DocumentRegular,
+  ChevronRightRegular,
+  ChevronDownRegular,
+  DismissRegular,
+  ArrowDownloadRegular,
+} from '@fluentui/react-icons';
+import type { VirtualFile, VFSFile, FileTreeNode } from '../../services/virtual-fs';
+import { buildFileTree } from '../../services/virtual-fs';
+
+/* ------------------------------------------------------------------ */
+/*  Styles                                                             */
+/* ------------------------------------------------------------------ */
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '260px',
+    minWidth: '200px',
+    maxWidth: '360px',
+    height: '100%',
+    backgroundColor: tokens.colorNeutralBackground2,
+    ...shorthands.borderRight(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+    overflowY: 'auto',
+    overflowX: 'hidden',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalS,
+    paddingLeft: tokens.spacingHorizontalM,
+    paddingRight: tokens.spacingHorizontalS,
+    ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+  },
+  headerTitle: {
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  headerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalXS,
+  },
+  treeList: {
+    listStyleType: 'none',
+    ...shorthands.margin(0),
+    ...shorthands.padding(0),
+  },
+  treeItem: {
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    paddingTop: '2px',
+    paddingBottom: '2px',
+    paddingRight: tokens.spacingHorizontalS,
+    ':hover': {
+      backgroundColor: tokens.colorNeutralBackground2Hover,
+    },
+  },
+  treeItemSelected: {
+    backgroundColor: tokens.colorNeutralBackground2Selected,
+  },
+  treeChevron: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '16px',
+    flexShrink: 0,
+  },
+  treeIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    marginRight: tokens.spacingHorizontalXS,
+    flexShrink: 0,
+  },
+  treeName: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  generating: {
+    animationName: {
+      '0%': { opacity: 0.5 },
+      '50%': { opacity: 1 },
+      '100%': { opacity: 0.5 },
+    },
+    animationDuration: '1.5s',
+    animationIterationCount: 'infinite',
+  },
+  empty: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: tokens.spacingVerticalXXL,
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Merge streaming (in-memory) and persisted (IndexedDB) files into a single
+ * tree. Streaming files win when both sources have the same path.
+ */
+function buildMergedTree(
+  streamingFiles: VirtualFile[],
+  persistedFiles: VFSFile[],
+): FileTreeNode[] {
+  const streamingPaths = new Set(streamingFiles.map((f) => f.path));
+
+  // Convert streaming files to VFSFile-like shape for buildFileTree
+  const streamingAsVfs: VFSFile[] = streamingFiles.map((f) => ({
+    path: f.path,
+    content: f.content,
+    language: f.language,
+    createdAt: f.createdAt,
+    updatedAt: f.updatedAt,
+  }));
+
+  const filteredPersisted = persistedFiles.filter((f) => !streamingPaths.has(f.path));
+  const allFiles = [...streamingAsVfs, ...filteredPersisted];
+  const tree = buildFileTree(allFiles);
+
+  // Annotate nodes with streaming VirtualFile reference for status
+  const streamingMap = new Map(streamingFiles.map((f) => [f.path, f]));
+  function annotate(nodes: FileTreeNode[]) {
+    for (const node of nodes) {
+      if (!node.isDirectory) {
+        const sf = streamingMap.get(node.path);
+        if (sf) {
+          node.file = sf;
+        }
+      }
+      if (node.children) annotate(node.children);
+    }
+  }
+  annotate(tree);
+  return tree;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tree node component                                                */
+/* ------------------------------------------------------------------ */
+
+interface SidebarTreeNodeProps {
+  node: FileTreeNode;
+  depth: number;
+  expandedFolders: Set<string>;
+  onToggleFolder: (path: string) => void;
+  selectedPath?: string;
+  onSelectFile: (path: string) => void;
+}
+
+function SidebarTreeNode({
+  node,
+  depth,
+  expandedFolders,
+  onToggleFolder,
+  selectedPath,
+  onSelectFile,
+}: SidebarTreeNodeProps) {
+  const styles = useStyles();
+  const isExpanded = expandedFolders.has(node.path);
+  const isSelected = !node.isDirectory && node.path === selectedPath;
+  const isGenerating = node.file?.status === 'generating';
+
+  const handleClick = useCallback(() => {
+    if (node.isDirectory) {
+      onToggleFolder(node.path);
+    } else {
+      onSelectFile(node.path);
+    }
+  }, [node.isDirectory, node.path, onToggleFolder, onSelectFile]);
+
+  return (
+    <li>
+      <div
+        className={mergeClasses(
+          styles.treeItem,
+          isSelected && styles.treeItemSelected,
+          isGenerating && styles.generating,
+        )}
+        style={{ paddingLeft: `${depth * 16 + 4}px` }}
+        role="treeitem"
+        aria-selected={isSelected}
+        aria-expanded={node.isDirectory ? isExpanded : undefined}
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+      >
+        <span className={styles.treeChevron}>
+          {node.isDirectory ? (
+            isExpanded ? <ChevronDownRegular fontSize={12} /> : <ChevronRightRegular fontSize={12} />
+          ) : null}
+        </span>
+        <span className={styles.treeIcon}>
+          {node.isDirectory ? (
+            isExpanded ? <FolderOpenRegular fontSize={16} /> : <FolderRegular fontSize={16} />
+          ) : (
+            isGenerating ? <Spinner size="tiny" /> : <DocumentRegular fontSize={16} />
+          )}
+        </span>
+        <Text size={200} className={styles.treeName} title={node.name}>
+          {node.name}
+        </Text>
+      </div>
+      {node.isDirectory && isExpanded && node.children && (
+        <ul className={styles.treeList} role="group">
+          {node.children.map((child) => (
+            <SidebarTreeNode
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              expandedFolders={expandedFolders}
+              onToggleFolder={onToggleFolder}
+              selectedPath={selectedPath}
+              onSelectFile={onSelectFile}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
+
+export interface FileManagerSidebarProps {
+  /** In-memory streaming files (real-time generation). */
+  streamingFiles: VirtualFile[];
+  /** IndexedDB-backed persisted files. */
+  persistedFiles: VFSFile[];
+  /** Currently selected file path in the viewer. */
+  selectedPath?: string;
+  /** Called when user clicks a file node. */
+  onSelectFile: (path: string) => void;
+  /** Called to download all files as ZIP. */
+  onDownloadZip?: () => void;
+  /** Called to dismiss / close the sidebar. */
+  onDismiss: () => void;
+}
+
+export function FileManagerSidebar({
+  streamingFiles,
+  persistedFiles,
+  selectedPath,
+  onSelectFile,
+  onDownloadZip,
+  onDismiss,
+}: FileManagerSidebarProps) {
+  const styles = useStyles();
+
+  const tree = useMemo(
+    () => buildMergedTree(streamingFiles, persistedFiles),
+    [streamingFiles, persistedFiles],
+  );
+
+  // Count all leaf (non-directory) files
+  const fileCount = useMemo(() => {
+    function count(nodes: FileTreeNode[]): number {
+      return nodes.reduce(
+        (acc, n) => acc + (n.isDirectory ? count(n.children ?? []) : 1),
+        0,
+      );
+    }
+    return count(tree);
+  }, [tree]);
+
+  // Auto-expand all folders by default
+  const [expandedFolders, setExpandedFolders] = React.useState<Set<string>>(new Set());
+  React.useEffect(() => {
+    function collectDirs(nodes: FileTreeNode[], set: Set<string>) {
+      for (const n of nodes) {
+        if (n.isDirectory) {
+          set.add(n.path);
+          if (n.children) collectDirs(n.children, set);
+        }
+      }
+    }
+    const dirs = new Set<string>();
+    collectDirs(tree, dirs);
+    setExpandedFolders((prev) => {
+      const merged = new Set(prev);
+      for (const d of dirs) merged.add(d);
+      return merged;
+    });
+  }, [tree]);
+
+  const handleToggleFolder = useCallback((path: string) => {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className={styles.root} data-testid="file-manager-sidebar">
+      <div className={styles.header}>
+        <Text className={styles.headerTitle} size={300}>
+          Files{fileCount > 0 ? ` (${fileCount})` : ''}
+        </Text>
+        <div className={styles.headerActions}>
+          {onDownloadZip && fileCount > 0 && (
+            <Button
+              appearance="subtle"
+              size="small"
+              icon={<ArrowDownloadRegular />}
+              title="Download ZIP"
+              onClick={onDownloadZip}
+            />
+          )}
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={<DismissRegular />}
+            title="Close file panel"
+            onClick={onDismiss}
+          />
+        </div>
+      </div>
+
+      {fileCount === 0 ? (
+        <div className={styles.empty}>
+          <Text size={200}>No files yet</Text>
+        </div>
+      ) : (
+        <ul className={styles.treeList} role="tree">
+          {tree.map((node) => (
+            <SidebarTreeNode
+              key={node.path}
+              node={node}
+              depth={0}
+              expandedFolders={expandedFolders}
+              onToggleFolder={handleToggleFolder}
+              selectedPath={selectedPath}
+              onSelectFile={onSelectFile}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/FileManager/FileViewer.tsx
+++ b/packages/web/src/components/FileManager/FileViewer.tsx
@@ -1,0 +1,327 @@
+/**
+ * @module FileViewer
+ *
+ * Right-side panel that displays the content of a selected file with
+ * syntax highlighting (via highlight.js), a language badge, and
+ * copy / download / delete actions.
+ */
+
+import React, { useMemo, useEffect, useState, useCallback } from 'react';
+import {
+  makeStyles,
+  tokens,
+  shorthands,
+  Button,
+  Badge,
+  Text,
+  Spinner,
+  mergeClasses,
+} from '@fluentui/react-components';
+import {
+  CopyRegular,
+  ArrowDownloadRegular,
+  DeleteRegular,
+  DismissRegular,
+} from '@fluentui/react-icons';
+import hljs from 'highlight.js/lib/core';
+
+// Register common languages
+import typescript from 'highlight.js/lib/languages/typescript';
+import javascript from 'highlight.js/lib/languages/javascript';
+import python from 'highlight.js/lib/languages/python';
+import json from 'highlight.js/lib/languages/json';
+import yaml from 'highlight.js/lib/languages/yaml';
+import xml from 'highlight.js/lib/languages/xml';
+import css from 'highlight.js/lib/languages/css';
+import markdown from 'highlight.js/lib/languages/markdown';
+import bash from 'highlight.js/lib/languages/bash';
+import sql from 'highlight.js/lib/languages/sql';
+import go from 'highlight.js/lib/languages/go';
+import rust from 'highlight.js/lib/languages/rust';
+import java from 'highlight.js/lib/languages/java';
+import csharp from 'highlight.js/lib/languages/csharp';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('html', xml);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('shell', bash);
+hljs.registerLanguage('sql', sql);
+hljs.registerLanguage('go', go);
+hljs.registerLanguage('rust', rust);
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('csharp', csharp);
+hljs.registerLanguage('dockerfile', dockerfile);
+
+import type { VirtualFile, VFSFile } from '../../services/virtual-fs';
+import type { VirtualFS } from '../../services/virtual-fs';
+
+/* ------------------------------------------------------------------ */
+/*  Styles                                                             */
+/* ------------------------------------------------------------------ */
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '45%',
+    minWidth: '320px',
+    maxWidth: '55%',
+    height: '100%',
+    backgroundColor: tokens.colorNeutralBackground1,
+    ...shorthands.borderLeft(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+    overflowY: 'auto',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalS,
+    paddingLeft: tokens.spacingHorizontalM,
+    paddingRight: tokens.spacingHorizontalS,
+    ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+  },
+  headerLeft: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalS,
+    overflow: 'hidden',
+    flex: 1,
+  },
+  headerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalXS,
+    flexShrink: 0,
+  },
+  fileName: {
+    fontWeight: tokens.fontWeightSemibold,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  codeBlock: {
+    flex: 1,
+    overflowY: 'auto',
+    ...shorthands.margin(0),
+    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase200,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  },
+  generating: {
+    animationName: {
+      '0%': { opacity: 0.5 },
+      '50%': { opacity: 1 },
+      '100%': { opacity: 0.5 },
+    },
+    animationDuration: '1.5s',
+    animationIterationCount: 'infinite',
+  },
+  empty: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const LANG_DISPLAY: Record<string, string> = {
+  typescript: 'TypeScript',
+  javascript: 'JavaScript',
+  python: 'Python',
+  json: 'JSON',
+  yaml: 'YAML',
+  xml: 'XML',
+  html: 'HTML',
+  css: 'CSS',
+  markdown: 'Markdown',
+  bash: 'Bash',
+  shell: 'Shell',
+  sql: 'SQL',
+  go: 'Go',
+  rust: 'Rust',
+  java: 'Java',
+  csharp: 'C#',
+  dockerfile: 'Dockerfile',
+  plaintext: 'Text',
+};
+
+function highlightCode(content: string, language: string): string {
+  try {
+    if (hljs.getLanguage(language)) {
+      return hljs.highlight(content, { language }).value;
+    }
+  } catch {
+    // fall through
+  }
+  return hljs.highlightAuto(content).value;
+}
+
+function downloadFile(path: string, content: string) {
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = path.split('/').pop() ?? 'file';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
+
+export interface FileViewerProps {
+  /** Path of the file to display. */
+  filePath: string | undefined;
+  /** In-memory streaming files for real-time lookup. */
+  streamingFiles: VirtualFile[];
+  /** The IndexedDB-backed VirtualFS for persisted file lookup. */
+  vfs: VirtualFS;
+  /** Called when the user deletes the file. */
+  onDeleteFile?: (path: string) => void;
+  /** Called to close the viewer. */
+  onDismiss: () => void;
+}
+
+export function FileViewer({
+  filePath,
+  streamingFiles,
+  vfs,
+  onDeleteFile,
+  onDismiss,
+}: FileViewerProps) {
+  const styles = useStyles();
+  const [copied, setCopied] = useState(false);
+
+  // Try streaming (in-memory) first
+  const streamingFile = useMemo(
+    () => (filePath ? streamingFiles.find((f) => f.path === filePath) : undefined),
+    [filePath, streamingFiles],
+  );
+
+  // Fall back to IndexedDB persisted file
+  const [persistedFile, setPersistedFile] = useState<VFSFile | undefined>();
+  useEffect(() => {
+    if (!filePath || streamingFile) {
+      setPersistedFile(undefined);
+      return;
+    }
+    let cancelled = false;
+    vfs.getFile(filePath).then((f) => {
+      if (!cancelled) setPersistedFile(f);
+    }).catch(() => {
+      if (!cancelled) setPersistedFile(undefined);
+    });
+    return () => { cancelled = true; };
+  }, [filePath, streamingFile, vfs]);
+
+  const file = streamingFile ?? persistedFile;
+  const isGenerating = streamingFile?.status === 'generating';
+  const language = file?.language ?? 'plaintext';
+  const content = file?.content ?? '';
+  const fileName = filePath?.split('/').pop() ?? '';
+
+  const highlighted = useMemo(
+    () => (content ? highlightCode(content, language) : ''),
+    [content, language],
+  );
+
+  const handleCopy = useCallback(async () => {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard not available
+    }
+  }, [content]);
+
+  const handleDownload = useCallback(() => {
+    if (filePath && content) downloadFile(filePath, content);
+  }, [filePath, content]);
+
+  const handleDelete = useCallback(() => {
+    if (filePath && onDeleteFile) onDeleteFile(filePath);
+  }, [filePath, onDeleteFile]);
+
+  if (!filePath) {
+    return (
+      <div className={styles.root} data-testid="file-viewer">
+        <div className={styles.empty}>
+          <Text size={200}>Select a file to view</Text>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.root} data-testid="file-viewer">
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <Text className={styles.fileName} size={300} title={filePath}>
+            {fileName}
+          </Text>
+          <Badge appearance="outline" size="small">
+            {LANG_DISPLAY[language] ?? language}
+          </Badge>
+          {isGenerating && <Spinner size="tiny" label="Generating…" />}
+        </div>
+        <div className={styles.headerActions}>
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={<CopyRegular />}
+            title={copied ? 'Copied!' : 'Copy to clipboard'}
+            onClick={handleCopy}
+          />
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={<ArrowDownloadRegular />}
+            title="Download file"
+            onClick={handleDownload}
+          />
+          {onDeleteFile && (
+            <Button
+              appearance="subtle"
+              size="small"
+              icon={<DeleteRegular />}
+              title="Delete file"
+              onClick={handleDelete}
+            />
+          )}
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={<DismissRegular />}
+            title="Close viewer"
+            onClick={onDismiss}
+          />
+        </div>
+      </div>
+
+      <pre
+        className={mergeClasses(styles.codeBlock, isGenerating && styles.generating)}
+        dangerouslySetInnerHTML={{ __html: highlighted }}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/FileManager/index.ts
+++ b/packages/web/src/components/FileManager/index.ts
@@ -1,0 +1,2 @@
+export { FileManagerSidebar } from './FileManagerSidebar';
+export { FileViewer } from './FileViewer';

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -8,8 +8,12 @@ interface LayoutProps {
   showSessionsToggle: boolean;
   sidebar?: React.ReactNode;
   fileEditor?: React.ReactNode;
+  fileManagerSidebar?: React.ReactNode;
+  fileViewer?: React.ReactNode;
   hasFiles?: boolean;
   showFilePanel?: boolean;
+  showFileSidebar?: boolean;
+  showFileViewer?: boolean;
   onToggleFilePanel?: () => void;
   children: React.ReactNode;
 }
@@ -21,8 +25,12 @@ export function Layout({
   showSessionsToggle,
   sidebar,
   fileEditor,
+  fileManagerSidebar,
+  fileViewer,
   hasFiles,
   showFilePanel,
+  showFileSidebar,
+  showFileViewer,
   onToggleFilePanel,
   children,
 }: LayoutProps) {
@@ -38,10 +46,12 @@ export function Layout({
       />
       <div className={`app-layout${hasFiles ? ' has-files' : ''}`}>
         {sidebar}
+        {showFileSidebar && fileManagerSidebar}
         <main className="chat-main" role="main">
           {children}
         </main>
         {showFilePanel && fileEditor}
+        {showFileViewer && fileViewer}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Add **FileManagerSidebar** and **FileViewer** components that provide a centralized file browser for all generated project files.

### New components
- **FileManagerSidebar** — left-side collapsible tree that merges streaming (in-memory VFS) and persisted (IndexedDB VFS) files. Fluent UI Tree, Griffel styles, generating animation, download ZIP, dismiss.
- **FileViewer** — right-side panel with highlight.js syntax highlighting, language badge, copy/download/delete actions, and generating indicator.

### Changes
- **Layout.tsx** — new props: `fileManagerSidebar`, `fileViewer`, `showFileSidebar`, `showFileViewer`
- **App.tsx** — new state (`fileSidebarOpen`, `viewerFile`), handlers (select, ZIP download, delete, dismiss), Layout prop wiring
- Folder toggle in Topbar now controls both sidebar and file panel simultaneously
- `viewerFile` state is cleared on session reset / new session / clear all

### Testing
- TypeScript: `npx tsc --noEmit` ✅ (no new errors)
- Vite build: ✅
- Vitest: all 1016 tests pass ✅

Closes #201

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)