### PR TITLE
fix: replace emoji status indicators with Fluent UI icons

### DIFF
--- a/packages/web/src/catalog/components/AzureAction.tsx
+++ b/packages/web/src/catalog/components/AzureAction.tsx
@@ -280,8 +280,8 @@ export const AzureAction = createReactComponent(AzureActionApi, ({ props }) => {
       {/* Destructive confirmation (per Zapp: type resource name to confirm) */}
       {state === 'confirming' && isDestructive && (
         <div className={classes.confirmSection}>
-          <Body1 style={{ fontWeight: 600, color: tokens.colorPaletteRedForeground1 }}>
-            ⚠️ Destructive operation
+          <Body1 style={{ fontWeight: 600, color: tokens.colorPaletteRedForeground1, display: 'inline-flex', alignItems: 'center', gap: tokens.spacingHorizontalXS }}>
+            <Warning20Regular /> Destructive operation
           </Body1>
           <Body2 style={{ marginTop: tokens.spacingVerticalXS }}>
             This will permanently delete the resource. Type <strong>{resourceName}</strong> to confirm.

--- a/packages/web/src/catalog/components/AzureAction.tsx
+++ b/packages/web/src/catalog/components/AzureAction.tsx
@@ -281,7 +281,8 @@ export const AzureAction = createReactComponent(AzureActionApi, ({ props }) => {
       {state === 'confirming' && isDestructive && (
         <div className={classes.confirmSection}>
           <Body1 style={{ fontWeight: 600, color: tokens.colorPaletteRedForeground1, display: 'inline-flex', alignItems: 'center', gap: tokens.spacingHorizontalXS }}>
-            <Warning20Regular /> Destructive operation
+            <Warning20Regular />
+            Destructive operation
           </Body1>
           <Body2 style={{ marginTop: tokens.spacingVerticalXS }}>
             This will permanently delete the resource. Type <strong>{resourceName}</strong> to confirm.

--- a/packages/web/src/catalog/components/GitHubAction.tsx
+++ b/packages/web/src/catalog/components/GitHubAction.tsx
@@ -332,7 +332,8 @@ export const GitHubAction = createReactComponent(GitHubActionApi, ({ props }) =>
       {state === 'confirming' && isDestructive && (
         <div className={classes.confirmSection}>
           <Body1 style={{ fontWeight: 600, color: tokens.colorPaletteRedForeground1, display: 'inline-flex', alignItems: 'center', gap: tokens.spacingHorizontalXS }}>
-            <Warning20Regular /> Destructive operation
+            <Warning20Regular />
+            Destructive operation
           </Body1>
           <Caption1 style={{ marginTop: tokens.spacingVerticalXS }}>
             This will permanently delete the resource. Type <strong>{resourceName}</strong> to confirm.

--- a/packages/web/src/catalog/components/GitHubAction.tsx
+++ b/packages/web/src/catalog/components/GitHubAction.tsx
@@ -331,8 +331,8 @@ export const GitHubAction = createReactComponent(GitHubActionApi, ({ props }) =>
       {/* Destructive typed confirmation (per Zapp: type resource name to confirm) */}
       {state === 'confirming' && isDestructive && (
         <div className={classes.confirmSection}>
-          <Body1 style={{ fontWeight: 600, color: tokens.colorPaletteRedForeground1 }}>
-            ⚠️ Destructive operation
+          <Body1 style={{ fontWeight: 600, color: tokens.colorPaletteRedForeground1, display: 'inline-flex', alignItems: 'center', gap: tokens.spacingHorizontalXS }}>
+            <Warning20Regular /> Destructive operation
           </Body1>
           <Caption1 style={{ marginTop: tokens.spacingVerticalXS }}>
             This will permanently delete the resource. Type <strong>{resourceName}</strong> to confirm.

--- a/packages/web/src/utils/statusIcons.tsx
+++ b/packages/web/src/utils/statusIcons.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  CheckmarkCircle20Filled,
+  Warning20Filled,
+  DismissCircle20Filled,
+  Info20Filled,
+} from '@fluentui/react-icons';
+import { tokens } from '@fluentui/react-components';
+
+const emojiIconMap: Record<string, { icon: React.FC<{ style?: React.CSSProperties }>; color: string }> = {
+  '✅': { icon: CheckmarkCircle20Filled, color: tokens.colorPaletteGreenForeground1 },
+  '⚠️': { icon: Warning20Filled, color: tokens.colorPaletteDarkOrangeForeground1 },
+  '❌': { icon: DismissCircle20Filled, color: tokens.colorPaletteRedForeground1 },
+  'ℹ️': { icon: Info20Filled, color: tokens.colorBrandForeground1 },
+};
+
+// Sorted longest-first so multi-codepoint emoji (⚠️, ℹ️) match before single-codepoint
+const sortedEmoji = Object.keys(emojiIconMap).sort((a, b) => b.length - a.length);
+
+/**
+ * Replaces a leading emoji status indicator in a text string with the
+ * corresponding Fluent UI icon component. Returns the original string
+ * unchanged if no known emoji prefix is found.
+ */
+export function replaceStatusEmoji(text: string): React.ReactNode {
+  for (const emoji of sortedEmoji) {
+    if (text.startsWith(emoji)) {
+      const rest = text.slice(emoji.length).trimStart();
+      const { icon: Icon, color } = emojiIconMap[emoji];
+      return (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+          <Icon style={{ color, flexShrink: 0 }} />
+          {rest}
+        </span>
+      );
+    }
+  }
+  return text;
+}

--- a/packages/web/src/utils/statusIcons.tsx
+++ b/packages/web/src/utils/statusIcons.tsx
@@ -12,7 +12,7 @@ const emojiIconMap: Record<string, { icon: React.FC<{ style?: React.CSSPropertie
   '⚠️': { icon: Warning20Filled, color: tokens.colorPaletteDarkOrangeForeground1 },
   '⚠': { icon: Warning20Filled, color: tokens.colorPaletteDarkOrangeForeground1 },
   '❌': { icon: DismissCircle20Filled, color: tokens.colorPaletteRedForeground1 },
-  'ℹ️': { icon: Info20Filled, color: tokens.colorBrandForeground1 },
+  'ℹ️': { icon: Info20Filled, color: tokens.colorPaletteBlueForeground2 },
   'ℹ': { icon: Info20Filled, color: tokens.colorBrandForeground1 },
 };
 

--- a/packages/web/src/utils/statusIcons.tsx
+++ b/packages/web/src/utils/statusIcons.tsx
@@ -13,7 +13,7 @@ const emojiIconMap: Record<string, { icon: React.FC<{ style?: React.CSSPropertie
   '⚠': { icon: Warning20Filled, color: tokens.colorPaletteDarkOrangeForeground1 },
   '❌': { icon: DismissCircle20Filled, color: tokens.colorPaletteRedForeground1 },
   'ℹ️': { icon: Info20Filled, color: tokens.colorPaletteBlueForeground2 },
-  'ℹ': { icon: Info20Filled, color: tokens.colorBrandForeground1 },
+  'ℹ': { icon: Info20Filled, color: tokens.colorPaletteBlueForeground2 },
 };
 
 // Sorted longest-first so multi-codepoint emoji variants (⚠️, ℹ️) match before single-codepoint forms

--- a/packages/web/src/utils/statusIcons.tsx
+++ b/packages/web/src/utils/statusIcons.tsx
@@ -24,7 +24,7 @@ const sortedEmoji = Object.keys(emojiIconMap).sort((a, b) => b.length - a.length
  * corresponding Fluent UI icon component. Returns the original string
  * unchanged if no known emoji prefix is found.
  */
-export function replaceStatusEmoji(text: string): React.ReactNode {
+export function replaceStatusEmoji(text: string): string | JSX.Element {
   for (const emoji of sortedEmoji) {
     if (text.startsWith(emoji)) {
       const rest = text.slice(emoji.length).trimStart();

--- a/packages/web/src/utils/statusIcons.tsx
+++ b/packages/web/src/utils/statusIcons.tsx
@@ -24,7 +24,7 @@ const sortedEmoji = Object.keys(emojiIconMap).sort((a, b) => b.length - a.length
  * corresponding Fluent UI icon component. Returns the original string
  * unchanged if no known emoji prefix is found.
  */
-export function replaceStatusEmoji(text: string): string | JSX.Element {
+export function replaceStatusEmoji(text: string): string | React.ReactElement {
   for (const emoji of sortedEmoji) {
     if (text.startsWith(emoji)) {
       const rest = text.slice(emoji.length).trimStart();

--- a/packages/web/src/utils/statusIcons.tsx
+++ b/packages/web/src/utils/statusIcons.tsx
@@ -10,11 +10,13 @@ import { tokens } from '@fluentui/react-components';
 const emojiIconMap: Record<string, { icon: React.FC<{ style?: React.CSSProperties }>; color: string }> = {
   '✅': { icon: CheckmarkCircle20Filled, color: tokens.colorPaletteGreenForeground1 },
   '⚠️': { icon: Warning20Filled, color: tokens.colorPaletteDarkOrangeForeground1 },
+  '⚠': { icon: Warning20Filled, color: tokens.colorPaletteDarkOrangeForeground1 },
   '❌': { icon: DismissCircle20Filled, color: tokens.colorPaletteRedForeground1 },
   'ℹ️': { icon: Info20Filled, color: tokens.colorBrandForeground1 },
+  'ℹ': { icon: Info20Filled, color: tokens.colorBrandForeground1 },
 };
 
-// Sorted longest-first so multi-codepoint emoji (⚠️, ℹ️) match before single-codepoint
+// Sorted longest-first so multi-codepoint emoji variants (⚠️, ℹ️) match before single-codepoint forms
 const sortedEmoji = Object.keys(emojiIconMap).sort((a, b) => b.length - a.length);
 
 /**

--- a/packages/web/src/vendor/a2ui/react/A2uiSurface.tsx
+++ b/packages/web/src/vendor/a2ui/react/A2uiSurface.tsx
@@ -17,6 +17,7 @@
 import React, {useSyncExternalStore, memo, useMemo, useCallback} from 'react';
 import {type SurfaceModel, ComponentContext, type ComponentModel} from '../web_core/index';
 import type {ReactComponentImplementation} from './adapter';
+import {Warning20Filled} from '@fluentui/react-icons';
 
 const ResolvedChild = memo(
   ({
@@ -112,8 +113,8 @@ export const DeferredChild: React.FC<{
     console.warn(`[A2UI] No renderer registered for component type "${componentModel.type}" (id: ${id})`);
     if (process.env.NODE_ENV !== 'production') {
       return (
-        <div style={{color: '#d4820c', padding: '4px', fontSize: '12px'}}>
-          ⚠️ Unknown component: {componentModel.type}
+        <div style={{color: '#d4820c', padding: '4px', fontSize: '12px', display: 'inline-flex', alignItems: 'center', gap: '4px'}}>
+          <Warning20Filled /> Unknown component: {componentModel.type}
         </div>
       );
     }

--- a/packages/web/src/vendor/a2ui/react/catalog/basic/components/CheckBox.tsx
+++ b/packages/web/src/vendor/a2ui/react/catalog/basic/components/CheckBox.tsx
@@ -19,6 +19,7 @@ import {createReactComponent} from '../../../adapter';
 import {CheckBoxApi} from '../../../../web_core/basic_catalog/index';
 import {Checkbox, Field, makeStyles, tokens} from '@fluentui/react-components';
 import type {CheckboxOnChangeData} from '@fluentui/react-components';
+import {replaceStatusEmoji} from '../../../../../../utils/statusIcons';
 
 const useStyles = makeStyles({
   root: {
@@ -42,7 +43,7 @@ export const CheckBox = createReactComponent(CheckBoxApi, ({props}) => {
         validationMessage={hasError ? props.validationErrors?.[0] : undefined}
         validationState={hasError ? 'error' : 'none'}
       >
-        <Checkbox checked={!!props.value} onChange={onChange} label={props.label || undefined} />
+        <Checkbox checked={!!props.value} onChange={onChange} label={props.label ? replaceStatusEmoji(props.label) : undefined} />
       </Field>
     </div>
   );


### PR DESCRIPTION
Working as Fry (Frontend Dev)

## What changed
Replaced emoji status indicators (✅ ⚠️ ❌ ℹ️) with proper Fluent UI icon components across all A2UI components for consistent design system styling.

**Files changed:**
- **`statusIcons.tsx`** (new) — Shared utility that maps emoji prefixes in text to Fluent UI `20Filled` icon components with semantic colors (green/amber/red/blue)
- **`CheckBox.tsx`** — Label rendering now auto-replaces emoji with icons, handling data from backend/LLM responses
- **`GitHubAction.tsx`** / **`AzureAction.tsx`** — Destructive operation warnings use `Warning20Regular` icon instead of ⚠️ emoji
- **`A2uiSurface.tsx`** — Dev-mode unknown component warning uses `Warning20Filled` icon

Closes #258