### PR TITLE
fix: action button labels + ChoicePicker primary styling

### DIFF
--- a/packages/web/src/catalog/fluent-components/ChoicePicker.tsx
+++ b/packages/web/src/catalog/fluent-components/ChoicePicker.tsx
@@ -19,7 +19,6 @@ import {
   mergeClasses,
   tokens,
 } from '@fluentui/react-components';
-import { ArrowRight16Regular } from '@fluentui/react-icons';
 import { useMessageText } from '../../contexts/MessageTextContext';
 import { sanitizeActionContext } from '../../utils/sanitize-action-context';
 
@@ -102,10 +101,6 @@ const useStyles = makeStyles({
   continueVisible: {
     opacity: 1,
     transform: 'translateY(0)',
-  },
-  continueHint: {
-    fontSize: tokens.fontSizeBase200,
-    color: tokens.colorNeutralForeground3,
   },
 });
 
@@ -270,17 +265,13 @@ export const ChoicePicker = createReactComponent(FlexibleChoicePickerApi, ({prop
           aria-hidden={!showContinue}
         >
           <Button
-            appearance="subtle"
-            size="small"
-            icon={<ArrowRight16Regular />}
-            iconPosition="after"
+            appearance="primary"
             onClick={handleContinue}
             disabled={!showContinue}
             aria-label={`Continue with ${bestGuessLabel}`}
           >
             Continue{bestGuessLabel ? ` with ${bestGuessLabel}` : ''}
           </Button>
-          <span className={classes.continueHint}>best guess</span>
         </div>
       )}
     </div>

--- a/packages/web/src/hooks/useActionDispatch.ts
+++ b/packages/web/src/hooks/useActionDispatch.ts
@@ -61,7 +61,12 @@ function actionToMessage(action: A2uiClientAction): string {
       return context.selectedLabel;
     }
 
-    // 2. Prefer value / selectedValue — the user's actual selection
+    // 2. Prefer label — the button's user-facing text (e.g. "Looks good, generate the project")
+    if (typeof context.label === 'string' && context.label) {
+      return context.label;
+    }
+
+    // 3. Prefer value / selectedValue — the user's actual selection
     const rawValue = context.value ?? context.selectedValue;
     if (rawValue !== undefined && rawValue !== null && rawValue !== '') {
       const valueStr = Array.isArray(rawValue) ? rawValue.join(', ') : String(rawValue);
@@ -70,7 +75,7 @@ function actionToMessage(action: A2uiClientAction): string {
       }
     }
 
-    // 3. Build a compact summary from non-internal context keys (sanitized)
+    // 4. Build a compact summary from non-internal context keys (sanitized)
     const INTERNAL_KEYS = new Set(['label', 'selectedLabel', 'value', 'selectedValue']);
     const safeCtx = sanitizeActionContext(context);
     const contextParts: string[] = [];


### PR DESCRIPTION
Fixes #262 and #259.

**Bug #262:** Action buttons now show the button's label text in chat instead of the raw event name (e.g. shows 'Looks good, generate the project' instead of 'approve-architecture').

**Bug #259:** ChoicePicker default option is now a prominent Fluent UI primary button. Removed the 'best guess' label and arrow icon.

Working as Fry (Frontend Dev)

Closes #262
Closes #259