### PR TITLE
fix: Playground gray rectangle + consistent Fluent UI button styling

### DIFF
--- a/packages/web/css/playground.css
+++ b/packages/web/css/playground.css
@@ -25,7 +25,6 @@
   overflow-y: auto;
   overflow-x: hidden;
   padding: 24px;
-  background: var(--color-neutral-background-3);
 }
 
 .playground-gallery {

--- a/packages/web/src/pages/playground-scenarios.ts
+++ b/packages/web/src/pages/playground-scenarios.ts
@@ -172,12 +172,9 @@ const inputButton = (): A2uiMsg[] => {
     { id: 'root', component: 'Column', children: ['heading', 'btn-row'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'Button Variants', variant: 'h3' },
     { id: 'btn-row', component: 'Row', children: ['btn-primary', 'btn-outlined', 'btn-text'], gap: 'medium' },
-    { id: 'btn-primary', component: 'Button', child: 'bp-label', variant: 'primary', action: { event: { name: 'deploy' } } },
-    { id: 'bp-label', component: 'Text', text: 'Deploy Now' },
-    { id: 'btn-outlined', component: 'Button', child: 'bo-label', variant: 'outlined', action: { event: { name: 'preview' } } },
-    { id: 'bo-label', component: 'Text', text: 'Preview' },
-    { id: 'btn-text', component: 'Button', child: 'bt-label', variant: 'text', action: { event: { name: 'cancel' } } },
-    { id: 'bt-label', component: 'Text', text: 'Cancel' },
+    { id: 'btn-primary', component: 'Button', label: 'Deploy Now', variant: 'primary', action: { event: { name: 'deploy' } } },
+    { id: 'btn-outlined', component: 'Button', label: 'Preview', variant: 'outlined', action: { event: { name: 'preview' } } },
+    { id: 'btn-text', component: 'Button', label: 'Cancel', variant: 'text', action: { event: { name: 'cancel' } } },
   ] as A2uiComponent[]);
 };
 
@@ -247,16 +244,13 @@ const inputModal = (): A2uiMsg[] => {
     { id: 'root', component: 'Column', children: ['heading', 'modal1'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'Modal Component', variant: 'h3' },
     { id: 'modal1', component: 'Modal', trigger: 'modal-trigger', content: 'modal-content' },
-    { id: 'modal-trigger', component: 'Button', child: 'trigger-label', variant: 'primary' },
-    { id: 'trigger-label', component: 'Text', text: 'Open confirmation' },
+    { id: 'modal-trigger', component: 'Button', label: 'Open confirmation', variant: 'primary' },
     { id: 'modal-content', component: 'Column', children: ['mc-title', 'mc-body', 'mc-actions'], gap: 'medium' },
     { id: 'mc-title', component: 'Text', text: 'Confirm deployment', variant: 'h3' },
     { id: 'mc-body', component: 'Text', text: 'This will deploy your application to the production environment. Are you sure?', variant: 'body1' },
     { id: 'mc-actions', component: 'Row', children: ['mc-confirm', 'mc-cancel'], gap: 'medium' },
-    { id: 'mc-confirm', component: 'Button', child: 'mc-confirm-label', variant: 'primary', action: { event: { name: 'confirm-deploy' } } },
-    { id: 'mc-confirm-label', component: 'Text', text: 'Deploy' },
-    { id: 'mc-cancel', component: 'Button', child: 'mc-cancel-label', variant: 'outlined' },
-    { id: 'mc-cancel-label', component: 'Text', text: 'Cancel' },
+    { id: 'mc-confirm', component: 'Button', label: 'Deploy', variant: 'primary', action: { event: { name: 'confirm-deploy' } } },
+    { id: 'mc-cancel', component: 'Button', label: 'Cancel', variant: 'outlined' },
   ] as A2uiComponent[]);
 };
 
@@ -886,10 +880,8 @@ const fileEditorCreateFlow = (): A2uiMsg[] => {
       ],
     },
     { id: 'actions', component: 'Row', children: ['accept-btn', 'edit-btn'], gap: 'medium' },
-    { id: 'accept-btn', component: 'Button', child: 'accept-label', variant: 'primary', action: { event: { name: 'accept-files' } } },
-    { id: 'accept-label', component: 'Text', text: 'Accept All' },
-    { id: 'edit-btn', component: 'Button', child: 'edit-label', variant: 'outlined', action: { event: { name: 'edit-files' } } },
-    { id: 'edit-label', component: 'Text', text: 'Edit Before Saving' },
+    { id: 'accept-btn', component: 'Button', label: 'Accept All', variant: 'primary', action: { event: { name: 'accept-files' } } },
+    { id: 'edit-btn', component: 'Button', label: 'Edit Before Saving', variant: 'outlined', action: { event: { name: 'edit-files' } } },
   ] as A2uiComponent[]);
 };
 
@@ -954,10 +946,8 @@ router.delete('/api/users/:id', async (req, res) => {
 export default router;`,
       },
       { id: 'actions', component: 'Row', children: ['save-btn', 'revert-btn'], gap: 'medium' },
-      { id: 'save-btn', component: 'Button', child: 'save-label', variant: 'primary', action: { event: { name: 'save-file' } } },
-      { id: 'save-label', component: 'Text', text: 'Save Changes' },
-      { id: 'revert-btn', component: 'Button', child: 'revert-label', variant: 'outlined', action: { event: { name: 'revert-file' } } },
-      { id: 'revert-label', component: 'Text', text: 'Revert' },
+      { id: 'save-btn', component: 'Button', label: 'Save Changes', variant: 'primary', action: { event: { name: 'save-file' } } },
+      { id: 'revert-btn', component: 'Button', label: 'Revert', variant: 'outlined', action: { event: { name: 'revert-file' } } },
     ] } } as A2uiMsg,
   ];
 };
@@ -1243,10 +1233,8 @@ const phaseReviewScenario = (): A2uiMsg[] => {
     { id: 'ck4', component: 'CheckBox', label: '⚠️ Autoscaler max replicas set to 8 (consider increasing for production)', value: true },
     { id: 'ck5', component: 'CheckBox', label: '✅ Resource quotas defined', value: true },
     { id: 'actions', component: 'Row', children: ['deploy-btn', 'back-btn'], gap: 'medium' },
-    { id: 'deploy-btn', component: 'Button', child: 'deploy-label', variant: 'primary', action: { event: { name: 'approve-deploy' } } },
-    { id: 'deploy-label', component: 'Text', text: 'Approve & Deploy' },
-    { id: 'back-btn', component: 'Button', child: 'back-label', variant: 'outlined', action: { event: { name: 'back-to-generate' } } },
-    { id: 'back-label', component: 'Text', text: 'Back to Generate' },
+    { id: 'deploy-btn', component: 'Button', label: 'Approve & Deploy', variant: 'primary', action: { event: { name: 'approve-deploy' } } },
+    { id: 'back-btn', component: 'Button', label: 'Back to Generate', variant: 'outlined', action: { event: { name: 'back-to-generate' } } },
   ] as A2uiComponent[]);
 };
 

--- a/packages/web/src/services/demo-scenarios.ts
+++ b/packages/web/src/services/demo-scenarios.ts
@@ -59,12 +59,10 @@ const ARCHITECTURE: DemoResponse = {
     { id: 'r4-value', component: 'Text', text: 'AKS Automatic (zero-config Kubernetes)', variant: 'body2' },
     { id: 'divider2', component: 'Divider' },
     { id: 'actions-row', component: 'Row', children: ['approve-btn', 'modify-btn'], gap: 'small' },
-    { id: 'approve-btn', component: 'Button', child: 'approve-text', variant: 'primary',
+    { id: 'approve-btn', component: 'Button', label: "Looks good, let's build it", variant: 'primary',
       action: { event: { name: 'approve-arch' } } },
-    { id: 'approve-text', component: 'Text', text: "Looks good, let's build it" },
-    { id: 'modify-btn', component: 'Button', child: 'modify-text', variant: 'outlined',
+    { id: 'modify-btn', component: 'Button', label: 'I want to change something', variant: 'outlined',
       action: { event: { name: 'modify-arch' } } },
-    { id: 'modify-text', component: 'Text', text: 'I want to change something' },
   ]),
 };
 
@@ -217,12 +215,10 @@ const REVIEW_EXPANDED: DemoResponse = {
     // Actions
     { id: 'rev-divider', component: 'Divider' },
     { id: 'rev-actions', component: 'Row', children: ['approve-btn', 'modify-btn'], gap: 'small' },
-    { id: 'approve-btn', component: 'Button', child: 'approve-text', variant: 'primary',
+    { id: 'approve-btn', component: 'Button', label: 'Approve and continue', variant: 'primary',
       action: { event: { name: 'approve-review' } } },
-    { id: 'approve-text', component: 'Text', text: 'Approve and continue' },
-    { id: 'modify-btn', component: 'Button', child: 'modify-text', variant: 'outlined',
+    { id: 'modify-btn', component: 'Button', label: 'Change something', variant: 'outlined',
       action: { event: { name: 'modify-review' } } },
-    { id: 'modify-text', component: 'Text', text: 'Change something' },
   ]),
 };
 
@@ -260,12 +256,10 @@ const HANDOFF: DemoResponse = {
     { id: 'next-md', component: 'Markdown', content: 'Your code is on GitHub with CI/CD ready. Every push to `main` triggers **build → test → deploy**.' },
     { id: 'next-divider', component: 'Divider' },
     { id: 'next-actions', component: 'Row', children: ['codespace-btn', 'deploy-btn'], gap: 'small' },
-    { id: 'codespace-btn', component: 'Button', child: 'cs-text', variant: 'primary',
+    { id: 'codespace-btn', component: 'Button', label: 'Open in Codespaces', variant: 'primary',
       action: { event: { name: 'open-codespace' } } },
-    { id: 'cs-text', component: 'Text', text: 'Open in Codespaces' },
-    { id: 'deploy-btn', component: 'Button', child: 'deploy-text', variant: 'outlined',
+    { id: 'deploy-btn', component: 'Button', label: 'Deploy now', variant: 'outlined',
       action: { event: { name: 'start-deploy' } } },
-    { id: 'deploy-text', component: 'Text', text: 'Deploy now' },
   ]),
 };
 
@@ -345,9 +339,8 @@ const CONFIGURE_FORM: DemoResponse = {
       { id: 'python', label: 'Python 3.12', description: 'Great for APIs and data services' },
       { id: 'dotnet', label: '.NET 8', description: 'Enterprise-grade C# runtime' },
     ], value: '', action: { event: { name: 'select-runtime' } } },
-    { id: 'continue-btn', component: 'Button', child: 'continue-text', variant: 'primary',
+    { id: 'continue-btn', component: 'Button', label: 'Continue →', variant: 'primary',
       action: { event: { name: 'continue-config' } } },
-    { id: 'continue-text', component: 'Text', text: 'Continue →' },
   ]),
 };
 


### PR DESCRIPTION
## Summary

Fixes two visual bugs for demo readiness:

### #253 — Gray rectangle at bottom of Playground
Removed the distinct `background` color from `.playground-gallery-scroll` in `playground.css`. The scroll area used `var(--color-neutral-background-3)` which created a visible gray rectangle below the masonry gallery cards. The scroll container still fills the remaining space (flex: 1) but now inherits the parent background seamlessly.

### #254 — Inconsistent button styling across A2UI components
All action buttons in playground scenarios and demo scenarios were using the `child` + separate `Text` component pattern to set their label, e.g.:
```json
{ "id": "save-btn", "component": "Button", "child": "save-label", ... }
{ "id": "save-label", "component": "Text", "text": "Save Changes" }
```
This rendered a full `Text` component inside the `FluentButton`, causing inconsistent font size/color styling. The reference "Submit" button correctly used the `label` prop directly:
```json
{ "id": "submit-btn", "component": "Button", "label": "Submit", ... }
```
Converted all 15 buttons across both files to use `label` instead of `child` + Text, removing the orphaned Text components.

**Note:** The Alert component already uses Fluent UI `MessageBar` correctly (both basic catalog and fluent override). No Alert changes needed.

### Files changed
- `packages/web/css/playground.css` — removed background from gallery scroll area
- `packages/web/src/pages/playground-scenarios.ts` — 10 buttons converted to `label` prop
- `packages/web/src/services/demo-scenarios.ts` — 5 buttons converted to `label` prop

Closes #253
Closes #254

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)