### PR TITLE
Remove Raw Text Content and Render Decisions from debug panel

### DIFF
--- a/packages/web/src/components/Chat/DebugPanel.tsx
+++ b/packages/web/src/components/Chat/DebugPanel.tsx
@@ -118,16 +118,6 @@ const useStyles = makeStyles({
   jsonNull: {
     color: tokens.colorNeutralForeground4,
   },
-  decisionList: {
-    listStyleType: 'disc',
-    paddingLeft: tokens.spacingHorizontalL,
-    marginTop: tokens.spacingVerticalXXS,
-    marginBottom: '0',
-  },
-  decisionItem: {
-    color: tokens.colorNeutralForeground2,
-    marginBottom: tokens.spacingVerticalXXS,
-  },
   notAvailable: {
     color: tokens.colorNeutralForeground4,
     fontStyle: 'italic',
@@ -238,14 +228,6 @@ export function DebugPanel({ debugInfo, surfaceIds }: DebugPanelProps) {
 
   const codeBlockClass = `${styles.codeBlock} ${resolvedTheme === 'dark' ? styles.codeBlockDark : styles.codeBlockLight}`;
 
-  // Defense-in-depth: truncate raw content client-side even if the server
-  // already redacts, in case of future changes or misconfigurations.
-  const MAX_RAW_DISPLAY = 500;
-  const rawText = debugInfo?.rawContent ?? debugInfo?.rawResponse ?? '';
-  const displayRaw = rawText.length > MAX_RAW_DISPLAY
-    ? rawText.slice(0, MAX_RAW_DISPLAY) + '\u2026 [truncated]'
-    : rawText;
-
   return (
     <div className={styles.container}>
       <button
@@ -285,15 +267,6 @@ export function DebugPanel({ debugInfo, surfaceIds }: DebugPanelProps) {
             )}
           </CollapsibleSection>
 
-          {/* Raw Text Content (truncated for defense-in-depth) */}
-          <CollapsibleSection label="Raw Text Content" defaultOpen={false} styles={styles}>
-            {displayRaw ? (
-              <code className={codeBlockClass}>{displayRaw}</code>
-            ) : (
-              <Text className={styles.notAvailable} size={200}>Not available</Text>
-            )}
-          </CollapsibleSection>
-
           {/* Action Events */}
           <CollapsibleSection label={`Action Events (${actionLog.length})`} defaultOpen={actionLog.length > 0} styles={styles}>
             {actionLog.length > 0 ? (
@@ -319,18 +292,6 @@ export function DebugPanel({ debugInfo, surfaceIds }: DebugPanelProps) {
             )}
           </CollapsibleSection>
 
-          {/* Render Decisions */}
-          <CollapsibleSection label="Render Decisions" defaultOpen={false} styles={styles}>
-            {debugInfo?.renderDecisions && debugInfo.renderDecisions.length > 0 ? (
-              <ul className={styles.decisionList}>
-                {debugInfo.renderDecisions.map((decision, i) => (
-                  <li key={i} className={styles.decisionItem}>{decision}</li>
-                ))}
-              </ul>
-            ) : (
-              <Text className={styles.notAvailable} size={200}>Not available</Text>
-            )}
-          </CollapsibleSection>
         </div>
       )}
     </div>

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -86,7 +86,6 @@ export function useStreaming() {
     let lastModel: string | undefined;
     let lastSessionId: string | undefined;
     let lastPhase: string | undefined;
-    const renderDecisions: string[] = [];
     const debugA2uiMessages: any[] = [];
 
     try {
@@ -187,7 +186,6 @@ export function useStreaming() {
               if (parsed.model) lastModel = parsed.model;
               if (parsed.sessionId) lastSessionId = parsed.sessionId;
               if (parsed.phase) callbacks.onPhase(parsed.phase);
-              if (parsed.renderDecisions) renderDecisions.push(...parsed.renderDecisions);
               currentEventType = '';
               continue;
             }
@@ -233,9 +231,6 @@ export function useStreaming() {
               lastSessionId = event.sessionId;
             }
 
-            if (event.renderDecisions) {
-              renderDecisions.push(...event.renderDecisions);
-            }
           } catch { /* skip malformed JSON */ }
         }
       }
@@ -280,9 +275,7 @@ export function useStreaming() {
               a2ui: debugA2uiMessages.length > 0 ? debugA2uiMessages : undefined,
               model: lastModel,
               phase: lastPhase,
-              renderDecisions: renderDecisions.length > 0 ? renderDecisions : undefined,
             },
-            renderDecisions: renderDecisions.length > 0 ? renderDecisions : undefined,
           }
         : undefined;
 

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1177,7 +1177,6 @@ function PlaygroundInner() {
         a2ui?: object[];
         model?: string;
         rawResponse?: string;
-        renderDecisions?: string[];
       };
 
       if (data.sessionId && !createSessionIdRef.current) {
@@ -1210,7 +1209,7 @@ function PlaygroundInner() {
 
       // Capture debug metadata when debug mode is on
       const debugInfo: DebugMetadata | undefined = debugEnabled
-        ? { model: data.model, rawResponse: data.rawResponse, renderDecisions: data.renderDecisions }
+        ? { model: data.model, rawResponse: data.rawResponse }
         : undefined;
 
       const assistantMsg: ChatMessage = {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -27,10 +27,7 @@ export interface DebugMetadata {
     a2ui?: A2uiMsg[];
     model?: string;
     phase?: string;
-    renderDecisions?: string[];
   };
-  /** Rendering engine decisions (component choices, catalog, degradation). */
-  renderDecisions?: string[];
 }
 
 export interface ChatMessage {
@@ -103,6 +100,4 @@ export interface StreamEvent {
   phase?: string;
   model?: string;
   sessionId?: string;
-  /** Debug-only: rendering decisions from the engine. */
-  renderDecisions?: string[];
 }


### PR DESCRIPTION
## Summary

Removes two sections from the debug panel:
- **Raw Text Content** — redundant with the Full LLM Response section
- **Render Decisions** — no longer needed

### Changes

| File | What |
|------|------|
| `DebugPanel.tsx` | Removed both collapsible sections, unused styles (`decisionList`, `decisionItem`), and local truncation variables |
| `useStreaming.ts` | Removed `renderDecisions` array initialization and collection logic |
| `Playground.tsx` | Removed `renderDecisions` from response type and debug metadata |
| `types.ts` | Removed `renderDecisions` from `DebugMetadata`, `fullEnvelope`, and `StreamEvent` |

Working as Fry (Frontend Dev)

**4 files changed, 1 insertion, 53 deletions** — pure cleanup, no behavior change to remaining debug panel sections.