### PR TITLE
docs: add Extending Kickstart guide

### DIFF
--- a/docs-site/docs/extending/_category_.json
+++ b/docs-site/docs/extending/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Extending Kickstart",
+  "position": 4
+}

--- a/docs-site/docs/extending/api-endpoints.md
+++ b/docs-site/docs/extending/api-endpoints.md
@@ -1,0 +1,358 @@
+---
+sidebar_position: 5
+---
+
+# API Endpoints
+
+Kickstart's backend runs on **Azure Functions v4** (Node.js), deployed as managed functions inside an Azure Static Web App. Endpoints handle LLM conversations, code generation, A2UI action processing, and proxy routes to external APIs.
+
+This guide covers the endpoint pattern, SSE streaming, shared utilities, and how to add a new endpoint.
+
+## How Endpoints Work
+
+### Azure Functions v4 Pattern
+
+Every endpoint follows the same registration pattern using `app.http()` in `packages/web/api/src/functions/`:
+
+```typescript
+import { app } from "@azure/functions";
+import type {
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+
+app.http("functionName", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  route: "endpoint-path",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext,
+  ): Promise<HttpResponseInit> => {
+    // Handler logic
+  },
+});
+```
+
+| Property | Description |
+|---|---|
+| `"functionName"` | Unique function name used by the Azure Functions runtime |
+| `methods` | HTTP methods to accept (`["GET"]`, `["POST"]`, etc.) |
+| `authLevel` | Always `"anonymous"` — SWA handles auth at the edge |
+| `route` | URL path (relative to `/api/`) |
+| `handler` | Async function receiving the request and invocation context |
+
+### Existing Endpoints
+
+| Endpoint | Method | Route | Response Format | Description |
+|---|---|---|---|---|
+| `converse` | POST | `/api/converse` | SSE or JSON | Main LLM conversation proxy — multi-round tool calling |
+| `action` | POST | `/api/action` | JSON | A2UI action event processing |
+| `generate` | POST | `/api/generate` | SSE or JSON | Codex-powered code generation |
+| `health` | GET | `/api/health` | JSON | Health check (`{ status: "ok" }`) |
+| `arm-proxy` | Various | `/api/arm-proxy/*` | JSON | Azure Resource Manager CORS proxy |
+| `github-proxy` | Various | `/api/github-proxy/*` | JSON | GitHub API CORS proxy |
+| `pricing-proxy` | Various | `/api/pricing-proxy/*` | JSON | Azure Pricing API CORS proxy |
+| `inspirations` | GET | `/api/inspirations` | JSON | App inspiration templates |
+| `widget-inspirations` | GET | `/api/widget-inspirations` | JSON | Widget catalog inspirations |
+| `github-oauth` | Various | `/api/github-oauth/*` | JSON | GitHub OAuth Device Flow |
+| `playground` | POST | `/api/playground` | SSE or JSON | Prompt playground for testing |
+
+### SSE Streaming Pattern
+
+Long-running AI operations use **Server-Sent Events** for real-time streaming. The client opts in by sending `Accept: text/event-stream`:
+
+```typescript
+// Check if the client wants SSE
+const wantsStream = request.headers
+  .get("accept")
+  ?.includes("text/event-stream");
+
+if (wantsStream) {
+  return handleStreaming(/* ... */);
+}
+
+// Otherwise return a normal JSON response
+return { status: 200, jsonBody: result };
+```
+
+The streaming response uses a `ReadableStream` with `TextEncoder`:
+
+```typescript
+function handleStreaming(/* params */): HttpResponseInit {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        // Stream content chunks
+        controller.enqueue(
+          encoder.encode(
+            `event: chunk\ndata: ${JSON.stringify({ content: "..." })}\n\n`
+          ),
+        );
+
+        // Stream tool calls and results
+        controller.enqueue(
+          encoder.encode(
+            `event: tool_call\ndata: ${JSON.stringify({ name: "tool_name" })}\n\n`
+          ),
+        );
+
+        // Final done event
+        controller.enqueue(
+          encoder.encode(
+            `event: done\ndata: ${JSON.stringify({ sessionId, phase })}\n\n`
+          ),
+        );
+
+        controller.close();
+      } catch (err) {
+        controller.enqueue(
+          encoder.encode(
+            `event: error\ndata: ${JSON.stringify({ error: "message" })}\n\n`
+          ),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    },
+    body: stream,
+  };
+}
+```
+
+#### SSE Event Types
+
+The `converse` endpoint defines these event types:
+
+| Event Type | Payload | Description |
+|---|---|---|
+| `chunk` | `{ content: string }` | Incremental text chunk from the LLM |
+| `tool_call` | `{ name: string }` | LLM requested a tool call |
+| `tool_result` | `{ name: string, result: unknown }` | Tool execution result |
+| `message` | `{ content: string }` | Final complete message text |
+| `a2ui` | A2UI component JSON | Structured UI component for rendering |
+| `done` | `{ sessionId, phase, phaseLabel, model, ... }` | Stream complete — metadata payload |
+| `error` | `{ error: string }` | Stream error — generic message only |
+
+### Shared Utilities
+
+Endpoints share a set of utility modules in `packages/web/api/src/lib/`:
+
+| Module | Exports | Purpose |
+|---|---|---|
+| `openai-client.ts` | `chatCompletion()`, `chatCompletionWithTools()`, `chatCompletionStream()`, `codexCompletion()` | Azure OpenAI client with JSON mode and tool support |
+| `session-store.ts` | `getSession()`, `createSession()`, `hydrateSession()`, `addMessage()` | In-memory session management with 1-hour TTL |
+| `error-response.ts` | `safeErrorResponse()`, `safeStreamError()` | Generic error responses — logs details server-side, returns safe messages to clients |
+| `rate-limiter.ts` | `checkRateLimit()`, `rateLimitResponse()` | Sliding-window rate limiting (30 req/min per client, 300 req/min global backstop) |
+| `response-processor.ts` | `processResponse()` | Parse LLM JSON envelope into message + A2UI components |
+| `content-safety.ts` | `checkContentSafety()` | Content safety pre-flight check on user messages |
+| `auto-continue.ts` | `chatCompletionWithAutoContinue()`, `isTruncated()` | Auto-continuation for truncated LLM responses |
+| `sanitize-tool-output.ts` | `sanitizeToolOutput()` | Sanitize tool results before feeding back to the LLM |
+
+---
+
+## How to Add an Endpoint
+
+### Step 1 — Create the function file
+
+Create a new file in `packages/web/api/src/functions/`. The filename doesn't matter for routing — the `route` parameter in `app.http()` controls the URL path.
+
+```
+packages/web/api/src/functions/my-endpoint.ts
+```
+
+### Step 2 — Implement the handler
+
+Use the standard Azure Functions v4 pattern. Apply rate limiting and error handling:
+
+```typescript
+import { app } from "@azure/functions";
+import type {
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse } from "../lib/error-response.js";
+
+interface MyEndpointRequest {
+  query: string;
+}
+
+app.http("myEndpoint", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  route: "my-endpoint",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext,
+  ): Promise<HttpResponseInit> => {
+    // Rate limit check
+    const rateCheck = checkRateLimit(request);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
+    try {
+      const body = (await request.json()) as MyEndpointRequest;
+
+      if (!body.query?.trim()) {
+        return { status: 400, jsonBody: { error: "query is required" } };
+      }
+
+      // Your logic here
+      const result = await processQuery(body.query);
+
+      return { status: 200, jsonBody: result };
+    } catch (err) {
+      return safeErrorResponse(err, context, "MyEndpoint error");
+    }
+  },
+});
+```
+
+### Step 3 — Add SSE streaming (if applicable)
+
+If your endpoint calls the LLM or performs long-running work, support SSE streaming. Check the `Accept` header and return a `ReadableStream`:
+
+```typescript
+const wantsStream = request.headers
+  .get("accept")
+  ?.includes("text/event-stream");
+
+if (wantsStream) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        // Stream your data
+        for (const item of results) {
+          controller.enqueue(
+            encoder.encode(
+              `event: chunk\ndata: ${JSON.stringify(item)}\n\n`
+            ),
+          );
+        }
+
+        controller.enqueue(
+          encoder.encode(
+            `event: done\ndata: ${JSON.stringify({ complete: true })}\n\n`
+          ),
+        );
+        controller.close();
+      } catch (err) {
+        const safeMsg = safeStreamError(err, context, "Stream error");
+        controller.enqueue(
+          encoder.encode(
+            `event: error\ndata: ${JSON.stringify({ error: safeMsg })}\n\n`
+          ),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    },
+    body: stream,
+  };
+}
+```
+
+### Step 4 — Build and verify
+
+The API uses esbuild and auto-discovers function files — no manual registration needed:
+
+```bash
+npm run build -w @kickstart/api
+```
+
+Start the development server and test your endpoint:
+
+```bash
+# JSON response
+curl -X POST http://localhost:7071/api/my-endpoint \
+  -H "Content-Type: application/json" \
+  -d '{"query": "test"}'
+
+# SSE streaming
+curl -X POST http://localhost:7071/api/my-endpoint \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"query": "test"}'
+```
+
+### Step 5 — Add SWA route config (if needed)
+
+If your endpoint needs specific routing rules (e.g., CORS headers, auth requirements), update `swa-cli.config.json` or add route rules to `staticwebapp.config.json`. The default wildcard `/api/*` proxies all API calls, so new endpoints under `/api/` typically work without changes.
+
+---
+
+## Patterns to Follow
+
+### Error Handling
+
+Always use `safeErrorResponse()` for non-streaming endpoints and `safeStreamError()` for SSE streams. These log the full error server-side but return only a generic message to clients — preventing internal details from leaking.
+
+```typescript
+// JSON endpoint — 3 args: error, context, label
+return safeErrorResponse(err, context, "MyEndpoint error");
+
+// SSE stream — 3 args: error, context, label — returns a safe string
+const safeMsg = safeStreamError(err, context, "Stream error");
+```
+
+### Rate Limiting
+
+Apply `checkRateLimit()` at the top of every public handler. Pass the request object directly — the limiter extracts the client identifier from SWA principal headers or falls back to IP headers:
+
+```typescript
+const rateCheck = checkRateLimit(request);
+if (!rateCheck.allowed) {
+  return rateLimitResponse(rateCheck.retryAfterMs!);
+}
+```
+
+Limits: **30 requests per minute** per client, **300 per minute** global backstop.
+
+### Content Safety
+
+For endpoints that accept user-generated text, run `checkContentSafety()` before processing:
+
+```typescript
+const safetyResult = await checkContentSafety(body.message);
+if (!safetyResult.safe) {
+  return { status: 400, jsonBody: { error: safetyResult.error } };
+}
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `packages/web/api/src/functions/converse.ts` | Main LLM conversation endpoint with SSE streaming and tool calling |
+| `packages/web/api/src/functions/generate.ts` | Code generation endpoint (Codex) with SSE streaming |
+| `packages/web/api/src/functions/health.ts` | Minimal health check — good template for simple endpoints |
+| `packages/web/api/src/functions/action.ts` | A2UI action event processing (JSON only) |
+| `packages/web/api/src/lib/openai-client.ts` | Azure OpenAI client with streaming async generator |
+| `packages/web/api/src/lib/session-store.ts` | In-memory session management with TTL |
+| `packages/web/api/src/lib/error-response.ts` | `safeErrorResponse()` and `safeStreamError()` utilities |
+| `packages/web/api/src/lib/rate-limiter.ts` | Sliding-window rate limiter (per-client + global backstop) |

--- a/docs-site/docs/extending/conversation-phases.md
+++ b/docs-site/docs/extending/conversation-phases.md
@@ -1,0 +1,217 @@
+---
+sidebar_position: 2
+---
+
+# Conversation Phases
+
+Kickstart guides users through a multi-phase conversation — Discover, Design, Generate, Review, Handoff, Deploy. The phase engine is a pure-function state machine that determines what the AI focuses on, which skills are available, and how the system prompt is assembled at each step.
+
+This guide explains the phase system and walks you through adding a new phase.
+
+## How Phases Work
+
+### The Phase Enum
+
+Every phase is identified by a string-valued enum, defined in `packages/core/src/engine/types.ts`:
+
+```typescript
+export enum Phase {
+  Discover = "discover",
+  Design   = "design",
+  Generate = "generate",
+  Review   = "review",
+  Handoff  = "handoff",
+  Deploy   = "deploy",
+}
+```
+
+### Phase Definitions
+
+Each phase has a `PhaseDefinition` that describes its purpose, transition conditions, and system prompt template. Definitions live in `packages/core/src/engine/phases.ts`:
+
+```typescript
+export interface PhaseDefinition {
+  id: Phase;
+  label: string;
+  description: string;
+  entryConditions: string[];  // Human-readable — used in system prompt
+  exitConditions: string[];   // Human-readable — used in system prompt
+  promptTemplate: string;     // Injected as Layer 3 of the system prompt
+  nextPhase: Phase | null;    // null = terminal phase
+}
+```
+
+The `PHASE_DEFINITIONS` array in `phases.ts` is the authoritative phase order. The first entry is the initial phase; `nextPhase` chains them.
+
+### The State Machine
+
+`packages/core/src/engine/machine.ts` implements a pure state machine:
+
+```typescript
+export interface ConversationState {
+  currentPhase: Phase;
+  phaseStatus: Record<Phase, "pending" | "active" | "complete" | "skipped">;
+  phaseData: Record<Phase, unknown>;
+  isComplete: boolean;
+}
+
+// Pure transition function — no side effects
+transition(state: ConversationState, event: PhaseEvent): ConversationState
+```
+
+Valid events:
+
+| Event | Description |
+|---|---|
+| `START` | Begin the conversation (activates first phase) |
+| `ADVANCE` | Move to `nextPhase` |
+| `SKIP` | Skip current phase, same as ADVANCE but marks it `skipped` |
+| `RESET` | Return to the first phase |
+| `USER_INPUT` | Notify state of new user message |
+| `PHASE_COMPLETE` | Mark current phase complete without advancing |
+
+### Auto-Advance
+
+The LLM can trigger a phase transition autonomously. When the LLM response includes `phaseComplete: true` in the JSON envelope, `handleImplicitFlags()` in `machine.ts` fires a `PHASE_COMPLETE` event automatically — no user action required.
+
+Similarly, A2UI actions with `navigate:` or `complete:` prefixes (handled in `packages/core/src/engine/auto-continue.ts`) can trigger transitions from button clicks in the UI.
+
+### Skill Resolution
+
+Skills are filtered by phase. `packages/core/src/engine/skill-resolver.ts` runs a middleware chain:
+
+1. **phaseFilter** — drops skills whose `phases` array doesn't include `currentPhase`
+2. **keywordActivation** — boosts skills that match keywords in the user message
+3. **priorityOrder** — sorts remaining skills by priority
+
+Convenience groups are exported for registration:
+
+```typescript
+export const DISCOVERY_PHASES  = [Phase.Discover];
+export const DESIGN_PHASES     = [Phase.Discover, Phase.Design];
+export const GENERATE_PHASES   = [Phase.Generate, Phase.Review];
+export const DEPLOYMENT_PHASES = [Phase.Handoff, Phase.Deploy];
+```
+
+### System Prompt Architecture
+
+The system prompt builder (`packages/core/src/prompts/system-prompt.ts`) stacks three layers per turn:
+
+| Layer | Content |
+|---|---|
+| Layer 1 | Active skills (resolved for current phase) |
+| Layer 2 | Copilot extension instructions |
+| Layer 3 | Phase-specific `promptTemplate` from `PhaseDefinition` |
+
+This means the `promptTemplate` you write in a `PhaseDefinition` is injected verbatim as the innermost context ring for that phase.
+
+---
+
+## How to Add a Phase
+
+### Step 1 — Add the enum value
+
+Open `packages/core/src/engine/types.ts` and add your new phase to the `Phase` enum:
+
+```typescript
+export enum Phase {
+  Discover  = "discover",
+  Design    = "design",
+  Validate  = "validate",   // ← new phase
+  Generate  = "generate",
+  Review    = "review",
+  Handoff   = "handoff",
+  Deploy    = "deploy",
+}
+```
+
+### Step 2 — Define the phase
+
+Open `packages/core/src/engine/phases.ts` and add a `PhaseDefinition` to the `PHASE_DEFINITIONS` array at the correct position. Update the `nextPhase` of the preceding phase to point to your new one:
+
+```typescript
+{
+  id: Phase.Validate,
+  label: "Validate",
+  description: "Verify that the proposed architecture meets the user's requirements before generating artifacts.",
+  entryConditions: [
+    "Architecture design is complete",
+    "User has confirmed service selection",
+  ],
+  exitConditions: [
+    "User has approved the architecture",
+    "All required fields are populated",
+  ],
+  promptTemplate: `
+You are in the VALIDATE phase. Your goal is to confirm the architecture before generating files.
+
+Review the proposed design with the user:
+- Confirm service tiers and scaling settings
+- Highlight any cost or security implications
+- Ask for explicit approval before proceeding
+
+When the user approves, set phaseComplete: true in your response envelope.
+  `.trim(),
+  nextPhase: Phase.Generate,
+},
+```
+
+Also update the `Design` phase definition so its `nextPhase` points to `Phase.Validate` instead of `Phase.Generate`.
+
+### Step 3 — Register skills for the new phase
+
+If you have skills that should be active during this phase, add `Phase.Validate` to their `phases` array in your `IntegrationKit` definitions. You can also define a new phase group constant in `skill-resolver.ts`:
+
+```typescript
+export const VALIDATE_PHASES = [Phase.Validate];
+```
+
+### Step 4 — Add phase-specific prompts to kits (optional)
+
+If an `IntegrationKit` needs to inject additional context during your phase, add it to `phasePrompts`:
+
+```typescript
+const myKit: IntegrationKit = {
+  // ...
+  phasePrompts: {
+    [Phase.Validate]: [
+      "When validating architecture, always check for missing health check configurations.",
+    ],
+  },
+};
+```
+
+### Step 5 — Write tests
+
+Add test cases to:
+
+- `packages/core/src/__tests__/phases.test.ts` — verify your `PhaseDefinition` is well-formed, `entryConditions` and `exitConditions` are populated, `nextPhase` chains correctly
+- `packages/core/src/__tests__/machine.test.ts` — verify state transitions flow through your new phase correctly, auto-advance works, SKIP routes past it
+
+```typescript
+it("transitions through Validate phase", () => {
+  const state = transition(initialState, { type: "START" });
+  // advance to Validate
+  const validated = transition(
+    transition(state, { type: "ADVANCE" }), // Design
+    { type: "ADVANCE" }                      // Validate
+  );
+  expect(validated.currentPhase).toBe(Phase.Validate);
+  expect(validated.phaseStatus[Phase.Validate]).toBe("active");
+});
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `packages/core/src/engine/types.ts` | `Phase` enum and `PhaseDefinition` interface |
+| `packages/core/src/engine/phases.ts` | `PHASE_DEFINITIONS` array — phase order and templates |
+| `packages/core/src/engine/machine.ts` | State machine: `ConversationState`, `transition()`, `handleImplicitFlags()` |
+| `packages/core/src/engine/skill-resolver.ts` | Phase-aware skill filtering and phase group constants |
+| `packages/core/src/engine/auto-continue.ts` | A2UI action → phase transition wiring |
+| `packages/core/src/prompts/system-prompt.ts` | 3-layer system prompt assembly |
+| `packages/core/src/__tests__/phases.test.ts` | Phase definition tests |
+| `packages/core/src/__tests__/machine.test.ts` | State machine transition tests |

--- a/docs-site/docs/extending/integration-kits.md
+++ b/docs-site/docs/extending/integration-kits.md
@@ -1,0 +1,347 @@
+---
+sidebar_position: 4
+---
+
+# Integration Kits
+
+An IntegrationKit is the canonical unit for extending Kickstart with a new integration surface. It bundles tools, API connectors, system-prompt augmentations, UI component registrations, and lifecycle hooks into a single composable package. When you register a kit, everything gets wired up automatically — tools go into the ToolRegistry, connectors into the APIConnectorRegistry, and prompts into the skill resolver.
+
+This guide covers the kit interface, the registry, built-in kits, and how to create your own.
+
+## How Kits Work
+
+### The IntegrationKit Interface
+
+Every kit implements the `IntegrationKit` interface defined in `packages/core/src/kits/types.ts`:
+
+```typescript
+export interface IntegrationKit {
+  name: string;
+  description: string;
+  tools: Tool<any>[];
+  connectors: APIConnector[];
+  prompts?: string[];
+  phasePrompts?: Partial<Record<Phase, string[]>>;
+  skills?: Skill[];
+  components?: ComponentRegistration[];
+  auth?: KitAuthRequirement[];
+  dependencies?: string[];
+  onActivate?: () => Promise<void>;
+  onDeactivate?: () => Promise<void>;
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Unique kit identifier (e.g. `"azure"`, `"github"`) |
+| `description` | `string` | Human-readable summary of what the kit provides |
+| `tools` | `Tool<any>[]` | LLM-callable functions — auto-registered into `ToolRegistry` |
+| `connectors` | `APIConnector[]` | Authenticated API clients — auto-registered into `APIConnectorRegistry` |
+| `prompts` | `string[]?` | Flat system-prompt augmentations injected for all phases (or filtered by keyword heuristics) |
+| `phasePrompts` | `Partial<Record<Phase, string[]>>?` | Per-phase prompt augmentations — takes priority over flat `prompts` for a given phase |
+| `skills` | `Skill[]?` | Typed domain knowledge injected per-phase with keyword activation and priority ordering |
+| `components` | `ComponentRegistration[]?` | A2UI component type registrations (frontend binding is in `packages/web`) |
+| `auth` | `KitAuthRequirement[]?` | Declarative auth requirements — the web layer uses these to wire providers |
+| `dependencies` | `string[]?` | Names of kits that must be registered before this one |
+| `onActivate` | `() => Promise<void>?` | Lifecycle hook called after registration and dependency validation |
+| `onDeactivate` | `() => Promise<void>?` | Lifecycle hook called before the kit is removed from the registry |
+
+### Supporting Types
+
+#### ComponentRegistration
+
+```typescript
+interface ComponentRegistration {
+  type: string;           // A2UI component type identifier, e.g. 'azureLoginCard'
+  description: string;    // Human-readable description
+  promptMeta?: {
+    category: ComponentCategory;  // Grouping for the prompt catalog
+    example: string;              // JSON example shown to the LLM
+    notes?: string;               // Optional notes after the example
+  };
+}
+```
+
+#### KitAuthRequirement
+
+```typescript
+interface KitAuthRequirement {
+  provider: string;    // Auth provider identifier, e.g. 'azure-msal', 'github-oauth'
+  scopes: string[];    // OAuth scopes or permission strings
+  optional?: boolean;  // If true, the kit can function (degraded) without this auth
+}
+```
+
+### The Kit Registry
+
+`packages/core/src/kits/registry.ts` exports an `IntegrationKitRegistry` class and a `defaultKitRegistry` singleton:
+
+```typescript
+import { registerKit, defaultKitRegistry } from "@kickstart/core";
+
+// Register at app startup (dependencies first)
+await registerKit(githubKit);
+await registerKit(azureKit);
+
+// Query registered kits
+defaultKitRegistry.get("azure");
+defaultKitRegistry.getAll();
+defaultKitRegistry.names();
+defaultKitRegistry.has("github");
+```
+
+#### What happens when you register a kit
+
+1. **Auth validation** — verifies `provider` is non-empty and `scopes` is a non-empty string array
+2. **Dependency validation** — all declared deps must be registered first
+3. **Cycle detection** — DFS walk detects circular dependency chains (e.g. A → B → A)
+4. **Collision detection** — tool and connector names must be unique across kits
+5. **Tool auto-wiring** — all `tools` are registered into the `ToolRegistry`
+6. **Connector auto-wiring** — all `connectors` are registered into the `APIConnectorRegistry`
+7. **Lifecycle hook** — `onActivate()` is called if provided
+8. **Transactional rollback** — if `onActivate()` throws, all changes are rolled back (tools unregistered, connectors removed, kit deleted)
+
+#### Unregistration
+
+```typescript
+await defaultKitRegistry.unregister("my-kit");
+```
+
+Unregistration blocks if other kits declare this kit as a dependency. `onDeactivate()` is called before removal — if it throws, the kit stays registered.
+
+### Prompt Resolution
+
+Kits contribute to the system prompt at three levels (highest priority first):
+
+1. **`skills`** — typed `Skill` objects filtered by phase and activated by keyword matching in conversation history. Skills have explicit `priority` ordering.
+2. **`phasePrompts[phase]`** — explicit per-phase augmentations. When present for a given phase, these take priority over the flat `prompts` array.
+3. **`prompts`** — flat augmentations filtered by keyword heuristics in the skill resolver for backward compatibility.
+
+The skill resolver (`packages/core/src/engine/skill-resolver.ts`) runs a middleware chain: phaseFilter → keywordActivation → priorityOrder. See [Conversation Phases](./conversation-phases.md) for details on how skills are resolved per phase.
+
+### Trust Model
+
+Kits are **trusted first-party code**. No sandboxing is applied — lifecycle hooks (`onActivate`, `onDeactivate`) and tool `execute` functions run with full process privileges. If third-party kits are needed in the future, implement capability restrictions and sandboxing before allowing untrusted code to register as a kit.
+
+---
+
+## Built-in Kits
+
+### GitHub Kit
+
+**File:** `packages/core/src/kits/github-kit.ts`
+
+| | Details |
+|---|---|
+| **Tools** | `github_repo_info`, `github_repo_tree`, `github_repo_file_read` |
+| **Connectors** | `GitHubConnector` (OAuth Device Flow + PAT auth) |
+| **Components** | `AuthCard` (GitHub sign-in), `githubRepoPicker` (repo search and selection) |
+| **Auth** | `github-oauth` with scopes `repo`, `read:user` |
+| **Phase prompts** | Discover (repo analysis protocol), Design (CI/CD extension), Generate (deploy.yml with OIDC), Handoff (push + secrets setup), Deploy (Actions monitoring) |
+
+### Azure Kit
+
+**File:** `packages/core/src/kits/azure-kit.ts`
+
+| | Details |
+|---|---|
+| **Tools** | `azure_resource_list`, `azure_resource_get`, `estimate_cost` |
+| **Connectors** | `AzureARMConnector` (Azure Resource Manager), `PricingConnector` (no auth) |
+| **Components** | `AuthCard` (Azure MSAL), `azureResourcePicker`, `azureResourceForm`, `azureAction` |
+| **Auth** | `azure-msal` with scope `https://management.azure.com/.default` |
+| **Skills** | `iac-bicep-modules` (Bicep conventions), `iac-secure-decorators` (@secure() usage), and more |
+
+---
+
+## How to Create an Integration Kit
+
+### Step 1 — Plan your kit surface
+
+Decide what your kit provides:
+
+- **Tools** — what LLM-callable functions does your integration need? (see [LLM Tools](./llm-tools.md))
+- **Connectors** — does it call an external API that needs authentication?
+- **Prompts** — should the AI behave differently during certain phases when your kit is active?
+- **Components** — does it register A2UI component types for the frontend?
+
+### Step 2 — Implement the tools
+
+Create tool files in `packages/core/src/tools/` following the `Tool<TArgs>` interface. See [LLM Tools](./llm-tools.md) for the complete walkthrough.
+
+```typescript
+// packages/core/src/tools/my-service-query.ts
+import type { Tool, ToolContext } from "./types.js";
+
+interface MyServiceQueryArgs {
+  query: string;
+}
+
+export const myServiceQuery: Tool<MyServiceQueryArgs> = {
+  name: "my_service_query",
+  description: "Query the My Service API for relevant resources.",
+  parameters: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "Search query" },
+    },
+    required: ["query"],
+  },
+  async execute(args, context) {
+    // Implementation
+    return { results: [] };
+  },
+};
+```
+
+### Step 3 — Implement the connector (if needed)
+
+Create a connector implementing the `APIConnector` interface from `packages/core/src/connectors/types.ts`:
+
+```typescript
+import type { APIConnector, HttpMethod, APIConnectorRequestOptions } from "./types.js";
+
+export class MyServiceConnector implements APIConnector {
+  readonly name = "my-service";
+  readonly baseUrl = "https://api.myservice.com/v1";
+
+  async authenticate(): Promise<void> {
+    // Acquire or refresh tokens
+  }
+
+  isAuthenticated(): boolean {
+    return false;
+  }
+
+  async request(
+    method: HttpMethod,
+    path: string,
+    body?: unknown,
+    options?: APIConnectorRequestOptions,
+  ): Promise<Response> {
+    return fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: { ...options?.headers },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: options?.signal,
+    });
+  }
+}
+```
+
+### Step 4 — Define the kit
+
+Create your kit file in `packages/core/src/kits/`:
+
+```typescript
+// packages/core/src/kits/my-service-kit.ts
+import type { IntegrationKit } from "./types.js";
+import { Phase } from "../engine/types.js";
+import { myServiceQuery } from "../tools/my-service-query.js";
+import { MyServiceConnector } from "../connectors/MyServiceConnector.js";
+
+export const myServiceKit: IntegrationKit = {
+  name: "my-service",
+  description: "My Service integration — query resources and manage deployments.",
+
+  tools: [myServiceQuery],
+  connectors: [new MyServiceConnector()],
+
+  phasePrompts: {
+    [Phase.Discover]: [
+      "When the user mentions My Service, call my_service_query to discover " +
+      "their existing resources before making recommendations.",
+    ],
+  },
+
+  components: [
+    {
+      type: "myServicePicker",
+      description: "Resource picker for My Service resources.",
+    },
+  ],
+
+  auth: [
+    {
+      provider: "my-service-oauth",
+      scopes: ["read", "write"],
+      optional: false,
+    },
+  ],
+
+  // If this kit depends on the GitHub kit being registered first:
+  // dependencies: ["github"],
+
+  async onActivate() {
+    // Runs after registration — initialize caches, warm connections, etc.
+  },
+
+  async onDeactivate() {
+    // Runs before removal — clean up resources
+  },
+};
+```
+
+### Step 5 — Register at app startup
+
+Import and register your kit where the app bootstraps. Register dependencies first:
+
+```typescript
+import { registerKit } from "@kickstart/core";
+import { myServiceKit } from "@kickstart/core/kits/my-service-kit";
+
+// After existing kits are registered
+await registerKit(myServiceKit);
+```
+
+### Step 6 — Write tests
+
+Add test cases to `packages/core/src/__tests__/integration-kit.test.ts` (or create a new test file):
+
+```typescript
+import { IntegrationKitRegistry } from "../kits/registry.js";
+import { ToolRegistry } from "../tools/registry.js";
+import { APIConnectorRegistry } from "../connectors/registry.js";
+import { myServiceKit } from "../kits/my-service-kit.js";
+
+describe("myServiceKit", () => {
+  it("registers without errors", async () => {
+    const toolReg = new ToolRegistry();
+    const connReg = new APIConnectorRegistry();
+    const kitReg = new IntegrationKitRegistry(toolReg, connReg);
+
+    await kitReg.register(myServiceKit);
+
+    expect(kitReg.has("my-service")).toBe(true);
+    expect(toolReg.get("my_service_query")).toBeDefined();
+    expect(connReg.get("my-service")).toBeDefined();
+  });
+
+  it("rejects self-dependency", async () => {
+    const badKit = { ...myServiceKit, dependencies: ["my-service"] };
+    const kitReg = new IntegrationKitRegistry();
+    await expect(kitReg.register(badKit)).rejects.toThrow("dependency on itself");
+  });
+});
+```
+
+### Step 7 — Build and verify
+
+```bash
+npm run build -w @kickstart/core
+npm run test -w @kickstart/core
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `packages/core/src/kits/types.ts` | `IntegrationKit`, `ComponentRegistration`, `KitAuthRequirement` interfaces |
+| `packages/core/src/kits/registry.ts` | `IntegrationKitRegistry` class, `defaultKitRegistry` singleton, `registerKit()` |
+| `packages/core/src/kits/github-kit.ts` | GitHub integration kit (tools, connectors, phase prompts) |
+| `packages/core/src/kits/azure-kit.ts` | Azure integration kit (tools, connectors, skills, components) |
+| `packages/core/src/connectors/types.ts` | `APIConnector` interface and auth strategy types |
+| `packages/core/src/tools/types.ts` | `Tool<TArgs>` interface (see [LLM Tools](./llm-tools.md)) |
+| `packages/core/src/engine/skill-resolver.ts` | Prompt resolution middleware chain |
+| `packages/core/src/__tests__/integration-kit.test.ts` | Kit registration, dependency, and lifecycle tests |

--- a/docs-site/docs/extending/llm-tools.md
+++ b/docs-site/docs/extending/llm-tools.md
@@ -1,0 +1,233 @@
+---
+sidebar_position: 3
+---
+
+# LLM Tools
+
+LLM tools are functions you expose to the AI via [OpenAI function calling](https://platform.openai.com/docs/guides/function-calling). When the LLM decides it needs more information or needs to take an action, it emits a structured tool call — Kickstart executes the function and feeds the result back into the conversation.
+
+This guide covers the tool interface, the registry, and how to add a new tool.
+
+## How Tools Work
+
+### Tool Interface
+
+Every tool implements the `Tool<TArgs>` interface defined in `packages/core/src/tools/types.ts`:
+
+```typescript
+export interface Tool<TArgs = Record<string, unknown>> {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+  requireApproval?: boolean;
+  execute(args: TArgs, context: ToolContext): Promise<unknown>;
+}
+
+export interface ToolContext {
+  artifactStore: ArtifactStore;
+  fileSystem?: FileSystemProvider;
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Unique tool identifier — used as the function name in OpenAI calls |
+| `description` | `string` | Sent to the LLM to explain what the tool does and when to use it |
+| `parameters` | JSON Schema object | Describes the tool's arguments in OpenAI function-calling format |
+| `requireApproval` | `boolean?` | If `true`, the user must confirm before the tool executes |
+| `execute` | `function` | The implementation — receives typed args and a `ToolContext` |
+
+The `ToolContext` gives your tool access to:
+
+- **`artifactStore`** — read and write generated artifacts (Dockerfiles, manifests, etc.)
+- **`fileSystem`** — optional filesystem provider (available in MCP context, not in web API)
+
+### Tool Registry
+
+`packages/core/src/tools/registry.ts` exports a `ToolRegistry` class and a `defaultRegistry` singleton:
+
+```typescript
+const registry = new ToolRegistry();
+registry.register(myTool);
+registry.registerAll([tool1, tool2, tool3]);
+
+// Convert to OpenAI function-calling format
+const toolDefs = registry.toOpenAIFormat();
+
+// Execute a tool by name
+const result = await registry.execute("my_tool", args, context);
+```
+
+Tools registered on `defaultRegistry` are automatically available in the LLM conversation.
+
+### Wiring to the LLM
+
+In `packages/web/api/src/functions/converse.ts`:
+
+1. `defaultRegistry.toOpenAIFormat()` produces the tool definitions array
+2. The definitions are passed into the Azure OpenAI chat completion call
+3. When the LLM returns a tool call, `registry.execute(name, args, context)` is called
+4. The result is fed back to the LLM as a tool message
+5. This loops up to `maxToolRounds = 5` times per user turn
+
+Tool call events are streamed to the client as SSE events of type `tool_call` and `tool_result`.
+
+### Built-in Tools
+
+| Tool Name | Description |
+|---|---|
+| `github_repo_info` | Get metadata about a GitHub repository |
+| `github_repo_tree` | List files and directories in a repo |
+| `github_repo_file_read` | Read a specific file from a GitHub repo |
+| `github_api_get` | Make an authenticated GitHub API GET request |
+| `azure_resource_list` | List Azure resources in a subscription |
+| `azure_resource_get` | Get details on a specific Azure resource |
+| `estimate_cost` | Estimate monthly cost for a set of Azure services |
+| `fetch_webpage` | Fetch and extract content from a URL |
+| `generate_kubernetes_manifest` | Generate a Kubernetes manifest from a spec |
+| `list_artifacts` | List artifacts currently in the artifact store |
+| `get_artifact` | Read the content of a specific artifact |
+
+---
+
+## How to Add a Tool
+
+### Step 1 — Create the tool file
+
+Create a new file in `packages/core/src/tools/`. Name it after your tool using kebab-case:
+
+```
+packages/core/src/tools/my-tool.ts
+```
+
+Implement the `Tool<TArgs>` interface:
+
+```typescript
+import type { Tool, ToolContext } from "./types.js";
+
+interface MyToolArgs {
+  query: string;
+  maxResults?: number;
+}
+
+export const myTool: Tool<MyToolArgs> = {
+  name: "my_tool",
+  description:
+    "Searches for relevant documentation entries matching the query. " +
+    "Use this when the user asks about a specific technology or framework.",
+  parameters: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "The search query",
+      },
+      maxResults: {
+        type: "number",
+        description: "Maximum number of results to return (default: 5)",
+      },
+    },
+    required: ["query"],
+  },
+  requireApproval: false,
+
+  async execute(args: MyToolArgs, context: ToolContext): Promise<unknown> {
+    const { query, maxResults = 5 } = args;
+
+    // Your implementation here
+    const results = await fetchDocumentation(query, maxResults);
+
+    return {
+      results,
+      count: results.length,
+    };
+  },
+};
+```
+
+:::tip Write good descriptions
+The LLM decides when to call your tool based entirely on the `description`. Be explicit about what the tool does, what it returns, and — crucially — **when** to use it. "Use this when..." phrasing is highly effective.
+:::
+
+### Step 2 — Add SSRF and input validation
+
+If your tool makes outbound HTTP requests, validate inputs to prevent SSRF attacks. See `packages/core/src/tools/fetch-webpage.ts` for the reference implementation — it validates the URL scheme, blocks private IP ranges, and restricts to HTTP/HTTPS:
+
+```typescript
+async execute(args, context) {
+  const url = new URL(args.url); // throws on malformed URL
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new Error("Only HTTP/HTTPS URLs are supported");
+  }
+  // ...
+}
+```
+
+### Step 3 — Register the tool
+
+Open `packages/core/src/tools/index.ts` and add your tool to the registration block:
+
+```typescript
+import { myTool } from "./my-tool.js";
+
+// Register all tools on the default registry
+defaultRegistry.registerAll([
+  // ... existing tools ...
+  myTool,
+]);
+```
+
+Alternatively, if your tool belongs to an integration, add it to your `IntegrationKit`'s `tools` array instead. See [Integration Kits](./integration-kits.md) for details.
+
+### Step 4 — Write tests
+
+Add unit tests for your tool implementation. Test both the happy path and error conditions:
+
+```typescript
+import { myTool } from "../tools/my-tool.js";
+import type { ToolContext } from "../tools/types.js";
+
+const mockContext: ToolContext = {
+  artifactStore: { /* mock */ } as any,
+};
+
+describe("myTool", () => {
+  it("returns results for a valid query", async () => {
+    const result = await myTool.execute({ query: "nginx" }, mockContext);
+    expect(result).toHaveProperty("results");
+    expect(result).toHaveProperty("count");
+  });
+
+  it("respects maxResults", async () => {
+    const result = await myTool.execute(
+      { query: "nginx", maxResults: 2 },
+      mockContext
+    ) as any;
+    expect(result.results.length).toBeLessThanOrEqual(2);
+  });
+});
+```
+
+### Step 5 — Build and verify
+
+```bash
+npm run build -w @kickstart/core
+```
+
+Start the dev server and open a conversation. Ask the AI to do something that should trigger your tool. Watch the SSE stream in browser DevTools (Network → `converse` → EventStream) to see `tool_call` and `tool_result` events.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `packages/core/src/tools/types.ts` | `Tool<TArgs>` and `ToolContext` interfaces |
+| `packages/core/src/tools/registry.ts` | `ToolRegistry` class and `defaultRegistry` singleton |
+| `packages/core/src/tools/index.ts` | Tool registration entry point |
+| `packages/core/src/tools/fetch-webpage.ts` | Reference implementation with SSRF protection |
+| `packages/web/api/src/functions/converse.ts` | LLM wiring: `toOpenAIFormat()`, `execute()`, multi-round loop |

--- a/docs-site/docs/extending/mcp-tools.md
+++ b/docs-site/docs/extending/mcp-tools.md
@@ -1,0 +1,352 @@
+---
+sidebar_position: 6
+---
+
+# MCP Tools
+
+Kickstart ships an **MCP server** (`packages/mcp-server/`) that integrates with IDE-based AI assistants — VS Code Copilot, Claude Code, and any other client that speaks the [Model Context Protocol](https://modelcontextprotocol.io). The server exposes Kickstart's conversation engine, manifest generation, and A2UI responses as MCP tools over stdio transport.
+
+This guide covers the MCP server architecture, tool registration pattern, A2UI capability negotiation, and how to add a new tool.
+
+## How MCP Tools Work
+
+### Server Setup
+
+The entry point is `packages/mcp-server/src/index.ts`. It creates an `McpServer` instance, registers tools and resources, and connects via `StdioServerTransport`:
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const server = new McpServer({
+  name: "kickstart",
+  version: "0.1.0",
+});
+
+// Register tools here...
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+### Tool Registration Pattern
+
+Tools are registered using `server.tool()` with [Zod](https://zod.dev) schemas for parameter validation:
+
+```typescript
+import { z } from "zod";
+
+server.tool(
+  "tool-name",
+  "Human-readable description for the LLM",
+  {
+    paramName: z.string().describe("Parameter description"),
+    optionalParam: z.number().optional().describe("Optional parameter"),
+  },
+  async (params) => handleToolName(sessions, params.paramName),
+);
+```
+
+| Argument | Description |
+|---|---|
+| Name (`string`) | Unique tool identifier — this is what the IDE's LLM calls |
+| Description (`string`) | Sent to the LLM to explain when to use the tool |
+| Schema (`object`) | Zod schema — auto-validated before the handler runs |
+| Handler (`function`) | Async function receiving validated params, returns `{ content: ContentItem[] }` |
+
+### Existing Tools
+
+| Tool | Description |
+|---|---|
+| `kickstart` | Start a new Kickstart conversation. Returns an A2UI phase indicator and welcome text. |
+| `converse` | Continue a multi-turn conversation. Processes user message through the phase machine. |
+| `generate-manifests` | Generate Kubernetes manifests and GitHub Actions workflows from conversation state. |
+| `check-status` | Check deployment status for an active session. |
+| `action` | Handle a user action from the A2UI interface (button click, form submission). |
+| `app-message` | Relay a message from the MCP App HTML surface through the appropriate handler. |
+
+Additionally, a **resource** is registered:
+
+| Resource | URI | Description |
+|---|---|---|
+| `kickstart-app` | `kickstart://app/main` | HTML surface for IDE-native conversation UI (MCP App) |
+
+### Handler Pattern
+
+Tool handlers live in `packages/mcp-server/src/tools/` and follow a consistent pattern:
+
+```typescript
+type ContentItem =
+  | { type: "text"; text: string }
+  | { type: "resource"; resource: { uri: string; mimeType: string; text: string } };
+
+export async function handleMyTool(
+  sessions: Map<string, SessionState>,
+  param: string,
+  capability: A2UICapability = "kickstart",
+): Promise<{ content: ContentItem[] }> {
+  // 1. Validate session (if session-scoped)
+  const session = sessions.get(param);
+  if (!session) {
+    return {
+      content: [{ type: "text", text: "❌ Session not found." }],
+    };
+  }
+
+  // 2. Perform logic using @kickstart/core
+  const result = await doSomething(session);
+
+  // 3. Build A2UI component (optional)
+  const component = { type: "Card", id: "my-card", title: "Result", children: [] };
+
+  // 4. Wrap with createA2UIResource() for capability degradation
+  const a2uiResource = createA2UIResource(
+    component,
+    `a2ui://kickstart/session/${session.sessionId}/my-tool`,
+    capability,
+  );
+
+  // 5. Return content items
+  const content: ContentItem[] = [{ type: "text", text: result.summary }];
+  if (a2uiResource) content.push(a2uiResource);
+
+  return { content };
+}
+```
+
+### A2UI Capability Tiers
+
+Not all MCP clients support A2UI. The server negotiates capabilities during the `initialize` handshake and degrades gracefully:
+
+| Tier | Condition | Behavior |
+|---|---|---|
+| `kickstart` | Client advertises the Kickstart catalog ID | Full custom A2UI components |
+| `basic` | Client advertises any A2UI catalog | Components degraded to Card + Text |
+| `none` | No A2UI support | Text-only responses (A2UI resources omitted) |
+
+Capability resolution is handled by `resolveA2UICapability()` in `packages/mcp-server/src/a2ui.ts`:
+
+```typescript
+export function resolveA2UICapability(
+  clientCatalogs: readonly string[] | undefined,
+): A2UICapability {
+  if (!clientCatalogs || clientCatalogs.length === 0) return "none";
+  if (clientCatalogs.includes(KICKSTART_CATALOG_ID)) return "kickstart";
+  if (clientCatalogs.length > 0) return "basic";
+  return "none";
+}
+```
+
+Always wrap A2UI components with `createA2UIResource()` — it handles degradation automatically and returns `null` when the client has no A2UI support:
+
+```typescript
+const resource = createA2UIResource(component, uri, capability);
+if (resource) content.push(resource);  // Only added when client supports A2UI
+```
+
+### Session Management
+
+The MCP server uses an in-memory `Map<string, SessionState>` for session storage:
+
+- **TTL:** 1 hour per session
+- **Cleanup:** Stale sessions are purged every 10 minutes
+- **Engine state:** Stored separately in a module-level `Map` in `packages/mcp-server/src/tools/kickstart.ts`
+
+Sessions are created by the `kickstart` tool and referenced by `sessionId` in all subsequent tool calls.
+
+---
+
+## How to Add an MCP Tool
+
+### Step 1 — Create the handler file
+
+Create a new file in `packages/mcp-server/src/tools/`:
+
+```
+packages/mcp-server/src/tools/my-tool.ts
+```
+
+Implement the handler following the standard pattern:
+
+```typescript
+import type { SessionState } from "@kickstart/core";
+import { createA2UIResource } from "../a2ui.js";
+import type { A2UICapability } from "../a2ui.js";
+
+type ContentItem =
+  | { type: "text"; text: string }
+  | { type: "resource"; resource: { uri: string; mimeType: string; text: string } };
+
+export async function handleMyTool(
+  sessions: Map<string, SessionState>,
+  sessionId: string,
+  capability: A2UICapability = "kickstart",
+): Promise<{ content: ContentItem[] }> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return {
+      content: [{
+        type: "text",
+        text: `❌ Session \`${sessionId}\` not found. Start a new conversation with the \`kickstart\` tool.`,
+      }],
+    };
+  }
+
+  // Your logic here — use @kickstart/core APIs
+  const summary = `Processed session ${sessionId}`;
+
+  return {
+    content: [{ type: "text", text: summary }],
+  };
+}
+```
+
+### Step 2 — Register in index.ts
+
+Open `packages/mcp-server/src/index.ts` and add the import and tool registration:
+
+```typescript
+import { handleMyTool } from "./tools/my-tool.js";
+
+// ... after existing tool registrations ...
+
+server.tool(
+  "my-tool",
+  "Description of what this tool does — the IDE LLM uses this to decide when to call it.",
+  {
+    sessionId: z.string().describe("Active session ID from a kickstart conversation"),
+  },
+  async (params) => handleMyTool(sessions, params.sessionId, clientCapability),
+);
+```
+
+:::tip Write clear descriptions
+The IDE's LLM reads the tool description to decide when to call it. Be specific about what the tool does, what input it needs, and what it returns. If your tool requires a session, say so.
+:::
+
+### Step 3 — Add A2UI responses (optional)
+
+If your tool should return structured UI, build A2UI components and wrap them with `createA2UIResource()`:
+
+```typescript
+import type { CardComponent, TextComponent } from "@kickstart/core";
+
+const text: TextComponent = {
+  type: "Text",
+  id: "my-result-text",
+  content: "Here are the results...",
+};
+
+const card: CardComponent = {
+  type: "Card",
+  id: "my-result-card",
+  title: "My Tool Results",
+  children: [text],
+};
+
+const resource = createA2UIResource(
+  card,
+  `a2ui://kickstart/session/${sessionId}/my-tool`,
+  capability,
+);
+
+const content: ContentItem[] = [{ type: "text", text: summary }];
+if (resource) content.push(resource);
+```
+
+### Step 4 — Write tests
+
+Add tests in `packages/mcp-server/src/__tests__/`:
+
+```typescript
+import { handleMyTool } from "../tools/my-tool.js";
+import type { SessionState } from "@kickstart/core";
+import { InMemoryArtifactStore } from "@kickstart/core";
+
+describe("handleMyTool", () => {
+  const sessions = new Map<string, SessionState>();
+
+  beforeEach(() => {
+    sessions.set("test-session", {
+      sessionId: "test-session",
+      currentPhase: "discover",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      appDefinition: {},
+      messages: [],
+      artifactStore: new InMemoryArtifactStore(),
+    });
+  });
+
+  it("returns results for a valid session", async () => {
+    const result = await handleMyTool(sessions, "test-session", "none");
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+  });
+
+  it("returns error for unknown session", async () => {
+    const result = await handleMyTool(sessions, "nonexistent", "none");
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("not found"),
+    });
+  });
+});
+```
+
+### Step 5 — Build and test locally
+
+```bash
+npm run build -w @kickstart/mcp-server
+npm run test -w @kickstart/mcp-server
+```
+
+### Step 6 — Configure IDE clients
+
+To test with an IDE client, add the MCP server to the client's configuration.
+
+**VS Code Copilot** (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "kickstart": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["packages/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+**Claude Code** (`~/.claude/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "kickstart": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["packages/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+After configuring, restart the IDE extension and verify your tool appears in the tool list.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `packages/mcp-server/src/index.ts` | Server entry point — tool and resource registration |
+| `packages/mcp-server/src/a2ui.ts` | `createA2UIResource()`, capability resolution, degradation helpers |
+| `packages/mcp-server/src/tools/kickstart.ts` | `handleKickstart()` — session creation and engine state management |
+| `packages/mcp-server/src/tools/converse.ts` | `handleConverse()` — multi-turn conversation processing |
+| `packages/mcp-server/src/tools/generate-manifests.ts` | `handleGenerateManifests()` — manifest generation with safeguard validation |
+| `packages/mcp-server/src/tools/check-status.ts` | `handleCheckStatus()` — deployment status check |
+| `packages/mcp-server/src/tools/action.ts` | `handleAction()` — A2UI action event processing |
+| `packages/mcp-server/src/app/protocol.ts` | MCP App postMessage protocol parsing |
+| `packages/mcp-server/package.json` | Package config — binary entry point at `kickstart-mcp` |

--- a/docs-site/docs/extending/overview.md
+++ b/docs-site/docs/extending/overview.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 1
+---
+
+# Extending Kickstart
+
+Kickstart is built to be extended. Every major system surface has a defined extension point — no forking required. Whether you want to add a new guided conversation phase, expose a new function to the LLM, or bundle an entire third-party integration, there's a clean contract for doing it.
+
+## Extension Points
+
+| Extension Point | What You're Adding | Where It Lives |
+|---|---|---|
+| [Conversation Phases](./conversation-phases.md) | A new guided step in the AI flow | `packages/core/src/engine/` |
+| [LLM Tools](./llm-tools.md) | A new function the AI can call | `packages/core/src/tools/` |
+| [Integration Kits](./integration-kits.md) | A composable bundle of tools, connectors, prompts, and skills | `packages/core/src/kits/` |
+| [API Endpoints](./api-endpoints.md) | A new Azure Functions endpoint (optionally SSE-streaming) | `packages/web/api/src/functions/` |
+| [MCP Tools](./mcp-tools.md) | A new tool for VS Code Copilot / Claude Code IDE integration | `packages/mcp-server/src/tools/` |
+
+## Architecture Overview
+
+Kickstart's extensibility is layered. Most changes flow through the **core package** (`packages/core`), which is shared by both the web API and the MCP server.
+
+```
+packages/
+├── core/                    ← Shared engine: phases, tools, kits, prompts
+│   └── src/
+│       ├── engine/          ← Phase state machine, skill resolver
+│       ├── tools/           ← LLM tool registry
+│       ├── kits/            ← Integration kit registry
+│       └── prompts/         ← System prompt builder
+├── web/
+│   └── api/src/functions/   ← Azure Functions HTTP endpoints
+└── mcp-server/src/          ← MCP server for IDE clients
+```
+
+## Where to Start
+
+- **Adding a new AI capability?** → [LLM Tools](./llm-tools.md) is the fastest path. Create one file, register it, done.
+- **Adding an end-to-end integration** (e.g., a new cloud provider)? → [Integration Kits](./integration-kits.md) lets you bundle tools + connectors + prompts into one unit.
+- **Adding a new guided workflow step?** → [Conversation Phases](./conversation-phases.md) walks you through the phase state machine.
+- **Exposing a new HTTP surface?** → [API Endpoints](./api-endpoints.md) covers the Azure Functions v4 pattern with SSE streaming.
+- **Extending IDE integration?** → [MCP Tools](./mcp-tools.md) covers the MCP server pattern for VS Code Copilot and Claude Code.
+
+## Design Principles
+
+**First-party only.** There is no plugin sandbox or dynamic loading — all extensions are compiled into the package. This keeps the trust model simple: anything registered is trusted code.
+
+**Composition over inheritance.** Integration Kits wire into the ToolRegistry, ConnectorRegistry, and SkillResolver automatically. You define the what; the system handles the wiring.
+
+**Phase-aware.** Skills and prompts can be scoped to specific phases. An LLM tool registered for the `generate` phase doesn't appear in `discover` phase conversations.
+
+**SSE-first.** Long-running AI operations use Server-Sent Events. New endpoints that call the LLM should follow the same streaming pattern as `converse` and `generate`.


### PR DESCRIPTION
## Summary

Added comprehensive extension point documentation for Kickstart framework covering all five primary ways to extend the platform.

## Documentation Added

New docs-site section with guides for:
- **Conversation Phases** — adding new guided flow phases
- **LLM Tools** — exposing functions via OpenAI function calling  
- **Integration Kits** — composable bundles of tools, connectors, prompts
- **API Endpoints** — Azure Functions with SSE streaming
- **MCP Tools** — IDE integration for VS Code Copilot and Claude Code

~1,560 lines of documentation added covering all extension surfaces.

## Changes
- docs-site/docs/extending/_category_.json
- docs-site/docs/extending/overview.md
- docs-site/docs/extending/conversation-phases.md
- docs-site/docs/extending/llm-tools.md
- docs-site/docs/extending/integration-kits.md
- docs-site/docs/extending/api-endpoints.md
- docs-site/docs/extending/mcp-tools.md