### PR TITLE
fix: TextField editable + Markdown newline rendering

### DIFF
--- a/packages/web/src/catalog/components/Markdown.tsx
+++ b/packages/web/src/catalog/components/Markdown.tsx
@@ -195,6 +195,9 @@ const useStyles = makeStyles({
 export const Markdown = createReactComponent(MarkdownApi, ({ props }) => {
   const classes = useStyles();
 
+  // Normalize literal \n sequences (from LLM JSON) into actual newlines
+  const content = (props.content || '').replace(/\\n/g, '\n');
+
   return (
     <div className={classes.root}>
       <ReactMarkdown
@@ -261,7 +264,7 @@ export const Markdown = createReactComponent(MarkdownApi, ({ props }) => {
           hr: ({ node, ...props }) => <hr className={classes.hr} {...props} />,
         }}
       >
-        {props.content || ''}
+        {content}
       </ReactMarkdown>
     </div>
   );

--- a/packages/web/src/catalog/fluent-components/TextField.tsx
+++ b/packages/web/src/catalog/fluent-components/TextField.tsx
@@ -19,11 +19,11 @@ export const TextField = createReactComponent(TextFieldApi, ({props}) => {
   const [localValue, setLocalValue] = useState(props.value || '');
   const userEdited = useRef(false);
 
-  // Sync from external prop changes only when the user hasn't edited
+  // Sync from external prop changes and clear the local edit lock once applied
   useEffect(() => {
-    if (!userEdited.current) {
-      setLocalValue(props.value || '');
-    }
+    const nextValue = props.value || '';
+    setLocalValue(currentValue => (currentValue === nextValue ? currentValue : nextValue));
+    userEdited.current = false;
   }, [props.value]);
 
   const isLong = props.variant === 'longText';

--- a/packages/web/src/catalog/fluent-components/TextField.tsx
+++ b/packages/web/src/catalog/fluent-components/TextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import {createReactComponent} from '../../vendor/a2ui/react/adapter';
 import {TextFieldApi} from '../../vendor/a2ui/web_core/basic_catalog/index';
 import {Input, Textarea, Field, makeStyles, tokens} from '@fluentui/react-components';
@@ -16,6 +16,15 @@ const useStyles = makeStyles({
 
 export const TextField = createReactComponent(TextFieldApi, ({props}) => {
   const classes = useStyles();
+  const [localValue, setLocalValue] = useState(props.value || '');
+  const userEdited = useRef(false);
+
+  // Sync from external prop changes only when the user hasn't edited
+  useEffect(() => {
+    if (!userEdited.current) {
+      setLocalValue(props.value || '');
+    }
+  }, [props.value]);
 
   const isLong = props.variant === 'longText';
   const type =
@@ -24,10 +33,14 @@ export const TextField = createReactComponent(TextFieldApi, ({props}) => {
   const hasError = props.validationErrors && props.validationErrors.length > 0;
 
   const onInputChange = (_ev: React.ChangeEvent<HTMLInputElement>, data: InputOnChangeData) => {
+    userEdited.current = true;
+    setLocalValue(data.value);
     props.setValue(data.value);
   };
 
   const onTextareaChange = (_ev: React.ChangeEvent<HTMLTextAreaElement>, data: TextareaOnChangeData) => {
+    userEdited.current = true;
+    setLocalValue(data.value);
     props.setValue(data.value);
   };
 
@@ -40,13 +53,13 @@ export const TextField = createReactComponent(TextFieldApi, ({props}) => {
       >
         {isLong ? (
           <Textarea
-            value={props.value || ''}
+            value={localValue}
             onChange={onTextareaChange}
           />
         ) : (
           <Input
             type={type}
-            value={props.value || ''}
+            value={localValue}
             onChange={onInputChange}
           />
         )}


### PR DESCRIPTION
Working as Fry (Frontend Dev)

## Changes

**TextField (#267):** The input was effectively read-only because it used a controlled `value={props.value}` pattern, but the GenericBinder's `setValue` is a no-op when the LLM sends static values (no DataBinding path). Added local React state (`useState`) so keystrokes are captured immediately, while still calling `props.setValue` to propagate to the data model when bindings exist.

**Markdown (#260):** The LLM sends escaped `\\n` sequences in JSON strings. These arrived as literal backslash-n in the content prop. Added a `.replace(/\\\\n/g, '\n')` normalization step before passing content to ReactMarkdown.

Closes #267
Closes #260

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>