### PR TITLE
fix: hydration artifact restore + JSON.parse guard + response typing

### DIFF
--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -59,6 +59,22 @@ interface ConverseResponse {
   message: string;
   model?: string;
   a2ui?: object[];
+  autoContinue?: boolean;
+  autoContinuePrompt?: string;
+  debug?: DebugMetadata;
+  renderDecisions?: string;
+}
+
+/** SSE "done" event payload sent at the end of a streaming response. */
+interface StreamDonePayload {
+  sessionId: string;
+  phase: string;
+  phaseLabel: string;
+  model?: string;
+  autoContinue?: boolean;
+  autoContinuePrompt?: string;
+  debug?: DebugMetadata;
+  renderDecisions?: string;
 }
 
 app.http("converse", {
@@ -235,8 +251,8 @@ app.http("converse", {
 
       // Include auto-continue signal when more files are pending
       if (flags.filesComplete === false) {
-        (responseBody as unknown as Record<string, unknown>).autoContinue = true;
-        (responseBody as unknown as Record<string, unknown>).autoContinuePrompt = "Generate next set of files";
+        responseBody.autoContinue = true;
+        responseBody.autoContinuePrompt = "Generate next set of files";
       }
 
       // Attach debug metadata when requested
@@ -249,9 +265,8 @@ app.http("converse", {
           hadExplicitA2UI,
           session.engineState.currentPhase,
         );
-        (responseBody as unknown as Record<string, unknown>).debug = debugMeta;
-        (responseBody as unknown as Record<string, unknown>).renderDecisions =
-          formatRenderDecisions(debugMeta.renderDecisions);
+        responseBody.debug = debugMeta;
+        responseBody.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
       }
 
       return { status: 200, jsonBody: responseBody };
@@ -371,7 +386,7 @@ function handleStreaming(
             }
 
             const phaseDef = getPhaseDefinition(engineState.currentPhase as import("@kickstart/core").Phase);
-            const donePayload: Record<string, unknown> = {
+            const donePayload: StreamDonePayload = {
               sessionId,
               phase: engineState.currentPhase,
               phaseLabel: phaseDef.label,

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -32,9 +32,9 @@ import {
 import type { PhaseItem, ToolContext, ConversationState } from "@kickstart/core";
 import {
   getSession, createSession, hydrateSession, addMessage,
-  extractArtifactsFromA2UI, upsertArtifact,
+  extractArtifactsFromA2UI, upsertArtifact, buildArtifactSummary,
 } from "../lib/session-store.js";
-import type { ClientMessage, GeneratedArtifact } from "../lib/session-store.js";
+import type { ClientMessage, GeneratedArtifact, ClientArtifact } from "../lib/session-store.js";
 import { chatCompletion, chatCompletionWithTools, getChatDeploymentName } from "../lib/openai-client.js";
 import { checkContentSafety } from "../lib/content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
@@ -49,6 +49,8 @@ interface ConverseRequest {
   message: string;
   /** Client-side message history for session rehydration after cold starts. */
   messages?: ClientMessage[];
+  /** Client-side artifact metadata for restoring artifact tracking after cold starts. */
+  generatedArtifacts?: ClientArtifact[];
 }
 
 interface ConverseResponse {
@@ -116,7 +118,7 @@ app.http("converse", {
         : undefined;
       if (!session) {
         session = body.messages?.length
-          ? hydrateSession(body.messages)
+          ? hydrateSession(body.messages, body.generatedArtifacts)
           : createSession();
       }
 
@@ -476,31 +478,8 @@ function handleStreaming(
 }
 
 // ---------------------------------------------------------------------------
-// Artifact summary — gives the LLM running context of what's been generated
+// Artifact summary — buildArtifactSummary is imported from session-store.ts
 // ---------------------------------------------------------------------------
-
-/**
- * Build a text summary of generated artifacts for injection into the system prompt.
- * Uses pre-extracted metadata — no content re-scanning needed.
- */
-function buildArtifactSummary(artifacts: GeneratedArtifact[]): string {
-  if (artifacts.length === 0) return "";
-
-  const lines: string[] = [];
-  lines.push("Files generated so far: " + artifacts.map((a) => a.filename).join(", "));
-
-  const bicepResources = artifacts.flatMap((a) => a.bicepResources);
-  if (bicepResources.length > 0) {
-    lines.push("Azure resources declared: " + bicepResources.join(", "));
-  }
-
-  const k8sResources = artifacts.flatMap((a) => a.k8sResources);
-  if (k8sResources.length > 0) {
-    lines.push("Kubernetes resources declared: " + k8sResources.join(", "));
-  }
-
-  return lines.join("\n");
-}
 
 // ---------------------------------------------------------------------------
 // Implicit state flags — parsed from LLM JSON response

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -100,6 +100,15 @@ export interface ClientMessage {
   content: string;
 }
 
+/** Client-provided artifact metadata for session rehydration.
+ *  Validated/sanitized on ingress — only metadata, never file content. */
+export interface ClientArtifact {
+  filename: string;
+  language: string;
+  bicepResources?: string[];
+  k8sResources?: string[];
+}
+
 /**
  * Create a new session and seed it with client-provided conversation history.
  * Used when the in-memory session has been lost (cold start / scale event)
@@ -107,8 +116,14 @@ export interface ClientMessage {
  *
  * System messages are always rebuilt server-side — client-sent system
  * messages are silently dropped.
+ *
+ * If `clientArtifacts` is provided, the session's generatedArtifacts are
+ * populated directly from it instead of trying to parse assistant message JSON.
  */
-export function hydrateSession(clientMessages: ClientMessage[]): ApiSession {
+export function hydrateSession(
+  clientMessages: ClientMessage[],
+  clientArtifacts?: ClientArtifact[],
+): ApiSession {
   const session = createSession();
   const now = new Date().toISOString();
 
@@ -122,15 +137,86 @@ export function hydrateSession(clientMessages: ClientMessage[]): ApiSession {
       content: msg.content,
       timestamp: now,
     });
+  }
 
-    // Rebuild generatedArtifacts from assistant messages containing FileEditor components
-    if (msg.role === "assistant") {
-      rebuildArtifactsFromMessage(msg.content, session.generatedArtifacts);
+  // Restore artifact tracking from client-provided metadata (preferred),
+  // falling back to parsing assistant messages (legacy, rarely succeeds).
+  if (clientArtifacts?.length) {
+    session.generatedArtifacts = sanitizeClientArtifacts(clientArtifacts);
+  } else {
+    for (const msg of clientMessages) {
+      if (msg.role === "assistant" && msg.content) {
+        rebuildArtifactsFromMessage(msg.content, session.generatedArtifacts);
+      }
     }
   }
 
   session.state.updatedAt = now;
   return session;
+}
+
+/** Max length for a single artifact filename from client. */
+const MAX_FILENAME_LENGTH = 256;
+/** Max combined resource entries per artifact from client. */
+const MAX_RESOURCES_PER_ARTIFACT = 20;
+
+/** Sanitize and cap client-provided artifact metadata. */
+function sanitizeClientArtifacts(raw: ClientArtifact[]): GeneratedArtifact[] {
+  const seen = new Set<string>();
+  const result: GeneratedArtifact[] = [];
+
+  for (const a of raw) {
+    if (result.length >= MAX_TRACKED_ARTIFACTS) break;
+    if (typeof a.filename !== "string" || !a.filename.trim()) continue;
+
+    const filename = a.filename.trim().slice(0, MAX_FILENAME_LENGTH);
+    if (seen.has(filename)) continue;
+    seen.add(filename);
+
+    const language = typeof a.language === "string" && a.language.trim()
+      ? a.language.trim()
+      : inferLanguage(filename);
+    const bicepResources = sanitizeResourceList(a.bicepResources);
+    const k8sResources = sanitizeResourceList(a.k8sResources);
+
+    result.push({
+      filename,
+      language,
+      bicepResources: bicepResources.slice(0, MAX_RESOURCES_PER_ARTIFACT),
+      k8sResources: k8sResources.slice(0, MAX_RESOURCES_PER_ARTIFACT),
+    });
+  }
+
+  return result;
+}
+
+/** Validate a resource list — keep only non-empty strings. */
+function sanitizeResourceList(list: unknown): string[] {
+  if (!Array.isArray(list)) return [];
+  return list
+    .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+    .map((s) => s.trim().slice(0, 200));
+}
+
+/**
+ * Build a human-readable summary of generated artifacts for injection into the
+ * system prompt. Returns empty string if no artifacts exist.
+ */
+export function buildArtifactSummary(artifacts: GeneratedArtifact[]): string {
+  if (!artifacts.length) return "";
+
+  const lines: string[] = ["## Previously generated files"];
+  for (const a of artifacts) {
+    let line = `- ${a.filename} (${a.language})`;
+    if (a.bicepResources.length > 0) {
+      line += ` — Bicep resources: ${a.bicepResources.join(", ")}`;
+    }
+    if (a.k8sResources.length > 0) {
+      line += ` — K8s resources: ${a.k8sResources.join(", ")}`;
+    }
+    lines.push(line);
+  }
+  return lines.join("\n");
 }
 
 /** Max number of artifacts tracked to prevent unbounded growth. */

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -308,10 +308,15 @@ export function extractArtifactsFromA2UI(
  * Scan a message (raw JSON or A2UI content) for FileEditor components
  * and upsert any found artifacts into the list.
  */
+/** Max content length to attempt JSON.parse on during hydration (prevent DoS). */
+const MAX_HYDRATION_CONTENT_LENGTH = 100_000; // 100KB max per message
+
 function rebuildArtifactsFromMessage(
   content: string,
   artifacts: GeneratedArtifact[],
 ): void {
+  if (content.length > MAX_HYDRATION_CONTENT_LENGTH) return;
+
   // Match FileEditor components in assistant messages — these appear in
   // A2UI updateComponents payloads as JSON objects with component:"FileEditor"
   const fileEditorPattern = /"component"\s*:\s*"FileEditor"/;

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -86,7 +86,6 @@ export function useStreaming() {
     let lastModel: string | undefined;
     let lastSessionId: string | undefined;
     let lastPhase: string | undefined;
-    const renderDecisions: string[] = [];
     const debugA2uiMessages: any[] = [];
 
     try {
@@ -106,6 +105,10 @@ export function useStreaming() {
           content: m.text.trim(),
         }));
 
+      // Extract generated artifact metadata from A2UI messages in chat history
+      // so the server can restore artifact tracking without parsing full JSON.
+      const generatedArtifacts = extractArtifactMetadata(chatHistory);
+
       const res = await apiFetch('/api/converse', {
         method: 'POST',
         headers: {
@@ -117,6 +120,7 @@ export function useStreaming() {
           message,
           stream: true,
           ...(clientMessages?.length ? { messages: clientMessages } : {}),
+          ...(generatedArtifacts.length ? { generatedArtifacts } : {}),
         }),
         signal: controller.signal,
       }, debugMode);
@@ -187,7 +191,6 @@ export function useStreaming() {
               if (parsed.model) lastModel = parsed.model;
               if (parsed.sessionId) lastSessionId = parsed.sessionId;
               if (parsed.phase) callbacks.onPhase(parsed.phase);
-              if (parsed.renderDecisions) renderDecisions.push(...parsed.renderDecisions);
               currentEventType = '';
               continue;
             }
@@ -233,9 +236,6 @@ export function useStreaming() {
               lastSessionId = event.sessionId;
             }
 
-            if (event.renderDecisions) {
-              renderDecisions.push(...event.renderDecisions);
-            }
           } catch { /* skip malformed JSON */ }
         }
       }
@@ -280,9 +280,7 @@ export function useStreaming() {
               a2ui: debugA2uiMessages.length > 0 ? debugA2uiMessages : undefined,
               model: lastModel,
               phase: lastPhase,
-              renderDecisions: renderDecisions.length > 0 ? renderDecisions : undefined,
             },
-            renderDecisions: renderDecisions.length > 0 ? renderDecisions : undefined,
           }
         : undefined;
 
@@ -314,4 +312,36 @@ export function useStreaming() {
   }, [cancelReveal]);
 
   return { send, isStreaming, streamText, abort };
+}
+
+/** Artifact metadata shape sent to the server for rehydration (no file content). */
+interface ArtifactMeta {
+  filename: string;
+  language: string;
+}
+
+/**
+ * Scan chat history A2UI messages for FileEditor components and extract
+ * metadata (filename, language). Deduplicates by filename — last wins.
+ */
+function extractArtifactMetadata(chatHistory?: ChatMessage[]): ArtifactMeta[] {
+  if (!chatHistory?.length) return [];
+
+  const map = new Map<string, ArtifactMeta>();
+
+  for (const msg of chatHistory) {
+    if (!msg.a2uiMessages) continue;
+    for (const a2ui of msg.a2uiMessages) {
+      if (!a2ui.updateComponents?.components) continue;
+      for (const comp of a2ui.updateComponents.components) {
+        if (comp.component === 'FileEditor' && typeof comp.filename === 'string') {
+          const filename = comp.filename;
+          const language = typeof comp.language === 'string' ? comp.language : '';
+          map.set(filename, { filename, language });
+        }
+      }
+    }
+  }
+
+  return Array.from(map.values());
 }


### PR DESCRIPTION
Follow-up hardening for #278 (unified narrative prompt).

- Restore generatedArtifacts from client-provided metadata during cold-start hydration
- Add max-length guard on JSON.parse to prevent DoS during hydration
- Extend ConverseResponse interface with autoContinue fields (remove type assertion hacks)

Closes partially: #276

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)