### PR TITLE
fix: normalize A2UI component titles to Subtitle1

### DIFF
--- a/packages/web/src/catalog/components/ArchitectureDiagram.tsx
+++ b/packages/web/src/catalog/components/ArchitectureDiagram.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   Caption1,
   Card,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -499,7 +499,7 @@ export const ArchitectureDiagram = createReactComponent(ArchitectureDiagramApi, 
     <Card className={classes.root}>
       {(props.title || props.description) && (
         <div className={classes.header}>
-          {props.title && <Subtitle2>{props.title}</Subtitle2>}
+          {props.title && <Subtitle1>{props.title}</Subtitle1>}
           {props.description && <Body2>{props.description}</Body2>}
         </div>
       )}

--- a/packages/web/src/catalog/components/AzureAction.tsx
+++ b/packages/web/src/catalog/components/AzureAction.tsx
@@ -14,7 +14,7 @@ import {
   MessageBar,
   MessageBarBody,
   Spinner,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -242,7 +242,7 @@ export const AzureAction = createReactComponent(AzureActionApi, ({ props }) => {
   return (
     <Card className={classes.root}>
       <CardHeader
-        header={<Subtitle2>{titleText}</Subtitle2>}
+        header={<Subtitle1>{titleText}</Subtitle1>}
         description={description ? <Caption1 className={classes.description}>{description}</Caption1> : undefined}
       />
 

--- a/packages/web/src/catalog/components/AzureResourceForm.tsx
+++ b/packages/web/src/catalog/components/AzureResourceForm.tsx
@@ -12,7 +12,7 @@ import {
   Input,
   Select,
   Spinner,
-  Subtitle2,
+  Subtitle1,
   Switch,
   MessageBar,
   MessageBarBody,
@@ -307,7 +307,7 @@ export const AzureResourceForm = createReactComponent(AzureResourceFormApi, ({ p
 
   return (
     <Card className={classes.root}>
-      <CardHeader header={<Subtitle2>{title}</Subtitle2>} />
+      <CardHeader header={<Subtitle1>{title}</Subtitle1>} />
 
       <form onSubmit={handleSubmit} className={classes.form}>
         {dynamicFields.map(renderField)}

--- a/packages/web/src/catalog/components/CostEstimate.tsx
+++ b/packages/web/src/catalog/components/CostEstimate.tsx
@@ -10,7 +10,7 @@ import {
   Label,
   Select,
   Slider,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -249,7 +249,7 @@ export const CostEstimate = createReactComponent(CostEstimateApi, ({ props, cont
     <Card className={classes.root}>
       <div className={classes.header}>
         <MoneyRegular />
-        <Subtitle2>{props.title ?? 'Estimated Monthly Cost'}</Subtitle2>
+        <Subtitle1>{props.title ?? 'Estimated Monthly Cost'}</Subtitle1>
         {props.source && (
           <Caption1 className={classes.sourceLabel}>
             {props.source === 'live' ? '● Live pricing' : '○ Estimated'}

--- a/packages/web/src/catalog/components/DeploymentProgress.tsx
+++ b/packages/web/src/catalog/components/DeploymentProgress.tsx
@@ -8,7 +8,7 @@ import {
   Caption1,
   Card,
   Spinner,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -170,7 +170,7 @@ export const DeploymentProgress = createReactComponent(DeploymentProgressApi, ({
         {overallStatus === 'running' && <Spinner size="tiny" />}
         {overallStatus === 'complete' && <CheckmarkCircleRegular className={classes.iconComplete} />}
         {overallStatus === 'error' && <DismissCircleRegular className={classes.iconError} />}
-        <Subtitle2>{props.title ?? 'Deployment Progress'}</Subtitle2>
+        <Subtitle1>{props.title ?? 'Deployment Progress'}</Subtitle1>
       </div>
 
       <div className={classes.stepList} role="list" aria-label="Deployment steps" aria-live="polite">

--- a/packages/web/src/catalog/components/FormGroup.tsx
+++ b/packages/web/src/catalog/components/FormGroup.tsx
@@ -9,7 +9,7 @@ import {
   Card,
   CardHeader,
   Badge,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -38,7 +38,7 @@ export const FormGroup = createReactComponent(FormGroupApi, ({ props, buildChild
   return (
     <Card className={classes.root}>
       <CardHeader
-        header={<Subtitle2>{props.title}</Subtitle2>}
+        header={<Subtitle1>{props.title}</Subtitle1>}
         action={
           props.step != null ? (
             <Badge appearance="filled" color="informative">Step {props.step}</Badge>

--- a/packages/web/src/catalog/components/GitHubAction.tsx
+++ b/packages/web/src/catalog/components/GitHubAction.tsx
@@ -13,7 +13,7 @@ import {
   MessageBar,
   MessageBarBody,
   Spinner,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -287,7 +287,7 @@ export const GitHubAction = createReactComponent(GitHubActionApi, ({ props }) =>
   return (
     <Card className={classes.root}>
       <CardHeader
-        header={<Subtitle2>{titleText}</Subtitle2>}
+        header={<Subtitle1>{titleText}</Subtitle1>}
         description={description ? <Caption1 className={classes.description}>{description}</Caption1> : undefined}
       />
 

--- a/packages/web/src/catalog/components/GitHubCommit.tsx
+++ b/packages/web/src/catalog/components/GitHubCommit.tsx
@@ -15,7 +15,7 @@ import {
   MessageBar,
   MessageBarBody,
   Spinner,
-  Subtitle2,
+  Subtitle1,
   Textarea,
   Tooltip,
   makeStyles,
@@ -260,7 +260,7 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
     return (
       <Card className={classes.root}>
         <CardHeader
-          header={<Subtitle2>Create Pull Request</Subtitle2>}
+          header={<Subtitle1>Create Pull Request</Subtitle1>}
           description={
             <Caption1>
               {repoFullName || 'Repository'} \u2192 {branchName}
@@ -301,7 +301,7 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
     return (
       <Card className={classes.root}>
         <CardHeader
-          header={<Subtitle2>Creating Pull Request\u2026</Subtitle2>}
+          header={<Subtitle1>Creating Pull Request\u2026</Subtitle1>}
           description={<Caption1>Pushing {selectedArtifacts.length} files to {branchName}</Caption1>}
         />
         <div className={classes.actions} style={{ justifyContent: 'center' }}>
@@ -316,7 +316,7 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
     return (
       <Card className={classes.root}>
         <CardHeader
-          header={<Subtitle2>Configure Pull Request</Subtitle2>}
+          header={<Subtitle1>Configure Pull Request</Subtitle1>}
           description={
             <Caption1>
               {selectedArtifacts.length} file{selectedArtifacts.length !== 1 ? 's' : ''} selected
@@ -398,7 +398,7 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
   return (
     <Card className={classes.root}>
       <CardHeader
-        header={<Subtitle2>Create Pull Request</Subtitle2>}
+        header={<Subtitle1>Create Pull Request</Subtitle1>}
         description={
           <Caption1>
             Select artifacts to include in the pull request

--- a/packages/web/src/catalog/components/Questionnaire.tsx
+++ b/packages/web/src/catalog/components/Questionnaire.tsx
@@ -10,7 +10,7 @@ import {
   RadioGroup as FluentRadioGroup,
   Radio,
   Card,
-  Subtitle2,
+  Subtitle1,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
@@ -95,9 +95,9 @@ export const Questionnaire = createReactComponent(QuestionnaireApi, ({ props }) 
 
   return (
     <Card className={classes.root}>
-      <Subtitle2 style={{ marginBottom: tokens.spacingVerticalM }}>
+      <Subtitle1 style={{ marginBottom: tokens.spacingVerticalM }}>
         {props.submitLabel || 'Questionnaire'}
-      </Subtitle2>
+      </Subtitle1>
 
       {(props.questions || []).map((q) => {
         const qType = q.type || 'text';

--- a/packages/web/src/catalog/components/SteppedCarousel.tsx
+++ b/packages/web/src/catalog/components/SteppedCarousel.tsx
@@ -8,7 +8,7 @@ import {
 import {
   Card,
   Button,
-  Subtitle2,
+  Subtitle1,
   Caption1,
   makeStyles,
   tokens,
@@ -142,7 +142,7 @@ export const SteppedCarousel = createReactComponent(SteppedCarouselApi, ({ props
       </div>
 
       {/* Active step title */}
-      <Subtitle2>{activeStepData?.title}</Subtitle2>
+      <Subtitle1>{activeStepData?.title}</Subtitle1>
 
       {/* Active step content — key forces remount so CSS animation replays */}
       <div

--- a/packages/web/src/catalog/fluent-components/Card.tsx
+++ b/packages/web/src/catalog/fluent-components/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {createReactComponent} from '../../vendor/a2ui/react/adapter';
 import {z} from 'zod';
 import {ComponentIdSchema, DynamicStringSchema} from '../../vendor/a2ui/web_core/schema/common-types';
-import {Card as FluentCard, Subtitle2, makeStyles, tokens} from '@fluentui/react-components';
+import {Card as FluentCard, Subtitle1, makeStyles, tokens} from '@fluentui/react-components';
 
 // Flexible CardApi: accepts both `child` (spec) and `children` (common mistake by LLMs),
 // plus an optional `title` prop. No .strict() so unknown props don't break rendering.
@@ -36,7 +36,7 @@ export const Card = createReactComponent(FlexibleCardApi, ({props, buildChild}) 
   return (
     <FluentCard className={classes.root}>
       {props.title && typeof props.title === 'string' && (
-        <Subtitle2 className={classes.title} block>{props.title}</Subtitle2>
+        <Subtitle1 className={classes.title} block>{props.title}</Subtitle1>
       )}
       {childId ? buildChild(childId) : null}
     </FluentCard>


### PR DESCRIPTION
Working as Fry (Frontend Dev)

## What changed
All 11 A2UI component files listed in #296 used `Subtitle2` for their top-level card/component title. Replaced every import and JSX usage with `Subtitle1` to match the product convention that A2UI component titles start at Subtitle 1 sizing.

**Files changed (11):**
- `GitHubCommit.tsx` — 4 title instances
- `Questionnaire.tsx` — 1 title instance
- `CostEstimate.tsx` — 1 title instance
- `AzureAction.tsx` — 1 title instance
- `GitHubAction.tsx` — 1 title instance
- `DeploymentProgress.tsx` — 1 title instance
- `AzureResourceForm.tsx` — 1 title instance
- `FormGroup.tsx` — 1 title instance
- `ArchitectureDiagram.tsx` — 1 title instance
- `SteppedCarousel.tsx` — 1 title instance
- `Card.tsx` (fluent-components) — 1 title instance

No logic changes. Import swap + JSX tag rename only. No `h1`/`h2`/`h3` was found in component titles — all were `Subtitle2`.

Closes #296