### PR TITLE
fix: consistent assistant icon during streaming

### DIFF
--- a/packages/web/src/components/Chat/MessageList.tsx
+++ b/packages/web/src/components/Chat/MessageList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BotSparkle24Regular } from '@fluentui/react-icons';
 import { ChatMessage } from './ChatMessage';
 import { TypingIndicator } from './TypingIndicator';
 import { A2UISurfaceWrapper } from '../A2UI/A2UISurfaceWrapper';
@@ -34,13 +35,7 @@ export function MessageList({ messages, isStreaming, streamingText, streamingSur
       {/* Streaming message (being generated) — shows text and any components that arrive progressively */}
       {isStreaming && (streamingText || hasStreamingSurfaces) && (
         <div className="chat-bubble-row">
-          <img
-            src="/assets/icons/compute/aks-automatic.svg"
-            alt=""
-            className="assistant-avatar"
-            width="28"
-            height="28"
-          />
+          <BotSparkle24Regular className="assistant-avatar" />
           <div className="chat-bubble assistant streaming">
             {streamingText && (
               <>


### PR DESCRIPTION
Working as Fry (Frontend Dev)

## What changed
The streaming message bubble in `MessageList.tsx` was using an `<img>` tag pointing to `/assets/icons/compute/aks-automatic.svg` (the AKS cube icon) for the assistant avatar. Meanwhile, the completed message in `ChatMessage.tsx` uses the Fluent UI `BotSparkle24Regular` robot icon. This mismatch caused a visible flash — the AKS icon during streaming, then the robot icon once the message was finalized.

**Fix:** Replaced the `<img>` tag in the streaming bubble with the same `BotSparkle24Regular` icon component used everywhere else, so the avatar is consistent during and after streaming.

Closes #270