### PR TITLE
fix: Tabs component + unregistered component handling

### DIFF
--- a/packages/web/src/catalog/fluent-components/Tabs.tsx
+++ b/packages/web/src/catalog/fluent-components/Tabs.tsx
@@ -1,10 +1,33 @@
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {createReactComponent} from '../../vendor/a2ui/react/adapter';
-import {TabsApi} from '../../vendor/a2ui/web_core/basic_catalog/index';
+import {z} from 'zod';
+import {
+  DynamicStringSchema,
+  ChildListSchema,
+} from '../../vendor/a2ui/web_core/schema/common-types';
 import {TabList, Tab, makeStyles, tokens} from '@fluentui/react-components';
 import type {SelectTabData, SelectTabEvent} from '@fluentui/react-components';
+import {ChildList} from './ChildList';
 
 type _Tab = any;
+
+/**
+ * Custom API matching the backend schema (label + children[]) rather than the
+ * vendor TabsApi which expects title + child (singular).
+ */
+const KickstartTabsApi = {
+  name: 'Tabs' as const,
+  schema: z.object({
+    accessibility: z.any().optional(),
+    weight: z.number().optional(),
+    tabs: z.array(z.object({
+      label: DynamicStringSchema,
+      title: DynamicStringSchema.optional(),
+      child: z.string().optional(),
+      children: ChildListSchema.optional(),
+    })).min(1),
+  }),
+};
 
 const useStyles = makeStyles({
   root: {
@@ -16,10 +39,11 @@ const useStyles = makeStyles({
   },
   content: {
     flex: '1',
+    paddingTop: tokens.spacingVerticalS,
   },
 });
 
-export const Tabs = createReactComponent(TabsApi, ({props, buildChild}) => {
+export const Tabs = createReactComponent(KickstartTabsApi, ({props, buildChild, context}) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const classes = useStyles();
 
@@ -30,16 +54,27 @@ export const Tabs = createReactComponent(TabsApi, ({props, buildChild}) => {
     setSelectedIndex(data.value as number);
   };
 
+  // Resolve the display label: prefer label, fall back to title
+  const getTabLabel = (tab: _Tab): string => String(tab.label ?? tab.title ?? 'Tab');
+
   return (
     <div className={classes.root}>
       <TabList selectedValue={selectedIndex} onTabSelect={onTabSelect}>
         {tabs.map((tab: _Tab, i: number) => (
           <Tab key={i} value={i}>
-            {tab.title}
+            {getTabLabel(tab)}
           </Tab>
         ))}
       </TabList>
-      <div className={classes.content}>{activeTab ? buildChild(activeTab.child) : null}</div>
+      <div className={classes.content}>
+        {activeTab ? (
+          activeTab.children ? (
+            <ChildList childList={activeTab.children} buildChild={buildChild} context={context} />
+          ) : activeTab.child ? (
+            buildChild(activeTab.child)
+          ) : null
+        ) : null}
+      </div>
     </div>
   );
 });

--- a/packages/web/src/catalog/fluent-components/Tabs.tsx
+++ b/packages/web/src/catalog/fluent-components/Tabs.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {createReactComponent} from '../../vendor/a2ui/react/adapter';
 import {z} from 'zod';
 import {
+  ComponentIdSchema,
   DynamicStringSchema,
   ChildListSchema,
 } from '../../vendor/a2ui/web_core/schema/common-types';
@@ -21,10 +22,12 @@ const KickstartTabsApi = {
     accessibility: z.any().optional(),
     weight: z.number().optional(),
     tabs: z.array(z.object({
-      label: DynamicStringSchema,
+      label: DynamicStringSchema.optional(),
       title: DynamicStringSchema.optional(),
-      child: z.string().optional(),
+      child: ComponentIdSchema.optional(),
       children: ChildListSchema.optional(),
+    }).refine((tab) => tab.label != null || tab.title != null, {
+      message: 'Each tab must provide at least one of "label" or "title".',
     })).min(1),
   }),
 };

--- a/packages/web/src/vendor/a2ui/react/A2uiSurface.tsx
+++ b/packages/web/src/vendor/a2ui/react/A2uiSurface.tsx
@@ -109,7 +109,15 @@ export const DeferredChild: React.FC<{
   const compImpl = surface.catalog.components.get(componentModel.type);
 
   if (!compImpl) {
-    return <div style={{color: 'red'}}>Unknown component: {componentModel.type}</div>;
+    console.warn(`[A2UI] No renderer registered for component type "${componentModel.type}" (id: ${id})`);
+    if (process.env.NODE_ENV !== 'production') {
+      return (
+        <div style={{color: '#d4820c', padding: '4px', fontSize: '12px'}}>
+          ⚠️ Unknown component: {componentModel.type}
+        </div>
+      );
+    }
+    return null;
   }
 
   return (


### PR DESCRIPTION
Working as Fry (Frontend Dev)

## What changed

**Tabs component (#268):** The existing Tabs renderer used the vendor `TabsApi` schema (`title` + `child`), but the backend sends `label` + `children[]`. Created a custom `KickstartTabsApi` matching the actual backend schema. Tabs now render correctly with Fluent UI TabList and support both `children` arrays and single `child` IDs.

**Unregistered component handling (#282):** When a component type has no catalog renderer, the surface now:
- Logs a `console.warn` with the type and ID
- In dev mode: shows a visible ⚠️ warning instead of broken UI
- In production: gracefully returns nothing (no more stuck `[Loading...]`)

Closes #268
Closes #282