### PR TITLE
fix: code block theme — dark palette, readable font, line numbers

### DIFF
--- a/packages/web/src/catalog/components/CodeBlock.tsx
+++ b/packages/web/src/catalog/components/CodeBlock.tsx
@@ -3,12 +3,8 @@ import { createReactComponent } from '../../vendor/a2ui/react/adapter';
 import { z } from 'zod';
 import { DynamicStringSchema } from '../../vendor/a2ui/web_core/schema/common-types';
 import {
-  Card,
   Button,
-  Body1Strong,
-  Caption1,
   makeStyles,
-  tokens,
 } from '@fluentui/react-components';
 import { CopyRegular, CheckmarkRegular } from '@fluentui/react-icons';
 import { sanitizeHtml } from '../../utils/sanitize';
@@ -26,11 +22,13 @@ import markdown from 'highlight.js/lib/languages/markdown';
 import dockerfile from 'highlight.js/lib/languages/dockerfile';
 import yaml from 'highlight.js/lib/languages/yaml';
 import go from 'highlight.js/lib/languages/go';
-import 'highlight.js/styles/github.css';
+import 'highlight.js/styles/github-dark.css';
 
 // Register highlight.js languages
 hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('js', javascript);
 hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('ts', typescript);
 hljs.registerLanguage('python', python);
 hljs.registerLanguage('java', java);
 hljs.registerLanguage('csharp', csharp);
@@ -39,10 +37,23 @@ hljs.registerLanguage('xml', xml);
 hljs.registerLanguage('html', xml);
 hljs.registerLanguage('css', css);
 hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('shell', bash);
+hljs.registerLanguage('sh', bash);
 hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('md', markdown);
 hljs.registerLanguage('dockerfile', dockerfile);
 hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('yml', yaml);
 hljs.registerLanguage('go', go);
+
+const LANG_DISPLAY: Record<string, string> = {
+  typescript: 'TYPESCRIPT', javascript: 'JAVASCRIPT', python: 'PYTHON',
+  json: 'JSON', yaml: 'YAML', yml: 'YAML', xml: 'XML', html: 'HTML',
+  css: 'CSS', bash: 'BASH', shell: 'SHELL', sh: 'SHELL', sql: 'SQL',
+  go: 'GO', java: 'JAVA', csharp: 'C#', dockerfile: 'DOCKERFILE',
+  markdown: 'MARKDOWN', md: 'MARKDOWN', bicep: 'BICEP', ts: 'TYPESCRIPT',
+  js: 'JAVASCRIPT', plaintext: 'TEXT',
+};
 
 const CodeBlockApi = {
   name: 'CodeBlock',
@@ -55,11 +66,13 @@ const CodeBlockApi = {
 
 const useStyles = makeStyles({
   root: {
-    marginTop: tokens.spacingVerticalS,
-    marginBottom: tokens.spacingVerticalS,
+    marginTop: '8px',
+    marginBottom: '8px',
     width: '100%',
-    padding: '0',
     overflow: 'hidden',
+    borderRadius: '6px',
+    backgroundColor: '#1e1e1e',
+    color: '#d4d4d4',
     borderTopWidth: '0',
     borderRightWidth: '0',
     borderBottomWidth: '0',
@@ -69,80 +82,168 @@ const useStyles = makeStyles({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalM}`,
-    backgroundColor: tokens.colorNeutralBackground3,
+    padding: '6px 16px',
+    backgroundColor: '#252526',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: '#333333',
+    minHeight: '36px',
   },
   fileInfo: {
     display: 'flex',
     alignItems: 'center',
-    gap: tokens.spacingHorizontalS,
+    gap: '8px',
+    minWidth: '0',
+    overflow: 'hidden',
   },
-  codeContent: {
-    padding: tokens.spacingHorizontalM,
-    margin: '0',
+  fileName: {
+    fontSize: '12px',
+    fontWeight: 600,
+    color: '#cccccc',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  langBadge: {
+    fontSize: '10px',
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.04em',
+    padding: '1px 6px',
+    borderRadius: '3px',
+    backgroundColor: '#0e639c',
+    color: '#ffffff',
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
+  },
+  copyBtn: {
+    color: '#aaaaaa',
+    flexShrink: 0,
+    ':hover': {
+      color: '#ffffff',
+      backgroundColor: 'rgba(255,255,255,0.1)',
+    },
+  },
+  codeBody: {
     overflowX: 'auto',
-    borderRadius: '0',
+    padding: '8px 0',
   },
-  codeElement: {
+  codePre: {
+    margin: '0',
+    padding: '0',
     fontFamily: '"Cascadia Code", "Fira Code", "JetBrains Mono", Consolas, "Courier New", monospace',
     fontSize: '13px',
     lineHeight: '20px',
+    tabSize: '2',
+  },
+  codeLine: {
+    display: 'flex',
+    minHeight: '20px',
+    padding: '0 16px 0 0',
+    ':hover': {
+      backgroundColor: 'rgba(255,255,255,0.04)',
+    },
+  },
+  lineNumber: {
+    display: 'inline-block',
+    width: '48px',
+    paddingRight: '16px',
+    textAlign: 'right' as const,
+    color: '#555555',
+    userSelect: 'none' as const,
+    flexShrink: 0,
+  },
+  lineContent: {
+    flex: '1',
+    whiteSpace: 'pre',
+    minWidth: '0',
   },
 });
+
+/**
+ * Normalize literal backslash-n sequences to real newlines.
+ * Server / LLM payloads sometimes include escaped newlines in code strings.
+ */
+function normalizeNewlines(code: string): string {
+  // Only replace isolated \n (literal two-char sequence), not \\n (escaped backslash)
+  return code.replace(/(?<!\\)\\n/g, '\n');
+}
 
 export const CodeBlock = createReactComponent(CodeBlockApi, ({ props }) => {
   const [copied, setCopied] = useState(false);
   const classes = useStyles();
 
-  const highlightedCode = useMemo(() => {
-    if (!props.code) return '';
-    
+  const normalizedCode = useMemo(
+    () => (props.code ? normalizeNewlines(props.code) : ''),
+    [props.code],
+  );
+
+  const highlightedLines = useMemo(() => {
+    if (!normalizedCode) return [];
     try {
-      if (props.language) {
-        const result = hljs.highlight(props.code, { language: props.language });
-        return result.value;
+      let html: string;
+      if (props.language && hljs.getLanguage(props.language)) {
+        html = hljs.highlight(normalizedCode, { language: props.language }).value;
       } else {
-        const result = hljs.highlightAuto(props.code);
-        return result.value;
+        html = hljs.highlightAuto(normalizedCode).value;
       }
-    } catch (error) {
-      // If highlighting fails, HTML-escape the raw code to prevent XSS
-      return escapeHtml(props.code);
+      return html.split('\n');
+    } catch {
+      return escapeHtml(normalizedCode).split('\n');
     }
-  }, [props.code, props.language]);
+  }, [normalizedCode, props.language]);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(props.code || '').then(() => {
+    navigator.clipboard.writeText(normalizedCode).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
   };
 
+  const langLabel = props.language
+    ? LANG_DISPLAY[props.language.toLowerCase()] ?? props.language.toUpperCase()
+    : undefined;
+
   return (
-    <Card className={classes.root}>
-      {(props.filename || props.language) && (
-        <div className={classes.header}>
-          <div className={classes.fileInfo}>
-            {props.filename && <Body1Strong>{props.filename}</Body1Strong>}
-            {props.language && (
-              <Caption1>{props.language}</Caption1>
-            )}
-          </div>
-          <Button
-            appearance="subtle"
-            icon={copied ? <CheckmarkRegular /> : <CopyRegular />}
-            onClick={handleCopy}
-            size="small"
-            aria-label={copied ? 'Copied to clipboard' : 'Copy code to clipboard'}
-          >
-            {copied ? 'Copied' : 'Copy'}
-          </Button>
+    <div className={classes.root}>
+      <div className={classes.header}>
+        <div className={classes.fileInfo}>
+          {props.filename && (
+            <span className={classes.fileName}>{props.filename}</span>
+          )}
+          {langLabel && <span className={classes.langBadge}>{langLabel}</span>}
         </div>
-      )}
-      <pre className={classes.codeContent} role="region" aria-label={`Code block${props.language ? `: ${props.language}` : ''}${props.filename ? ` — ${props.filename}` : ''}`}>
-        <code className={`hljs ${classes.codeElement}`} dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlightedCode) }} />
-      </pre>
-    </Card>
+        <Button
+          appearance="subtle"
+          className={classes.copyBtn}
+          icon={copied ? <CheckmarkRegular /> : <CopyRegular />}
+          onClick={handleCopy}
+          size="small"
+          aria-label={copied ? 'Copied to clipboard' : 'Copy code to clipboard'}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+      <div
+        className={classes.codeBody}
+        role="region"
+        aria-label={`Code block${props.language ? `: ${props.language}` : ''}${props.filename ? ` — ${props.filename}` : ''}`}
+      >
+        <pre className={classes.codePre}>
+          <code className="hljs">
+            {highlightedLines.map((lineHtml, i) => (
+              <div key={i} className={classes.codeLine}>
+                <span className={classes.lineNumber}>{i + 1}</span>
+                <span
+                  className={classes.lineContent}
+                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(lineHtml) }}
+                />
+              </div>
+            ))}
+          </code>
+        </pre>
+      </div>
+    </div>
   );
 });
 

--- a/packages/web/src/components/Chat/ChatMarkdown.tsx
+++ b/packages/web/src/components/Chat/ChatMarkdown.tsx
@@ -39,6 +39,15 @@ hljs.registerLanguage('yaml', yaml);
 hljs.registerLanguage('yml', yaml);
 hljs.registerLanguage('go', go);
 
+const CHAT_LANG_DISPLAY: Record<string, string> = {
+  typescript: 'TYPESCRIPT', javascript: 'JAVASCRIPT', python: 'PYTHON',
+  json: 'JSON', yaml: 'YAML', yml: 'YAML', xml: 'XML', html: 'HTML',
+  css: 'CSS', bash: 'BASH', shell: 'SHELL', sh: 'SHELL', sql: 'SQL',
+  go: 'GO', java: 'JAVA', csharp: 'C#', dockerfile: 'DOCKERFILE',
+  markdown: 'MARKDOWN', md: 'MARKDOWN', bicep: 'BICEP', ts: 'TYPESCRIPT',
+  js: 'JAVASCRIPT', plaintext: 'TEXT',
+};
+
 interface ChatMarkdownProps {
   content: string;
 }
@@ -82,13 +91,79 @@ function HighlightedBlock({ code, language }: { code: string; language: string }
     }
   }, [code, language]);
 
+  const lines = html.split('\n');
+  const langLabel = language
+    ? (CHAT_LANG_DISPLAY[language.toLowerCase()] ?? language.toUpperCase())
+    : undefined;
+
   return (
-    <pre>
-      <code
-        className="hljs"
-        dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }}
-      />
-    </pre>
+    <div style={{
+      backgroundColor: '#1e1e1e',
+      color: '#d4d4d4',
+      borderRadius: '6px',
+      overflow: 'hidden',
+      margin: '8px 0',
+    }}>
+      {langLabel && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: '4px 12px',
+          backgroundColor: '#252526',
+          borderBottom: '1px solid #333333',
+          minHeight: '28px',
+        }}>
+          <span style={{
+            fontSize: '10px',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            padding: '1px 6px',
+            borderRadius: '3px',
+            backgroundColor: '#0e639c',
+            color: '#ffffff',
+          }}>
+            {langLabel}
+          </span>
+        </div>
+      )}
+      <div style={{ overflow: 'auto', padding: '8px 0' }}>
+        <pre style={{
+          margin: 0,
+          padding: 0,
+          fontFamily: '"Cascadia Code", "Fira Code", Consolas, "Courier New", monospace',
+          fontSize: '13px',
+          lineHeight: '20px',
+          tabSize: 2,
+        }}>
+          <code className="hljs">
+            {lines.map((lineHtml, i) => (
+              <div key={i} style={{
+                display: 'flex',
+                minHeight: '20px',
+                paddingRight: '16px',
+              }}>
+                <span style={{
+                  display: 'inline-block',
+                  width: '48px',
+                  paddingRight: '16px',
+                  textAlign: 'right',
+                  color: '#555555',
+                  userSelect: 'none',
+                  flexShrink: 0,
+                }}>
+                  {i + 1}
+                </span>
+                <span
+                  style={{ flex: 1, whiteSpace: 'pre', minWidth: 0 }}
+                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(lineHtml) }}
+                />
+              </div>
+            ))}
+          </code>
+        </pre>
+      </div>
+    </div>
   );
 }
 

--- a/packages/web/src/components/FileManager/FileViewer.tsx
+++ b/packages/web/src/components/FileManager/FileViewer.tsx
@@ -108,16 +108,43 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
   },
-  codeBlock: {
+  codeWrapper: {
     flex: 1,
     overflowY: 'auto',
+    backgroundColor: '#1e1e1e',
+    color: '#d4d4d4',
     ...shorthands.margin(0),
-    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
-    fontFamily: tokens.fontFamilyMonospace,
-    fontSize: tokens.fontSizeBase200,
-    lineHeight: tokens.lineHeightBase200,
-    whiteSpace: 'pre-wrap',
-    wordBreak: 'break-word',
+    ...shorthands.padding(tokens.spacingVerticalS, '0'),
+  },
+  codePre: {
+    ...shorthands.margin(0),
+    ...shorthands.padding(0),
+    fontFamily: '"Cascadia Code", "Fira Code", "JetBrains Mono", Consolas, "Courier New", monospace',
+    fontSize: '13px',
+    lineHeight: '20px',
+    tabSize: '2',
+  },
+  codeLine: {
+    display: 'flex',
+    minHeight: '20px',
+    paddingRight: tokens.spacingHorizontalM,
+    ':hover': {
+      backgroundColor: 'rgba(255,255,255,0.04)',
+    },
+  },
+  lineNumber: {
+    display: 'inline-block',
+    width: '48px',
+    paddingRight: tokens.spacingHorizontalM,
+    textAlign: 'right' as const,
+    color: '#555555',
+    userSelect: 'none' as const,
+    flexShrink: 0,
+  },
+  lineContent: {
+    flex: '1',
+    whiteSpace: 'pre',
+    minWidth: '0',
   },
   generating: {
     animationName: {
@@ -238,8 +265,8 @@ export function FileViewer({
   const content = file?.content ?? '';
   const fileName = filePath?.split('/').pop() ?? '';
 
-  const highlighted = useMemo(
-    () => (content ? highlightCode(content, language) : ''),
+  const highlightedLines = useMemo(
+    () => (content ? highlightCode(content, language).split('\n') : []),
     [content, language],
   );
 
@@ -318,10 +345,21 @@ export function FileViewer({
         </div>
       </div>
 
-      <pre
-        className={mergeClasses(styles.codeBlock, isGenerating && styles.generating)}
-        dangerouslySetInnerHTML={{ __html: highlighted }}
-      />
+      <div className={mergeClasses(styles.codeWrapper, isGenerating && styles.generating)}>
+        <pre className={styles.codePre}>
+          <code className="hljs">
+            {highlightedLines.map((lineHtml, i) => (
+              <div key={i} className={styles.codeLine}>
+                <span className={styles.lineNumber}>{i + 1}</span>
+                <span
+                  className={styles.lineContent}
+                  dangerouslySetInnerHTML={{ __html: lineHtml }}
+                />
+              </div>
+            ))}
+          </code>
+        </pre>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Working as Fry (Frontend Dev)

## What changed

Overhauled the code block rendering across three components to match the try-aks dark code viewer palette:

**CodeBlock.tsx** (catalog component — the main fix):
- Switched from `github.css` (light) to `github-dark.css` dark theme
- Dark background (`#1e1e1e`) with VS Code-style header bar (`#252526`)
- Line numbers with per-line rendering and hover highlight
- Styled language badge (uppercase, blue pill — matches CodeView)
- Literal `\\n` → real newline normalization (fixes YAML single-line bug)
- Registered additional language aliases (js, ts, sh, yml, md)

**FileViewer.tsx** (file panel):
- Dark code area background (`#1e1e1e`)
- Font size bumped to 13px / 20px line-height (was using tiny Fluent tokens)
- Added line numbers with per-line rendering

**ChatMarkdown.tsx** (markdown code blocks in chat):
- Added line numbers with per-line rendering
- Added language badge header bar
- Inline dark theme styling (`#1e1e1e` bg, `#252526` header)

All three components now share a consistent dark palette, 13px monospace font, line numbers, and language badges.

Closes #264