### PR TITLE
docs: Integration Kits reference + A2UI catalog visual references

### DIFF
--- a/docs/a2ui-catalog.md
+++ b/docs/a2ui-catalog.md
@@ -2,7 +2,110 @@
 
 A2UI (Agent-to-UI) v0.9 is the component protocol Kickstart uses to render rich interactive UI alongside AI responses. The LLM returns structured A2UI JSON; the web surface renders it using React 19 with Fluent 2 styling.
 
-> **Related docs:** [MCP Server](./mcp-server.md) for catalog negotiation · [API Reference](./api-reference.md) for the web endpoint
+> **Related docs:** [MCP Server](./mcp-server.md) for catalog negotiation · [API Reference](./api-reference.md) for the web endpoint · [Integration Kits](./integration-kits.md) for kit-contributed components
+
+> 💡 **Try it live:** All components can be tested interactively in the [Playground](https://kickstart.aks.azure.sabbour.me/?playground). Select any component from the sidebar to see it rendered with sample data.
+
+---
+
+## Component Gallery
+
+The Playground organizes every component into scenario groups. The tables below map each component to its playground group so you can find and test it instantly.
+
+### Layout Components
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| Row | a2ui | Horizontal flex layout | Layout |
+| Column | a2ui | Vertical flex layout | Layout |
+| List | a2ui | Ordered list of items | Layout |
+| Card | a2ui | Content card wrapper | Layout |
+| Tabs | a2ui | Tabbed content panels | Layout |
+| Divider | a2ui | Horizontal separator | Layout |
+| Accordion | a2ui | Collapsible FAQ sections | Layout |
+
+### Content Components
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| Text | a2ui | All text variants (h1–overline) | Content |
+| Image | a2ui | Image with placeholder fallback | Content |
+| Alert | a2ui | Info / success / warning / error messages | Content |
+| Badge | a2ui | Status, counter, and presence badges | Content |
+| Icon | a2ui | Fluent icon display | Content |
+| Link | a2ui | Hyperlinks with external indicator | Content |
+| Table | a2ui | Striped data table with caption | Content |
+| AudioPlayer | a2ui | HTML5 audio with controls | Content |
+| Video | a2ui | HTML5 video with 16:9 player | Content |
+
+### Input Components
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| Button | a2ui | Primary / outlined / text variants | Inputs |
+| TextField | a2ui | Text input with label and validation | Inputs |
+| CheckBox | a2ui | Toggle checkboxes | Inputs |
+| ChoicePicker | a2ui | Chips and list selection variants | Inputs |
+| Slider | a2ui | Range slider control | Inputs |
+| DateTimeInput | a2ui | Date and time picker | Inputs |
+| Modal | a2ui | Modal dialog with trigger | Inputs |
+| ComboBox | a2ui | Dropdown with search and custom entry | Inputs |
+| MultiSelect | a2ui | Multi-value dropdown | Inputs |
+| Toggle | a2ui | On/off switch control | Inputs |
+
+### Custom Kickstart Components
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| RadioGroup | kickstart | Radio options with descriptions | Custom Controls |
+| FormGroup | kickstart | Stepped form sections with validation | Custom Controls |
+| SteppedCarousel | kickstart | Wizard-style stepped carousel | Custom Controls |
+| CodeBlock | kickstart | Syntax-highlighted code with copy/download | Custom Controls |
+| ProgressSteps | kickstart | Multi-step progress tracker | Custom Controls |
+| ArchitectureDiagram | kickstart | Mermaid-powered architecture diagram | Custom Controls |
+| Questionnaire | kickstart | Multi-question form (text/choice/multiChoice) | Custom Controls |
+| Markdown | kickstart | Rich markdown with tables and code blocks | Custom Controls |
+
+### Azure Components
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| AzureLoginCard | kickstart | MSAL authentication with subscriptions | Azure Components |
+| AzureResourcePicker | kickstart | Cascading subscription → RG → resource selection | Azure Components |
+| AzureResourceForm | kickstart | Dynamic resource creation form | Azure Components |
+| AzureAction | kickstart | Safe ARM API operations with confirmation | Azure Components |
+
+### GitHub Components
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| GitHubLoginCard | kickstart | Device code authentication flow | GitHub Components |
+| GitHubRepoPicker | kickstart | Repository search and selection | GitHub Components |
+| GitHubAction | kickstart | Safe GitHub API operations | GitHub Components |
+| GitHubCommit | kickstart | PR creation wizard | GitHub Components |
+
+### Integration Kit Auth
+
+| Component | Catalog | Description | Playground Group |
+|-----------|---------|-------------|------------------|
+| AuthCard (Azure) | kickstart | Azure MSAL sign-in via kit registration | Integration Kits |
+| AuthCard (GitHub) | kickstart | GitHub OAuth sign-in via kit registration | Integration Kits |
+| Multi-Provider | kickstart | Azure + GitHub AuthCards side by side | Integration Kits |
+
+### Additional Playground Groups
+
+The playground also includes scenario groups for advanced patterns:
+
+| Group | Description |
+|-------|-------------|
+| Kickstart Scenarios | 9 end-to-end app demo flows (Welcome → Deploy) |
+| Multi-Phase Demo | Discover → Design → Generate → Review → Deploy phase demos |
+| File Operations | FileEditor with create, edit, delete, and multi-file tabs |
+| Cost Estimate | Azure pricing breakdown with SKU options |
+| Data Binding | Text/form components bound to JSON Pointer data paths |
+| Events & Actions | Button events, form submit, function call actions |
+| Surface Lifecycle | Multi-surface creation, update, and deletion |
+| Dynamic Patterns | Nested data scopes, conditional content, complex dashboards |
 
 ---
 
@@ -428,3 +531,265 @@ export const myKit: IntegrationKit = {
 ### 4. Use in tool handlers
 
 The component type string is sent in A2UI JSON from the LLM or tool handler response. The catalog runtime looks up the registered React component by `type` and renders it.
+
+---
+
+## LLM JSON Examples — Custom Kickstart Components
+
+The JSON examples below show what the LLM produces for each custom component. Use these as a reference when authoring tool handlers or extending the catalog.
+
+### RadioGroup
+
+```json
+{
+  "type": "RadioGroup",
+  "id": "runtime-picker",
+  "label": "Select runtime",
+  "options": [
+    { "label": "Node.js", "value": "node" },
+    { "label": "Python", "value": "python" },
+    { "label": "Go", "value": "go" }
+  ],
+  "value": "node"
+}
+```
+
+### FormGroup
+
+```json
+{
+  "type": "FormGroup",
+  "id": "app-config",
+  "label": "Application settings",
+  "children": [
+    { "type": "TextField", "id": "app-name", "label": "App name" },
+    { "type": "TextField", "id": "port", "label": "Container port" }
+  ]
+}
+```
+
+### SteppedCarousel
+
+```json
+{
+  "type": "SteppedCarousel",
+  "id": "setup-wizard",
+  "steps": [
+    { "id": "step-1", "title": "Select Runtime", "children": ["runtime-picker"] },
+    { "id": "step-2", "title": "Configure", "children": ["app-config"] },
+    { "id": "step-3", "title": "Review", "children": ["summary-text"] }
+  ],
+  "currentStep": "step-1"
+}
+```
+
+### CodeBlock
+
+```json
+{
+  "type": "CodeBlock",
+  "id": "deployment-yaml",
+  "code": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web-app",
+  "language": "yaml",
+  "filename": "k8s/deployment.yaml"
+}
+```
+
+### ProgressSteps
+
+```json
+{
+  "type": "ProgressSteps",
+  "id": "onboarding-steps",
+  "steps": [
+    { "id": "discover", "label": "Discover", "status": "complete" },
+    { "id": "design", "label": "Design", "status": "active" },
+    { "id": "generate", "label": "Generate", "status": "pending" }
+  ],
+  "currentStep": "design"
+}
+```
+
+### ArchitectureDiagram
+
+```json
+{
+  "type": "ArchitectureDiagram",
+  "id": "app-architecture",
+  "mermaid": "graph LR\n  App[My App] --> DB[(PostgreSQL)]\n  App --> Cache[(Redis)]\n  LB[Public URL] --> App"
+}
+```
+
+### Questionnaire
+
+```json
+{
+  "type": "Questionnaire",
+  "id": "app-requirements",
+  "title": "Tell us about your app",
+  "questions": [
+    { "id": "q1", "type": "text", "label": "App name", "placeholder": "my-app" },
+    { "id": "q2", "type": "choice", "label": "Language", "options": ["Node.js", "Python", "Go", ".NET"] },
+    { "id": "q3", "type": "multiChoice", "label": "Services needed", "options": ["Database", "Cache", "Queue", "Storage"] }
+  ]
+}
+```
+
+### Markdown
+
+```json
+{
+  "type": "Markdown",
+  "id": "summary-text",
+  "content": "## Architecture Summary\n\nYour app will be deployed on **AKS Automatic** with:\n\n- Container Registry (Basic)\n- PostgreSQL Flexible Server\n- Key Vault for secrets"
+}
+```
+
+### FileEditor
+
+```json
+{
+  "type": "FileEditor",
+  "id": "manifest-editor",
+  "filename": "k8s/deployment.yaml",
+  "language": "yaml",
+  "content": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web-app",
+  "readOnly": false
+}
+```
+
+### CostEstimate
+
+```json
+{
+  "type": "CostEstimate",
+  "id": "cost-breakdown",
+  "items": [
+    { "name": "AKS Automatic", "sku": "Standard", "monthlyCost": 73.00 },
+    { "name": "PostgreSQL", "sku": "Burstable B1ms", "monthlyCost": 25.00 },
+    { "name": "Container Registry", "sku": "Basic", "monthlyCost": 5.00 }
+  ],
+  "total": 103.00,
+  "currency": "USD"
+}
+```
+
+### DeploymentProgress
+
+```json
+{
+  "type": "DeploymentProgress",
+  "id": "deployment-status",
+  "steps": [
+    { "id": "acr-build", "label": "Build container image", "status": "success" },
+    { "id": "aks-deploy", "label": "Deploy to AKS cluster", "status": "running" },
+    { "id": "ingress-setup", "label": "Configure ingress", "status": "pending" }
+  ],
+  "overallStatus": "running"
+}
+```
+
+### AzureLoginCard
+
+```json
+{
+  "type": "AzureLoginCard",
+  "id": "azure-login",
+  "prompt": "Sign in to discover your Azure resources"
+}
+```
+
+### AzureResourcePicker
+
+```json
+{
+  "type": "AzureResourcePicker",
+  "id": "cluster-picker",
+  "resourceType": "cluster",
+  "label": "Select an AKS cluster",
+  "subscriptionId": "4498459e-..."
+}
+```
+
+### AzureResourceForm
+
+```json
+{
+  "type": "AzureResourceForm",
+  "id": "new-cluster-form",
+  "resourceType": "cluster",
+  "fields": [
+    { "id": "name", "label": "Cluster name", "value": "my-aks-cluster" },
+    { "id": "region", "label": "Region", "value": "eastus" }
+  ]
+}
+```
+
+### AzureAction
+
+```json
+{
+  "type": "AzureAction",
+  "id": "scale-aks",
+  "title": "Scale AKS cluster",
+  "description": "Updates the node count for the default node pool.",
+  "method": "PATCH",
+  "path": "/subscriptions/.../providers/Microsoft.ContainerService/managedClusters/my-cluster",
+  "body": { "properties": { "agentPoolProfiles": [{ "name": "default", "count": 5 }] } }
+}
+```
+
+### GitHubLoginCard
+
+```json
+{
+  "type": "GitHubLoginCard",
+  "id": "gh-login",
+  "deviceCode": "ABCD-EFGH",
+  "verificationUrl": "https://github.com/login/device",
+  "expiresAt": "2025-01-01T12:30:00Z"
+}
+```
+
+### GitHubRepoPicker
+
+```json
+{
+  "type": "GitHubRepoPicker",
+  "id": "repo-selector",
+  "label": "Choose a repository",
+  "allowCreate": true,
+  "options": [
+    { "label": "my-app", "value": "owner/my-app" },
+    { "label": "my-api", "value": "owner/my-api" }
+  ]
+}
+```
+
+### GitHubAction
+
+```json
+{
+  "type": "GitHubAction",
+  "id": "ci-run",
+  "workflowName": "Build & Deploy",
+  "status": "success",
+  "runUrl": "https://github.com/owner/repo/actions/runs/123",
+  "branch": "main",
+  "commitSha": "abc1234"
+}
+```
+
+### GitHubCommit
+
+```json
+{
+  "type": "GitHubCommit",
+  "id": "latest-commit",
+  "sha": "abc1234",
+  "message": "feat: add AKS deployment manifests",
+  "author": "Ahmed Sabbour",
+  "timestamp": "2025-01-01T12:00:00Z",
+  "url": "https://github.com/owner/repo/commit/abc1234"
+}
+```

--- a/docs/integration-kits.md
+++ b/docs/integration-kits.md
@@ -1,0 +1,443 @@
+# Integration Kits Reference
+
+Integration Kits are the composable extension system for Kickstart. Each kit bundles tools, API connectors, system-prompt augmentations, skills, and UI component registrations into a single registerable unit — everything the conversation engine needs to integrate with an external platform.
+
+> **Related docs:** [Architecture](./architecture.md) · [Prompt Architecture](./prompt-architecture.md) · [A2UI Catalog](./a2ui-catalog.md) · [API Reference](./api-reference.md)
+
+---
+
+## What is an IntegrationKit?
+
+An `IntegrationKit` is a TypeScript object that satisfies the `IntegrationKit` interface (`packages/core/src/kits/types.ts`). It acts as the canonical unit for extending Kickstart with a new integration target (e.g. Azure, GitHub).
+
+When a kit is registered, the registry automatically:
+
+1. Validates auth requirements (provider/scopes schema)
+2. Validates dependencies (all declared deps must already be registered)
+3. Detects circular dependencies via DFS
+4. Detects tool/connector name collisions across kits
+5. Registers all kit tools into the `ToolRegistry`
+6. Registers all kit connectors into the `APIConnectorRegistry`
+7. Calls the `onActivate()` lifecycle hook (if provided)
+8. On `onActivate` failure, **rolls back all changes** (transactional)
+
+### Trust Model
+
+Kits are **trusted first-party code**. No sandboxing is applied — lifecycle hooks and tool execute functions run with full process privileges. If third-party kits are needed in the future, implement capability restrictions and sandboxing first.
+
+---
+
+## Kit API Surface
+
+The `IntegrationKit` interface (`packages/core/src/kits/types.ts`):
+
+```typescript
+interface IntegrationKit {
+  // ── Identity ────────────────────────────────────────────────────────
+  name: string;            // Unique ID, e.g. 'azure', 'github'
+  description: string;     // Human-readable summary
+
+  // ── Core contributions ──────────────────────────────────────────────
+  tools: Tool<any>[];      // LLM-callable functions (auto-registered)
+  connectors: APIConnector[]; // Authenticated API clients (auto-registered)
+
+  // ── Prompt augmentations ────────────────────────────────────────────
+  prompts?: string[];      // Flat system-prompt augmentations (all phases)
+  phasePrompts?: Partial<Record<Phase, string[]>>; // Per-phase overrides
+  skills?: Skill[];        // Typed domain knowledge (phase + keyword filtered)
+
+  // ── UI surface ──────────────────────────────────────────────────────
+  components?: ComponentRegistration[]; // A2UI component type registrations
+
+  // ── ServicePack extensions ──────────────────────────────────────────
+  auth?: KitAuthRequirement[];    // Declarative auth requirements
+  dependencies?: string[];         // Kit names that must register first
+  onActivate?: () => Promise<void>;  // Post-registration lifecycle hook
+  onDeactivate?: () => Promise<void>; // Pre-removal lifecycle hook
+}
+```
+
+### Field Details
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique kit identifier. Used as the key in the kit registry. |
+| `description` | Yes | Human-readable summary of what the kit provides. |
+| `tools` | Yes | Array of LLM-callable `Tool` objects. Auto-registered into `ToolRegistry`. |
+| `connectors` | Yes | Array of `APIConnector` instances. Auto-registered into `APIConnectorRegistry`. |
+| `prompts` | No | Flat prompt strings injected for all phases (filtered by keyword heuristics when `phasePrompts` is not set). |
+| `phasePrompts` | No | Per-phase prompt arrays. When present for a given phase, these take priority over `prompts`. |
+| `skills` | No | Typed `Skill` objects with keyword-based activation, priority ordering, and per-phase filtering. Resolved alongside (not replacing) prompt arrays. |
+| `components` | No | A2UI component registrations. Core records type identifiers and descriptions; the web package binds actual React components. |
+| `auth` | No | Declarative auth requirements. The web layer reads these to configure auth providers. |
+| `dependencies` | No | Names of kits that must be registered before this one. |
+| `onActivate` | No | Async hook called after registration + dependency validation. Failure triggers rollback. |
+| `onDeactivate` | No | Async hook called before removal. Failure keeps the kit registered. |
+
+### ComponentRegistration
+
+```typescript
+interface ComponentRegistration {
+  type: string;          // A2UI component type, e.g. 'azureLoginCard'
+  description: string;   // Human-readable description
+  promptMeta?: {
+    category: ComponentCategory;  // Category for the prompt catalog
+    example: string;              // JSON example shown to the LLM
+    notes?: string;               // Optional notes after the example
+  };
+}
+```
+
+### KitAuthRequirement
+
+```typescript
+interface KitAuthRequirement {
+  provider: string;    // e.g. 'azure-msal', 'github-oauth'
+  scopes: string[];    // OAuth scopes or permissions required
+  optional?: boolean;  // If true, kit works (degraded) without this auth
+}
+```
+
+---
+
+## Kit Registry
+
+The `IntegrationKitRegistry` class (`packages/core/src/kits/registry.ts`) manages the full lifecycle of kits.
+
+### Singleton
+
+```typescript
+import { defaultKitRegistry, registerKit } from '@kickstart/core';
+
+// Register at app startup
+await registerKit(azureKit);
+await registerKit(githubKit);
+```
+
+`defaultKitRegistry` is backed by the default `ToolRegistry` and `APIConnectorRegistry` singletons. The `registerKit()` convenience function delegates to `defaultKitRegistry.register()`.
+
+### Registry API
+
+| Method | Description |
+|--------|-------------|
+| `register(kit)` | Register a kit — validates, wires tools/connectors, calls `onActivate`. Transactional on failure. |
+| `unregister(name)` | Remove a kit. Blocks if other kits depend on it. Calls `onDeactivate` first. |
+| `get(name)` | Look up a kit by name. Returns `undefined` if not found. |
+| `getAll()` | Returns all registered kits. |
+| `names()` | Returns all registered kit names. |
+| `has(name)` | Returns `true` if a kit is registered. |
+| `size` | Number of registered kits. |
+| `getDependents(name)` | Returns kit names that depend on the given kit. |
+| `getToolOwner(toolName)` | Returns the kit that owns a tool. |
+| `getConnectorOwner(name)` | Returns the kit that owns a connector. |
+| `getComponentCatalogEntries()` | Collects A2UI component catalog entries from all kits with `promptMeta`. |
+
+### Registration Lifecycle
+
+```
+register(kit)
+  ├─ validateAuth(kit)              — schema check on auth requirements
+  ├─ self-dependency check          — kit.dependencies cannot include kit.name
+  ├─ dependency validation          — all deps must be registered
+  ├─ cycle detection (DFS)          — no circular dependency chains
+  ├─ collision detection            — no tool/connector name clashes across kits
+  ├─ clean up previous (if re-reg)  — remove old tools/connectors
+  ├─ register kit + tools + connectors
+  └─ onActivate()                   — if it throws, full rollback
+```
+
+### Unregistration Lifecycle
+
+```
+unregister(name)
+  ├─ reverse-dependency check       — blocks if other kits depend on this one
+  ├─ onDeactivate()                 — if it throws, kit stays registered
+  └─ remove tools + connectors + kit
+```
+
+---
+
+## How Kits Feed the LLM
+
+Kits inject domain knowledge into the system prompt through the **Skill Resolver** (`packages/core/src/engine/skill-resolver.ts`).
+
+### Three-Layer Resolution
+
+The resolver uses a priority chain to determine which prompts to inject for a given phase:
+
+1. **Skills** (highest priority) — Typed `Skill` objects filtered by phase and activated by keyword matching against conversation history. Sorted by `priority` (higher first).
+2. **Phase Prompts** — Explicit per-phase prompt arrays from `kit.phasePrompts[phase]`. When present for a phase, these replace flat prompts for that kit.
+3. **Flat Prompts** (backward compat) — Strings from `kit.prompts[]` classified to phases by keyword heuristics.
+
+### `resolveSkills()` Function
+
+```typescript
+import { resolveSkills } from '@kickstart/core';
+
+const result = resolveSkills(Phase.Design, defaultKitRegistry.getAll());
+// result.prompts  — ordered list of prompt strings for the system prompt
+// result.availableTools — tool names available in this phase
+```
+
+The middleware chain:
+1. **Phase Filter** — keeps only skills whose `phases` array includes the current phase
+2. **Keyword Activation** — scans conversation history for skill keywords, activates matches
+3. **Priority Order** — sorts so higher-priority skills appear first in the prompt
+
+### Async Variant
+
+```typescript
+const result = await resolveSkillsAsync(Phase.Design, kits, conversationHistory);
+```
+
+Runs the full middleware chain including custom middleware registered via `registerSkillMiddleware()`.
+
+### Formatting for System Prompt
+
+```typescript
+import { formatSkillsSection } from '@kickstart/core';
+
+const section = formatSkillsSection(result);
+// Returns: "## Available Capabilities\n\n{skill content}"
+```
+
+---
+
+## Azure Kit
+
+**Source:** `packages/core/src/kits/azure-kit.ts`
+
+The Azure kit provides ARM resource discovery, cost estimation, AKS deployment guidance, and IaC best-practice knowledge.
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `azure_resource_list` | Discover existing resources in a subscription before recommending new ones |
+| `azure_resource_get` | Inspect a specific resource's ARM configuration |
+| `estimate_cost` | Budget estimation using the Azure Retail Pricing API |
+
+### Connectors
+
+| Connector | Auth | Description |
+|-----------|------|-------------|
+| `AzureARMConnector` | MSAL (azure-msal) | Azure Resource Manager REST API client |
+| `PricingConnector` | None | Azure Retail Pricing API (public, no auth required) |
+
+### Auth Requirements
+
+```typescript
+{
+  provider: 'azure-msal',
+  scopes: ['https://management.azure.com/.default'],
+  optional: false
+}
+```
+
+### A2UI Components
+
+| Component | Description |
+|-----------|-------------|
+| `AuthCard` (provider: "azure") | MSAL sign-in card with automatic subscription discovery |
+| `azureResourcePicker` | Cascading subscription → resource group → resource selector |
+| `azureResourceForm` | Dynamic ARM-driven form for resource creation |
+| `azureAction` | Write-with-confirm pattern for ARM operations (destructive ops require typing resource name) |
+
+### Skills (IaC Best Practices)
+
+The Azure kit includes five IaC skills activated by keyword matching:
+
+| Skill ID | Name | Phases | Priority | Keywords |
+|----------|------|--------|----------|----------|
+| `iac-bicep-modules` | Bicep Module Conventions | Generate | 5 | bicep, module, infrastructure, iac, template, arm |
+| `iac-secure-decorators` | @secure() Decorator Usage | Generate, Review | 10 | secure, secret, password, key, connection, credential |
+| `iac-diagnostic-settings` | Diagnostic Settings | Generate, Review | 3 | diagnostic, logging, monitoring, log analytics, metrics, observability |
+| `iac-resource-tagging` | Resource Tagging Strategy | Generate | 2 | tag, tagging, label, metadata, environment, cost tracking |
+| `iac-least-privilege-rbac` | Least-Privilege RBAC | Generate, Review | 10 | rbac, role, permission, identity, access, authorization, privilege |
+
+### Phase Prompts
+
+The Azure kit provides explicit per-phase prompts:
+
+| Phase | Focus |
+|-------|-------|
+| **Discover** | Call `azure_resource_list` early to discover existing AKS clusters and ACR registries |
+| **Design** | Prefer AKS Automatic, recommend managed services, include KAITO for AI/ML, provide pricing reference |
+| **Generate** | AKS Automatic manifests (Gateway API, Workload Identity, ACR integration, HPA, PDB), KAITO/RAGEngine CRDs, detailed AKS knowledge |
+| **Review** | Final cost breakdown via `estimate_cost`, deployment safeguard validation |
+| **Handoff** | OIDC setup reminder, GitHub Actions deployment workflow verification |
+| **Deploy** | Resource confirmation via `azure_resource_list/get`, DeploymentProgress tracking |
+
+### Flat Prompts (All Phases)
+
+General Azure knowledge injected across all phases when `phasePrompts` is not explicit:
+
+- **AKS Automatic** — always prefer `aksAutomatic` over manual cluster configuration
+- **Resource Discovery** — use `azure_resource_list` before recommending new resources
+- **Cost Transparency** — use `estimate_cost` before proposing deployment plans
+- **Deployment Safeguards** — hide K8s complexity behind AKS Automatic
+- **KAITO** — AI/ML workload guidance (GPU provisioning, model inference, preset models)
+- **RAGEngine** — RAG pipeline guidance (document ingestion, vector store, query-time retrieval)
+- **Fine-tuning** — LoRA/QLoRA fine-tuning on AKS GPU nodes
+- **ARM PUT Templates** — Validated ARM body templates for AKS, App Service, ACR, Container Apps, Storage, Key Vault, and Role Assignments
+
+### Azure APIs Unlocked
+
+Through the Azure kit's tools and connectors, the LLM can:
+
+- **ARM (Resource Manager)** — list/get any Azure resource by subscription/resource group
+- **Container Apps** — deploy apps via ARM PUT with managed environment references
+- **AKS** — create/configure AKS Automatic clusters (Gateway API, Workload Identity, NAP)
+- **Pricing** — estimate monthly costs by querying the Azure Retail Pricing API
+- **Service Connector patterns** — Managed Identity + RBAC role assignment instead of connection strings
+
+---
+
+## GitHub Kit
+
+**Source:** `packages/core/src/kits/github-kit.ts`
+
+The GitHub kit provides repository inspection, CI detection, and source-to-AKS deployment wiring.
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `github_repo_info` | Detect runtime, language, CI setup, topics from a GitHub repo |
+| `github_repo_tree` | Recursive file tree with key-file detection (Dockerfile, manifests, CI workflows) |
+| `github_repo_file_read` | Read individual files for manifest/dependency inspection |
+
+### Connectors
+
+| Connector | Auth | Description |
+|-----------|------|-------------|
+| `GitHubConnector` | GitHub OAuth (Device Flow + PAT) | GitHub REST API client |
+
+### Auth Requirements
+
+```typescript
+{
+  provider: 'github-oauth',
+  scopes: ['repo', 'read:user'],
+  optional: false
+}
+```
+
+### A2UI Components
+
+| Component | Description |
+|-----------|-------------|
+| `AuthCard` (provider: "github") | OAuth Device Flow sign-in card |
+| `githubRepoPicker` | Repository picker with search and client-side filtering |
+
+### Phase Prompts
+
+| Phase | Focus |
+|-------|-------|
+| **Discover** | Full repo analysis protocol: metadata → file tree → read key manifests → synthesize app profile |
+| **Design** | Check for existing GitHub Actions workflows, extend rather than replace, trunk-based strategy |
+| **Generate** | Generate `.github/workflows/deploy.yml` with OIDC, ACR push, AKS rolling update |
+| **Handoff** | Guide push to GitHub, verify OIDC federation setup, offer Codespaces link |
+| **Deploy** | GitHub Actions handles deployment, manual trigger via `workflow_dispatch` |
+
+### Flat Prompts (All Phases)
+
+- **Repository-first approach** — always call `github_repo_info` when a user provides a repo URL
+- **CI/CD wiring** — include GitHub Actions workflow with OIDC Workload Identity Federation
+- **Branch strategy** — trunk-based: default branch → production, PRs → preview environments
+- **OIDC pipeline setup** — 5-step federation setup: Entra app, federated credential, RBAC roles, GitHub secrets, workflow config
+
+---
+
+## Creating a Custom Kit
+
+```typescript
+import type { IntegrationKit } from '@kickstart/core';
+import { Phase } from '@kickstart/core';
+
+export const myKit: IntegrationKit = {
+  name: 'my-platform',
+  description: 'Integrates with My Platform for deployment',
+
+  tools: [myTool],
+  connectors: [new MyConnector()],
+
+  prompts: [
+    'General knowledge available in all phases...',
+  ],
+
+  phasePrompts: {
+    [Phase.Discover]: ['Discovery-specific instructions...'],
+    [Phase.Generate]: ['Code generation rules...'],
+  },
+
+  skills: [{
+    id: 'my-skill',
+    name: 'My Domain Knowledge',
+    phases: [Phase.Design, Phase.Generate],
+    keywords: ['my-platform', 'deploy'],
+    priority: 5,
+    content: '## My Platform Best Practices\n\n...',
+  }],
+
+  components: [{
+    type: 'myComponent',
+    description: 'Renders my custom UI element',
+  }],
+
+  auth: [{
+    provider: 'my-oauth',
+    scopes: ['read', 'write'],
+    optional: false,
+  }],
+
+  // Dependencies — register these kits first
+  dependencies: ['azure'],
+
+  // Lifecycle hooks
+  onActivate: async () => { /* post-registration setup */ },
+  onDeactivate: async () => { /* pre-removal cleanup */ },
+};
+```
+
+Register at app startup:
+
+```typescript
+import { registerKit } from '@kickstart/core';
+import { azureKit } from '@kickstart/core/kits/azure-kit';
+import { myKit } from './my-kit';
+
+await registerKit(azureKit);  // dependency first
+await registerKit(myKit);
+```
+
+---
+
+## Configuration
+
+### Azure Kit Environment
+
+The Azure kit requires MSAL authentication configured in the web layer. The `AzureARMConnector` uses token-based auth acquired via MSAL with scope `https://management.azure.com/.default`. The `PricingConnector` requires no auth (public API).
+
+The Azure OpenAI model used by the conversation engine is configured separately through the server's environment variables (see [Deployment](./deployment.md)).
+
+### GitHub Kit Environment
+
+The GitHub kit uses OAuth Device Flow for browser-based authentication. The `GitHubConnector` acquires tokens via the device code flow or accepts a pre-configured PAT. Required OAuth scopes: `repo`, `read:user`.
+
+---
+
+## Kit Dependency Graph
+
+```
+azureKit (standalone)
+  ├─ tools: azure_resource_list, azure_resource_get, estimate_cost
+  ├─ connectors: AzureARMConnector, PricingConnector
+  └─ skills: 5 IaC best-practice skills
+
+githubKit (standalone)
+  ├─ tools: github_repo_info, github_repo_tree, github_repo_file_read
+  └─ connectors: GitHubConnector
+```
+
+Both built-in kits are standalone (no cross-dependencies). Custom kits can declare dependencies on either or both.


### PR DESCRIPTION
## Summary

Two documentation additions requested by Ahmed:

### 1. `docs/integration-kits.md` — Integration Kits Reference

Full reference for the IntegrationKit extension system:
- **What is an IntegrationKit?** — purpose, lifecycle, trust model
- **Kit API surface** — all interface fields with types and descriptions
- **Kit Registry** — `IntegrationKitRegistry` API, registration/unregistration lifecycle
- **How kits feed the LLM** — skill resolver, three-layer resolution (skills → phasePrompts → flat prompts), middleware chain
- **Azure Kit** — tools, connectors, auth, components, 5 IaC skills, phase prompts, ARM templates
- **GitHub Kit** — tools, connectors, auth, components, phase prompts, OIDC setup
- **Custom kit authoring** — complete example with dependencies and lifecycle hooks
- **Configuration** — environment requirements for each kit

### 2. `docs/a2ui-catalog.md` — Component Gallery + JSON Examples

Enriched the existing catalog with visual references:
- **Component Gallery** tables mapping every component (40+) to its playground group and catalog
- Organized into: Layout, Content, Inputs, Custom Controls, Azure, GitHub, Integration Kits
- **Playground link** with "Try it live" callout
- **LLM JSON Examples** for all 20 custom Kickstart components (what the LLM actually produces)
- Cross-link to Integration Kits doc

### Files changed
- `docs/integration-kits.md` (new)
- `docs/a2ui-catalog.md` (enriched)

No source code changes.

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)