### PR TITLE
ci: remove paths-ignore to fix docs PR merge deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '.squad/**'
-      - 'docs/**'
-      - 'docs-site/**'
-      - 'infra/**'
-      - '**.md'
-      - '.github/ISSUE_TEMPLATE/**'
 
 jobs:
   lint-build:

--- a/.squad/decisions/inbox/bender-ci-paths-ignore-fix.md
+++ b/.squad/decisions/inbox/bender-ci-paths-ignore-fix.md
@@ -1,0 +1,4 @@
+### 2026-04-15: Removed paths-ignore from CI workflow
+**By:** Bender (Backend Dev)
+**What:** Removed paths-ignore from .github/workflows/ci.yml so all PRs trigger CI checks, preventing merge deadlocks on docs-only PRs.
+**Why:** The protect-main ruleset requires 'Lint, Build & Unit Tests' and 'Playwright E2E Tests', but paths-ignore excluded docs files. Docs-only PRs could never merge.


### PR DESCRIPTION
The protect-main ruleset requires CI checks that never triggered on docs-only PRs due to paths-ignore. This caused PRs #279, #280, #281, #285, and #286 to be permanently blocked.

Fix: remove paths-ignore so CI runs on all PRs. Docs-only PRs pass quickly.

Closes the root cause of the #285 merge block.