### PR TITLE
feat(web): wire generated files into workspace

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -17,19 +17,20 @@ import type { NavState } from './hooks/useNavigation';
 import { useStreaming } from './hooks/useStreaming';
 import { useMockStreaming } from './hooks/useMockStreaming';
 import { useAPIConnectorRegistry } from './contexts/APIConnectorContext';
+import { useArtifacts } from './contexts/ArtifactContext';
 import { useTheme } from './contexts/ThemeContext';
 import { useDebug } from './contexts/DebugContext';
 import { useVirtualFS } from './contexts/VirtualFSContext';
 import { healthCheck } from './services/api-client';
 import { isMockMode, isPlaygroundMode } from './services/mock-streaming';
 import { VirtualFileSystem } from './services/virtual-fs';
-import type { VFSFile } from './services/virtual-fs';
-import type { AppMode, ChatMessage, A2uiPayloadItem } from './types';
 import {
   getLatestConversationPhase,
   normalizeConversationPhase,
-  prepareChatA2uiPayload,
+  prepareChatA2ui,
+  rebuildChatSessionState,
 } from './utils/chat-a2ui';
+import type { AppMode, ChatMessage, A2uiPayloadItem } from './types';
 // A2uiClientAction type no longer needed — actions route through useActionDispatch only
 
 const mockEnabled = isMockMode();
@@ -52,8 +53,11 @@ export function App() {
   const [filePanelOpen, setFilePanelOpen] = useState(true);
   const [fileSidebarOpen, setFileSidebarOpen] = useState(true);
   const [viewerFile, setViewerFile] = useState<string | undefined>();
+  const selectedFileRef = useRef<string | undefined>(undefined);
+  const viewerFileRef = useRef<string | undefined>(undefined);
 
   const connectorRegistry = useAPIConnectorRegistry();
+  const { getArtifact } = useArtifacts();
 
   const { handler: actionHandler, resetConsecutiveCount } = useActionDispatch({
     onSendMessage: (msg) => handleSendMessage(msg),
@@ -106,7 +110,7 @@ export function App() {
   // Messages for the active session
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
-  // Current conversation phase for the active session
+  // Current conversation phase from SSE events
   const [currentPhase, setCurrentPhase] = useState<string | null>(null);
   const currentPhaseRef = useRef<string | null>(null);
 
@@ -115,6 +119,14 @@ export function App() {
 
   // Raw A2UI messages accumulated during streaming (for session persistence)
   const streamingA2UIMessagesRef = useRef<A2uiPayloadItem[]>([]);
+
+  useEffect(() => {
+    selectedFileRef.current = selectedFile;
+  }, [selectedFile]);
+
+  useEffect(() => {
+    viewerFileRef.current = viewerFile;
+  }, [viewerFile]);
 
   // Check API availability on mount (skip in mock mode — already true)
   useEffect(() => {
@@ -143,6 +155,64 @@ export function App() {
     setCurrentPhase(normalized);
     currentPhaseRef.current = normalized;
   }, []);
+
+  const openGeneratedFile = useCallback((path: string) => {
+    selectedFileRef.current = path;
+    viewerFileRef.current = path;
+    setSelectedFile(path);
+    setViewerFile(path);
+  }, []);
+
+  const resolveArtifactContent = useCallback((artifactPath: string) => {
+    return getArtifact(artifactPath)?.content ?? null;
+  }, [getArtifact]);
+
+  const clearWorkspace = useCallback(async () => {
+    a2ui.reset();
+    fs.clear();
+    lastPersistedRef.current = new Map();
+    clearActionLog();
+    selectedFileRef.current = undefined;
+    viewerFileRef.current = undefined;
+    setSelectedFile(undefined);
+    setViewerFile(undefined);
+    setConversationPhase(null);
+    try {
+      await vfs.clear();
+    } catch (err) {
+      console.error('[Workspace] failed to clear persisted files:', err);
+    }
+  }, [a2ui, fs, vfs, clearActionLog, setConversationPhase]);
+
+  const processIncomingA2UI = useCallback((msgs: A2uiPayloadItem[], turnId: string) => {
+    const prepared = prepareChatA2ui(msgs, turnId, {
+      currentPhase: currentPhaseRef.current,
+      resolveArtifactContent,
+    });
+
+    streamingA2UIMessagesRef.current = [
+      ...streamingA2UIMessagesRef.current,
+      ...prepared.storedMessages,
+    ];
+
+    if (prepared.phase) {
+      setConversationPhase(prepared.phase);
+    }
+
+    for (const file of prepared.files) {
+      fs.write(file.path, file.content, file.language);
+    }
+
+    if (prepared.files.length > 0 && !selectedFileRef.current && !viewerFileRef.current) {
+      openGeneratedFile(prepared.files[0].path);
+    }
+
+    const newIds = a2ui.processMessages(prepared.renderableMessages);
+    if (newIds.length > 0) {
+      streamingSurfaceIdsRef.current = [...streamingSurfaceIdsRef.current, ...newIds];
+      progressiveQueue.enqueue(newIds);
+    }
+  }, [resolveArtifactContent, fs, openGeneratedFile, a2ui, progressiveQueue, setConversationPhase]);
 
   const handleSendMessage = useCallback(async (text: string, isAutoContinue = false, explicitSessionId?: string) => {
     // Manual messages reset the consecutive auto-continue counter
@@ -190,22 +260,7 @@ export function App() {
     progressiveQueue.reset();
 
     const handleIncomingA2UI = (payload: A2uiPayloadItem[]) => {
-      const { phase, messages: scopedMessages } = prepareChatA2uiPayload(payload, assistantMessageId);
-
-      if (phase) {
-        setConversationPhase(phase);
-      }
-
-      if (scopedMessages.length === 0) {
-        return;
-      }
-
-      streamingA2UIMessagesRef.current = [...streamingA2UIMessagesRef.current, ...scopedMessages];
-      const newIds = a2ui.processMessages(scopedMessages);
-      if (newIds.length > 0) {
-        streamingSurfaceIdsRef.current = [...streamingSurfaceIdsRef.current, ...newIds];
-        progressiveQueue.enqueue(newIds);
-      }
+      processIncomingA2UI(payload, assistantMessageId);
     };
 
     // Use mock streaming when ?mock is active, real streaming otherwise
@@ -301,69 +356,56 @@ export function App() {
         },
       }, debugEnabled, activeSession?.messages ?? []);
     }
-  }, [sessions, streaming, mockStreaming, a2ui, isApiAvailable, resetConsecutiveCount, progressiveQueue, debugEnabled, clearActionLog, setConversationPhase]);
+  }, [sessions, streaming, mockStreaming, isApiAvailable, resetConsecutiveCount, progressiveQueue, debugEnabled, clearActionLog, setConversationPhase, processIncomingA2UI]);
 
-  const handleStartChat = useCallback((prompt: string) => {
-    a2ui.reset();
-    fs.clear();
-    void vfs.clear();
-    clearActionLog();
-    setSelectedFile(undefined);
-    setViewerFile(undefined);
+  const handleStartChat = useCallback(async (prompt: string) => {
+    await clearWorkspace();
     setMessages([]);
-    setConversationPhase(null);
     setMode('chat');
     document.body.classList.remove('on-landing');
 
     // Create session and send — pass explicit ID to avoid stale-closure duplicate
     const session = sessions.createSession(prompt);
     nav.pushSession(session.id);
-    handleSendMessage(prompt, false, session.id);
-  }, [sessions, a2ui, handleSendMessage, fs, vfs, nav.pushSession, clearActionLog, setConversationPhase]);
+    void handleSendMessage(prompt, false, session.id);
+  }, [clearWorkspace, sessions, handleSendMessage, nav.pushSession]);
 
-  const handleClearAllSessions = useCallback(() => {
+  const handleClearAllSessions = useCallback(async () => {
     sessions.clearAllSessions();
     setMessages([]);
-    a2ui.reset();
-    fs.clear();
-    void vfs.clear();
-    clearActionLog();
-    setSelectedFile(undefined);
-    setViewerFile(undefined);
-    setConversationPhase(null);
-  }, [sessions, a2ui, fs, vfs, clearActionLog, setConversationPhase]);
+    await clearWorkspace();
+  }, [sessions, clearWorkspace]);
 
-  const handleNewSession = useCallback((pushHistory = true) => {
-    a2ui.reset();
-    fs.clear();
-    void vfs.clear();
-    clearActionLog();
-    setSelectedFile(undefined);
-    setViewerFile(undefined);
+  const handleNewSession = useCallback(async (pushHistory = true) => {
+    await clearWorkspace();
     setMessages([]);
-    setConversationPhase(null);
     setMode('landing');
     document.body.classList.add('on-landing');
     sessions.setActiveSessionId(null);
     if (pushHistory) {
       nav.pushLanding();
     }
-  }, [a2ui, sessions, fs, vfs, nav.pushLanding, clearActionLog, setConversationPhase]);
+  }, [clearWorkspace, sessions, nav.pushLanding]);
 
-  const handleResumeSession = useCallback((sessionId: string, pushHistory = true) => {
+  const handleResumeSession = useCallback(async (sessionId: string, pushHistory = true) => {
     sessions.setActiveSessionId(sessionId);
     const session = sessions.sessions.find(s => s.id === sessionId);
     if (session) {
-      a2ui.reset();
-      clearActionLog();
-      for (const msg of session.messages) {
-        if (msg.a2uiMessages && msg.a2uiMessages.length > 0) {
-          const { messages: scopedMessages } = prepareChatA2uiPayload(msg.a2uiMessages, msg.id);
-          if (scopedMessages.length > 0) {
-            a2ui.processMessages(scopedMessages);
-          }
-        }
+      await clearWorkspace();
+      const restored = rebuildChatSessionState(session.messages, {
+        resolveArtifactContent,
+      });
+
+      if (restored.renderableMessages.length > 0) {
+        a2ui.processMessages(restored.renderableMessages);
       }
+      for (const file of restored.files) {
+        fs.write(file.path, file.content, file.language);
+      }
+      if (restored.files.length > 0) {
+        openGeneratedFile(restored.files[0].path);
+      }
+
       setMessages(session.messages);
       setConversationPhase(getLatestConversationPhase(session.messages));
       setMode('chat');
@@ -372,7 +414,7 @@ export function App() {
         nav.pushSession(sessionId);
       }
     }
-  }, [sessions, a2ui, nav.pushSession, clearActionLog, setConversationPhase]);
+  }, [sessions, clearWorkspace, resolveArtifactContent, a2ui, fs, openGeneratedFile, nav.pushSession, setConversationPhase]);
 
   // Wire up popstate -> handler dispatch (updated every render via ref)
   navHandlerRef.current = (state: NavState) => {
@@ -419,8 +461,8 @@ export function App() {
 
   // --- File Manager sidebar / viewer handlers ---
   const handleSelectViewerFile = useCallback((path: string) => {
-    setViewerFile(path);
-  }, []);
+    openGeneratedFile(path);
+  }, [openGeneratedFile]);
 
   const handleDownloadZip = useCallback(async () => {
     try {
@@ -443,9 +485,14 @@ export function App() {
       // file may not exist in IndexedDB
     }
     fs.delete(path);
-    if (viewerFile === path) setViewerFile(undefined);
-    if (selectedFile === path) setSelectedFile(undefined);
-    setViewerFile(undefined);
+    if (viewerFile === path) {
+      viewerFileRef.current = undefined;
+      setViewerFile(undefined);
+    }
+    if (selectedFile === path) {
+      selectedFileRef.current = undefined;
+      setSelectedFile(undefined);
+    }
   }, [vfs, fs, viewerFile, selectedFile]);
 
   const handleDismissSidebar = useCallback(() => {
@@ -453,25 +500,9 @@ export function App() {
   }, []);
 
   const handleDismissViewer = useCallback(() => {
+    viewerFileRef.current = undefined;
     setViewerFile(undefined);
   }, []);
-
-  // Wire navigation handler (popstate / initial deep-link)
-  navHandlerRef.current = (state: NavState) => {
-    if (state.view === 'session' && state.sessionId) {
-      handleResumeSession(state.sessionId, false);
-    } else {
-      handleNewSession(false);
-    }
-  };
-
-  // Restore deep-link on mount (e.g. #session/<id>)
-  useEffect(() => {
-    const initial = nav.getInitialState();
-    if (initial.view === 'session' && initial.sessionId) {
-      handleResumeSession(initial.sessionId, false);
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Playground mode — standalone A2UI test harness
   if (playgroundEnabled) {
@@ -518,7 +549,7 @@ export function App() {
             <FileEditor
               fs={fs}
               selectedPath={selectedFile}
-              onSelectFile={setSelectedFile}
+              onSelectFile={openGeneratedFile}
             />
             <FileTreePanel />
           </>

--- a/packages/web/src/__tests__/chat-ui.test.ts
+++ b/packages/web/src/__tests__/chat-ui.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ChatMessage as ChatMessageView } from '../components/Chat/ChatMessage';
 import { ChatShell } from '../components/Chat/ChatShell';
 import type { ChatMessage } from '../types';
-import { getLatestConversationPhase } from '../utils/chat-a2ui';
+import { GENERATE_PROGRESS_TITLE, getLatestConversationPhase, rebuildChatSessionState } from '../utils/chat-a2ui';
 
 const debugState = vi.hoisted(() => ({
   actionLog: [] as Array<{
@@ -146,5 +146,103 @@ describe('chat/debug UI regressions', () => {
     expect(markup).toContain('deploy-now');
     expect(markup).toContain('Deploy now');
     expect((markup.match(/data-testid="chat-debug-action-log"/g) ?? []).length).toBe(1);
+  });
+});
+
+describe('chat file workspace rehydration', () => {
+  it('rebuilds the selected session workspace without leaking files across sessions', () => {
+    const firstSession = rebuildChatSessionState([
+      {
+        id: 'assistant-turn-8',
+        a2uiMessages: [
+          {
+            type: 'ConversationPhase' as const,
+            id: 'phase-indicator',
+            currentPhase: 'generate',
+            phases: [
+              { id: 'discover', label: 'Discover', status: 'complete' as const },
+              { id: 'generate', label: 'Generate', status: 'active' as const },
+            ],
+          },
+          {
+            version: 'v0.9' as const,
+            createSurface: { surfaceId: 'msg-1', catalogId: 'kickstart' },
+          },
+          {
+            version: 'v0.9' as const,
+            updateComponents: {
+              surfaceId: 'msg-1',
+              components: [
+                {
+                  id: 'progress',
+                  component: 'DeploymentProgress',
+                  steps: [{ id: 'dockerfile', label: 'Dockerfile', status: 'complete' }],
+                },
+                {
+                  id: 'file',
+                  component: 'FileEditor',
+                  artifactPath: 'artifacts/Dockerfile',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ], {
+      resolveArtifactContent: (artifactPath) => artifactPath === 'artifacts/Dockerfile'
+        ? 'FROM node:20-alpine'
+        : null,
+    });
+
+    expect(firstSession.files).toEqual([
+      {
+        path: 'artifacts/Dockerfile',
+        content: 'FROM node:20-alpine',
+        language: 'dockerfile',
+      },
+    ]);
+    expect(firstSession.renderableMessages[0].createSurface?.surfaceId).toBe('assistant-turn-8::msg-1');
+    expect(firstSession.renderableMessages[1].updateComponents?.surfaceId).toBe('assistant-turn-8::msg-1');
+    expect(firstSession.renderableMessages[1].updateComponents?.components[0]).toMatchObject({
+      id: 'progress',
+      title: GENERATE_PROGRESS_TITLE,
+    });
+
+    const secondSession = rebuildChatSessionState([
+      {
+        id: 'assistant-turn-9',
+        a2uiMessages: [
+          {
+            version: 'v0.9' as const,
+            createSurface: { surfaceId: 'msg-2', catalogId: 'kickstart' },
+          },
+          {
+            version: 'v0.9' as const,
+            updateComponents: {
+              surfaceId: 'msg-2',
+              components: [
+                {
+                  id: 'file',
+                  component: 'FileEditor',
+                  filename: 'k8s/deployment.yaml',
+                  language: 'yaml',
+                  content: 'apiVersion: apps/v1',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(secondSession.files).toEqual([
+      {
+        path: 'k8s/deployment.yaml',
+        content: 'apiVersion: apps/v1',
+        language: 'yaml',
+      },
+    ]);
+    expect(secondSession.renderableMessages[0].createSurface?.surfaceId).toBe('assistant-turn-9::msg-2');
+    expect(secondSession.renderableMessages[1].updateComponents?.surfaceId).toBe('assistant-turn-9::msg-2');
   });
 });

--- a/packages/web/src/__tests__/chat-ui.test.ts
+++ b/packages/web/src/__tests__/chat-ui.test.ts
@@ -68,6 +68,10 @@ describe('chat/debug UI regressions', () => {
             type: 'ConversationPhase',
             id: 'phase-indicator',
             currentPhase: 'build',
+            phases: [
+              { id: 'discover', label: 'Discover', status: 'complete' },
+              { id: 'build', label: 'Build', status: 'active' },
+            ],
           },
         ],
       },

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -85,8 +85,8 @@ export function useStreaming() {
     let displayText = '';
     let lastModel: string | undefined;
     let lastSessionId: string | undefined;
-    let lastPhase: string | undefined;
-    const debugA2uiMessages: A2uiPayloadItem[] = [];
+      let lastPhase: string | undefined;
+      const debugA2uiMessages: A2uiPayloadItem[] = [];
 
     try {
       // Build client message history for rehydration (strip system messages

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -14,31 +14,6 @@ export interface ActionDebugEvent {
   outboundMessage: string;
 }
 
-export type ConversationPhaseId =
-  | 'discover'
-  | 'design'
-  | 'generate'
-  | 'review'
-  | 'handoff'
-  | 'deploy';
-
-export interface ConversationPhaseStep {
-  id?: string;
-  label?: string;
-  status?: string;
-}
-
-export interface ConversationPhasePayload {
-  id?: string;
-  type: 'ConversationPhase';
-  component?: 'ConversationPhase';
-  currentPhase?: string;
-  phases?: ConversationPhaseStep[];
-  [key: string]: unknown;
-}
-
-export type A2uiPayloadItem = A2uiMsg | ConversationPhasePayload;
-
 export interface DebugMetadata {
   /** Model name used for this response (e.g., "gpt-4o"). */
   model?: string;
@@ -55,6 +30,27 @@ export interface DebugMetadata {
   };
 }
 
+export type ConversationPhaseId =
+  | 'discover'
+  | 'design'
+  | 'generate'
+  | 'review'
+  | 'handoff'
+  | 'deploy';
+
+export interface ConversationPhaseStep {
+  id: string;
+  label: string;
+  status: 'pending' | 'active' | 'complete';
+}
+
+export interface ConversationPhasePayload {
+  type: 'ConversationPhase';
+  id: string;
+  phases: ConversationPhaseStep[];
+  currentPhase: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -68,7 +64,7 @@ export interface ChatMessage {
   isAutoContinue?: boolean;
   /** Debug metadata captured when debug mode is active. */
   debugInfo?: DebugMetadata;
-  /** Raw/scoped A2UI payload items for this turn (used to rehydrate on reload). */
+  /** Raw A2UI messages that produced the surfaces for this message (used to rehydrate on reload). */
   a2uiMessages?: A2uiPayloadItem[];
 }
 
@@ -116,6 +112,8 @@ export interface A2uiComponent {
   component: string;
   [key: string]: unknown;
 }
+
+export type A2uiPayloadItem = A2uiMsg | ConversationPhasePayload;
 
 export interface StreamEvent {
   error?: string;

--- a/packages/web/src/utils/chat-a2ui.test.ts
+++ b/packages/web/src/utils/chat-a2ui.test.ts
@@ -15,8 +15,8 @@ describe('prepareChatA2uiPayload', () => {
         id: 'phase-indicator',
         currentPhase: 'discover',
         phases: [
-          { id: 'discover', status: 'active' },
-          { id: 'design', status: 'pending' },
+          { id: 'discover', label: 'Discover', status: 'active' },
+          { id: 'design', label: 'Design', status: 'pending' },
         ],
       },
       {
@@ -236,6 +236,9 @@ describe('getLatestConversationPhase', () => {
             type: 'ConversationPhase',
             id: 'phase-indicator',
             currentPhase: 'review',
+            phases: [
+              { id: 'review', label: 'Review', status: 'active' },
+            ],
           },
         ],
       },
@@ -265,6 +268,9 @@ describe('getLatestConversationPhase', () => {
                 type: 'ConversationPhase',
                 id: 'phase-indicator',
                 currentPhase: 'validate',
+                phases: [
+                  { id: 'validate', label: 'Validate', status: 'active' },
+                ],
               },
             ],
           },

--- a/packages/web/src/utils/chat-a2ui.test.ts
+++ b/packages/web/src/utils/chat-a2ui.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatMessage, A2uiPayloadItem } from '../types';
-import { getLatestConversationPhase, prepareChatA2uiPayload } from './chat-a2ui';
+import {
+  GENERATE_PROGRESS_TITLE,
+  getLatestConversationPhase,
+  prepareChatA2ui,
+  prepareChatA2uiPayload,
+} from './chat-a2ui';
 
 describe('prepareChatA2uiPayload', () => {
   it('extracts the phase indicator and namespaces renderable surface ids per turn', () => {
@@ -82,11 +87,147 @@ describe('prepareChatA2uiPayload', () => {
   });
 });
 
+describe('prepareChatA2ui', () => {
+  it('replaces inline FileEditor components with compact file labels and extracts files', () => {
+    const payload: A2uiPayloadItem[] = [
+      {
+        type: 'ConversationPhase',
+        id: 'phase-indicator',
+        currentPhase: 'generate',
+        phases: [
+          { id: 'discover', label: 'Discover', status: 'complete' },
+          { id: 'generate', label: 'Generate', status: 'active' },
+        ],
+      },
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 'msg-1', catalogId: 'kickstart' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'msg-1',
+          components: [
+            {
+              id: 'progress',
+              component: 'DeploymentProgress',
+              steps: [{ id: 'dockerfile', label: 'Dockerfile', status: 'complete' }],
+            },
+            {
+              id: 'file',
+              component: 'FileEditor',
+              filename: 'Dockerfile',
+              language: 'dockerfile',
+              content: 'FROM node:20-alpine',
+            },
+          ],
+        },
+      },
+    ];
+
+    const prepared = prepareChatA2ui(payload, 'assistant-turn-3');
+    const renderableUpdate = prepared.renderableMessages[1].updateComponents;
+    const storedUpdate = prepared.storedMessages[2];
+
+    expect(prepared.phase).toBe('generate');
+    expect(prepared.files).toEqual([
+      {
+        path: 'Dockerfile',
+        content: 'FROM node:20-alpine',
+        language: 'dockerfile',
+      },
+    ]);
+    expect(renderableUpdate).toMatchObject({
+      surfaceId: 'assistant-turn-3::msg-1',
+      components: [
+        {
+          id: 'progress',
+          component: 'DeploymentProgress',
+          steps: [{ id: 'dockerfile', label: 'Dockerfile', status: 'complete' }],
+          title: GENERATE_PROGRESS_TITLE,
+        },
+        {
+          id: 'file',
+          component: 'Text',
+          text: '📄 Dockerfile',
+          variant: 'subtitle2',
+        },
+      ],
+    });
+    expect('updateComponents' in storedUpdate && storedUpdate.updateComponents?.surfaceId).toBe('msg-1');
+    expect('updateComponents' in storedUpdate && storedUpdate.updateComponents?.components[1]).toMatchObject({
+      id: 'file',
+      component: 'FileEditor',
+      filename: 'Dockerfile',
+      content: 'FROM node:20-alpine',
+    });
+  });
+
+  it('expands multi-file FileEditor payloads into a compact list', () => {
+    const payload: A2uiPayloadItem[] = [
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'msg-2',
+          components: [
+            {
+              id: 'editor',
+              component: 'FileEditor',
+              files: [
+                {
+                  filename: 'src/index.ts',
+                  language: 'typescript',
+                  content: 'console.log("hi")',
+                },
+                {
+                  filename: 'Dockerfile',
+                  language: 'dockerfile',
+                  content: 'FROM node:20-alpine',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ];
+
+    const prepared = prepareChatA2ui(payload, 'assistant-turn-4');
+
+    expect(prepared.files.map((file) => file.path)).toEqual([
+      'src/index.ts',
+      'Dockerfile',
+    ]);
+    expect(prepared.renderableMessages[0].updateComponents).toMatchObject({
+      surfaceId: 'assistant-turn-4::msg-2',
+      components: [
+        {
+          id: 'editor',
+          component: 'Column',
+          children: ['editor__file_0', 'editor__file_1'],
+          gap: 'small',
+        },
+        {
+          id: 'editor__file_0',
+          component: 'Text',
+          text: '📄 src/index.ts',
+          variant: 'subtitle2',
+        },
+        {
+          id: 'editor__file_1',
+          component: 'Text',
+          text: '📄 Dockerfile',
+          variant: 'subtitle2',
+        },
+      ],
+    });
+  });
+});
+
 describe('getLatestConversationPhase', () => {
   it('recovers the persisted phase from stored A2UI payload when the message field is empty', () => {
     const messages: ChatMessage[] = [
       {
-        id: 'assistant-turn-3',
+        id: 'assistant-turn-5',
         role: 'assistant',
         text: 'Still reviewing your setup.',
         timestamp: 0,
@@ -106,14 +247,14 @@ describe('getLatestConversationPhase', () => {
   it('falls back to debug envelope payloads for older assistant turns', () => {
     const messages: ChatMessage[] = [
       {
-        id: 'assistant-turn-4',
+        id: 'assistant-turn-6',
         role: 'assistant',
         text: 'Initial guidance',
         phase: 'discover',
         timestamp: 0,
       },
       {
-        id: 'assistant-turn-5',
+        id: 'assistant-turn-7',
         role: 'assistant',
         text: '',
         timestamp: 1,

--- a/packages/web/src/utils/chat-a2ui.ts
+++ b/packages/web/src/utils/chat-a2ui.ts
@@ -4,11 +4,46 @@ const PHASE_COMPONENT_NAME = 'ConversationPhase';
 const PHASE_SURFACE_ID = 'phase-indicator';
 const SURFACE_SCOPE_SEPARATOR = '::';
 
-const LEGACY_PHASE_ALIASES: Record<string, ConversationPhaseId> = {
+const PHASE_ALIASES = {
+  discover: 'discover',
   plan: 'design',
+  design: 'design',
   build: 'generate',
+  generate: 'generate',
+  review: 'review',
   validate: 'review',
+  handoff: 'handoff',
+  deploy: 'deploy',
+} as const satisfies Record<string, ConversationPhaseId>;
+
+const EXTENSION_LANGUAGES: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  py: 'python',
+  yaml: 'yaml',
+  yml: 'yaml',
+  json: 'json',
+  md: 'markdown',
+  css: 'css',
+  html: 'html',
+  sh: 'shell',
+  bash: 'shell',
+  dockerfile: 'dockerfile',
+  bicep: 'bicep',
+  go: 'go',
 };
+
+const FILE_NAME_LANGUAGES: Record<string, string> = {
+  Dockerfile: 'dockerfile',
+  '.dockerignore': 'ignore',
+  '.gitignore': 'ignore',
+  '.env': 'dotenv',
+  '.env.template': 'dotenv',
+};
+
+export const GENERATE_PROGRESS_TITLE = 'Project Setup';
 
 export const CONVERSATION_PHASE_ORDER = [
   'discover',
@@ -28,7 +63,35 @@ export const CONVERSATION_PHASE_LABELS: Record<ConversationPhaseId, string> = {
   deploy: 'Deploy',
 };
 
-function isA2uiMessage(item: A2uiPayloadItem): item is A2uiMsg {
+export interface GeneratedChatFile {
+  path: string;
+  content: string;
+  language?: string;
+}
+
+export interface PrepareChatA2uiOptions {
+  currentPhase?: string | null;
+  resolveArtifactContent?: (artifactPath: string) => string | null | undefined;
+}
+
+export interface PreparedChatA2ui {
+  storedMessages: A2uiPayloadItem[];
+  renderableMessages: A2uiMsg[];
+  files: GeneratedChatFile[];
+  phase: ConversationPhaseId | null;
+}
+
+export function normalizeConversationPhase(phase: string | null | undefined): ConversationPhaseId | null {
+  if (!phase) return null;
+
+  const normalized = phase.trim().toLowerCase();
+  if (!normalized) return null;
+  if (!(normalized in PHASE_ALIASES)) return null;
+
+  return PHASE_ALIASES[normalized as keyof typeof PHASE_ALIASES];
+}
+
+export function isA2uiMessage(item: A2uiPayloadItem): item is A2uiMsg {
   return Boolean(
     'version' in item
     || 'createSurface' in item
@@ -46,7 +109,7 @@ function isConversationPhaseComponent(component: unknown): component is Record<s
     || (candidate.type === 'createSurface' && candidate.component === PHASE_COMPONENT_NAME);
 }
 
-function extractPhaseFromPhaseList(phases: unknown): string | null {
+function extractPhaseFromPhaseList(phases: unknown): ConversationPhaseId | null {
   if (!Array.isArray(phases)) return null;
 
   const activePhase = phases.find((phase): phase is { id?: string; status?: string } =>
@@ -59,7 +122,7 @@ function extractPhaseFromPhaseList(phases: unknown): string | null {
   return normalizeConversationPhase(activePhase?.id);
 }
 
-function extractPhaseFromComponent(component: unknown): string | null {
+function extractPhaseFromComponent(component: unknown): ConversationPhaseId | null {
   if (!isConversationPhaseComponent(component)) return null;
 
   const candidate = component as Record<string, unknown>;
@@ -70,25 +133,7 @@ function extractPhaseFromComponent(component: unknown): string | null {
   return extractPhaseFromPhaseList(candidate.phases);
 }
 
-function scopeSurfaceId(surfaceId: string, turnId: string): string {
-  const prefix = `${turnId}${SURFACE_SCOPE_SEPARATOR}`;
-  return surfaceId.startsWith(prefix) ? surfaceId : `${prefix}${surfaceId}`;
-}
-
-function filterRenderableComponents(components: A2uiComponent[]): A2uiComponent[] {
-  return components.filter(component => !isConversationPhaseComponent(component));
-}
-
-export function normalizeConversationPhase(phase: string | null | undefined): string | null {
-  if (!phase) return null;
-
-  const normalized = phase.trim().toLowerCase();
-  if (!normalized) return null;
-
-  return LEGACY_PHASE_ALIASES[normalized] ?? normalized;
-}
-
-export function extractConversationPhase(items: readonly A2uiPayloadItem[]): string | null {
+export function extractConversationPhase(items: readonly A2uiPayloadItem[]): ConversationPhaseId | null {
   for (const item of items) {
     const directPhase = extractPhaseFromComponent(item);
     if (directPhase) return directPhase;
@@ -104,80 +149,158 @@ export function extractConversationPhase(items: readonly A2uiPayloadItem[]): str
   return null;
 }
 
-export function scopeRenderableA2uiMessages(
+function scopeSurfaceId(surfaceId: string, turnId: string): string {
+  const prefix = `${turnId}${SURFACE_SCOPE_SEPARATOR}`;
+  return surfaceId.startsWith(prefix) ? surfaceId : `${prefix}${surfaceId}`;
+}
+
+function scopeRenderableMessage(
+  item: A2uiMsg,
+  turnId: string,
+  components?: A2uiComponent[],
+): A2uiMsg | null {
+  if (item.createSurface) {
+    if (item.createSurface.surfaceId === PHASE_SURFACE_ID) return null;
+    return {
+      ...item,
+      createSurface: {
+        ...item.createSurface,
+        surfaceId: scopeSurfaceId(item.createSurface.surfaceId, turnId),
+      },
+    };
+  }
+
+  if (item.updateComponents) {
+    if (item.updateComponents.surfaceId === PHASE_SURFACE_ID) return null;
+    const scopedComponents = components ?? item.updateComponents.components;
+    if (scopedComponents.length === 0) return null;
+    return {
+      ...item,
+      updateComponents: {
+        ...item.updateComponents,
+        surfaceId: scopeSurfaceId(item.updateComponents.surfaceId, turnId),
+        components: scopedComponents,
+      },
+    };
+  }
+
+  if (item.updateDataModel) {
+    if (item.updateDataModel.surfaceId === PHASE_SURFACE_ID) return null;
+    return {
+      ...item,
+      updateDataModel: {
+        ...item.updateDataModel,
+        surfaceId: scopeSurfaceId(item.updateDataModel.surfaceId, turnId),
+      },
+    };
+  }
+
+  if (item.deleteSurface) {
+    if (item.deleteSurface.surfaceId === PHASE_SURFACE_ID) return null;
+    return {
+      ...item,
+      deleteSurface: {
+        ...item.deleteSurface,
+        surfaceId: scopeSurfaceId(item.deleteSurface.surfaceId, turnId),
+      },
+    };
+  }
+
+  return item;
+}
+
+export function prepareChatA2ui(
   items: readonly A2uiPayloadItem[],
   turnId: string,
-): A2uiMsg[] {
-  return items.flatMap((item) => {
-    if (!isA2uiMessage(item)) return [];
+  options: PrepareChatA2uiOptions = {},
+): PreparedChatA2ui {
+  const phase = extractConversationPhase(items) ?? normalizeConversationPhase(options.currentPhase);
+  const files: GeneratedChatFile[] = [];
+  const storedMessages: A2uiPayloadItem[] = [];
+  const renderableMessages: A2uiMsg[] = [];
 
-    if (item.createSurface) {
-      if (item.createSurface.surfaceId === PHASE_SURFACE_ID) return [];
-      return [{
-        ...item,
-        createSurface: {
-          ...item.createSurface,
-          surfaceId: scopeSurfaceId(item.createSurface.surfaceId, turnId),
-        },
-      }];
+  for (const item of items) {
+    if (!isA2uiMessage(item)) {
+      storedMessages.push(item);
+      continue;
     }
 
-    if (item.updateComponents) {
-      if (item.updateComponents.surfaceId === PHASE_SURFACE_ID) return [];
-
-      const components = filterRenderableComponents(item.updateComponents.components);
-      if (components.length === 0) return [];
-
-      return [{
-        ...item,
-        updateComponents: {
-          ...item.updateComponents,
-          surfaceId: scopeSurfaceId(item.updateComponents.surfaceId, turnId),
-          components,
-        },
-      }];
+    if (!item.updateComponents?.components) {
+      storedMessages.push(item);
+      const renderableMessage = scopeRenderableMessage(item, turnId);
+      if (renderableMessage) {
+        renderableMessages.push(renderableMessage);
+      }
+      continue;
     }
 
-    if (item.updateDataModel) {
-      if (item.updateDataModel.surfaceId === PHASE_SURFACE_ID) return [];
-      return [{
-        ...item,
-        updateDataModel: {
-          ...item.updateDataModel,
-          surfaceId: scopeSurfaceId(item.updateDataModel.surfaceId, turnId),
-        },
-      }];
-    }
+    const storedComponents = enrichComponents(
+      item.updateComponents.components,
+      files,
+      options.resolveArtifactContent,
+    );
 
-    if (item.deleteSurface) {
-      if (item.deleteSurface.surfaceId === PHASE_SURFACE_ID) return [];
-      return [{
-        ...item,
-        deleteSurface: {
-          ...item.deleteSurface,
-          surfaceId: scopeSurfaceId(item.deleteSurface.surfaceId, turnId),
-        },
-      }];
-    }
+    storedMessages.push({
+      ...item,
+      updateComponents: {
+        ...item.updateComponents,
+        components: storedComponents,
+      },
+    });
 
-    return [item];
-  });
+    const renderableMessage = scopeRenderableMessage(
+      item,
+      turnId,
+      renderComponentsForChat(storedComponents, phase),
+    );
+    if (renderableMessage) {
+      renderableMessages.push(renderableMessage);
+    }
+  }
+
+  return { storedMessages, renderableMessages, files, phase };
 }
 
 export function prepareChatA2uiPayload(
   items: readonly A2uiPayloadItem[],
   turnId: string,
-): {
-  phase: string | null;
-  messages: A2uiMsg[];
-} {
+): { phase: ConversationPhaseId | null; messages: A2uiMsg[] } {
+  const prepared = prepareChatA2ui(items, turnId);
   return {
-    phase: extractConversationPhase(items),
-    messages: scopeRenderableA2uiMessages(items, turnId),
+    phase: prepared.phase,
+    messages: prepared.renderableMessages,
   };
 }
 
-export function getLatestConversationPhase(messages: readonly ChatMessage[]): string | null {
+export function rebuildChatSessionState(
+  messages: readonly Pick<ChatMessage, 'id' | 'a2uiMessages' | 'phase'>[],
+  options: Omit<PrepareChatA2uiOptions, 'currentPhase'> = {},
+): Omit<PreparedChatA2ui, 'storedMessages'> {
+  const renderableMessages: A2uiMsg[] = [];
+  const files: GeneratedChatFile[] = [];
+  let phase: ConversationPhaseId | null = null;
+
+  for (const message of messages) {
+    const fallbackPhase = normalizeConversationPhase(message.phase) ?? phase;
+    if (!message.a2uiMessages?.length) {
+      phase = fallbackPhase;
+      continue;
+    }
+
+    const prepared = prepareChatA2ui(message.a2uiMessages, message.id, {
+      ...options,
+      currentPhase: fallbackPhase,
+    });
+
+    renderableMessages.push(...prepared.renderableMessages);
+    files.push(...prepared.files);
+    phase = prepared.phase ?? fallbackPhase;
+  }
+
+  return { renderableMessages, files, phase };
+}
+
+export function getLatestConversationPhase(messages: readonly ChatMessage[]): ConversationPhaseId | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message.role !== 'assistant') continue;
@@ -191,4 +314,173 @@ export function getLatestConversationPhase(messages: readonly ChatMessage[]): st
   }
 
   return null;
+}
+
+function enrichComponents(
+  components: A2uiComponent[],
+  files: GeneratedChatFile[],
+  resolveArtifactContent?: (artifactPath: string) => string | null | undefined,
+): A2uiComponent[] {
+  return components.map((component) => {
+    if (!isFileEditorComponent(component)) {
+      return component;
+    }
+
+    const normalizedEntries = extractFileEntries(component, resolveArtifactContent);
+    files.push(...normalizedEntries.map(({ path, content, language }) => ({
+      path,
+      content,
+      language,
+    })));
+
+    if ('files' in component && Array.isArray(component.files)) {
+      return {
+        ...component,
+        files: normalizedEntries.map(({ path, content, language }) => ({
+          filename: path,
+          content,
+          language,
+        })),
+      } as A2uiComponent;
+    }
+
+    const firstFile = normalizedEntries[0];
+    if (!firstFile) {
+      return component;
+    }
+
+    return {
+      ...component,
+      filename: firstFile.path,
+      content: firstFile.content,
+      language: firstFile.language,
+    } as A2uiComponent;
+  });
+}
+
+function renderComponentsForChat(
+  components: A2uiComponent[],
+  phase: ConversationPhaseId | null,
+): A2uiComponent[] {
+  return components.flatMap((component) => {
+    if (isConversationPhaseComponent(component)) {
+      return [];
+    }
+
+    if (isFileEditorComponent(component)) {
+      return buildGeneratedFileSummary(component);
+    }
+
+    if (phase === 'generate' && isDeploymentProgressComponent(component)) {
+      return [{ ...component, title: GENERATE_PROGRESS_TITLE } as A2uiComponent];
+    }
+
+    return [component];
+  });
+}
+
+function buildGeneratedFileSummary(component: A2uiComponent): A2uiComponent[] {
+  const entries = extractFileEntries(component);
+
+  if (entries.length === 0) {
+    return [{
+      id: component.id,
+      component: 'Text',
+      text: '📄 Generated files are available in the workspace.',
+      variant: 'body2',
+    } as A2uiComponent];
+  }
+
+  if (entries.length === 1) {
+    return [{
+      id: component.id,
+      component: 'Text',
+      text: formatFileLabel(entries[0].path),
+      variant: 'subtitle2',
+    } as A2uiComponent];
+  }
+
+  const childIds = entries.map((_, index) => `${component.id}__file_${index}`);
+
+  return [
+    {
+      id: component.id,
+      component: 'Column',
+      children: childIds,
+      gap: 'small',
+    } as A2uiComponent,
+    ...entries.map((entry, index) => ({
+      id: childIds[index],
+      component: 'Text',
+      text: formatFileLabel(entry.path),
+      variant: 'subtitle2',
+    }) as A2uiComponent),
+  ];
+}
+
+function extractFileEntries(
+  component: A2uiComponent,
+  resolveArtifactContent?: (artifactPath: string) => string | null | undefined,
+): Array<GeneratedChatFile & { artifactPath?: string }> {
+  const rawEntries = isFileEditorComponent(component) && Array.isArray(component.files) && component.files.length > 0
+    ? component.files
+    : [component];
+
+  return rawEntries
+    .map((entry) => normalizeFileEntry(entry, resolveArtifactContent))
+    .filter((entry): entry is GeneratedChatFile & { artifactPath?: string } => entry !== null);
+}
+
+function normalizeFileEntry(
+  entry: unknown,
+  resolveArtifactContent?: (artifactPath: string) => string | null | undefined,
+): (GeneratedChatFile & { artifactPath?: string }) | null {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const record = entry as Record<string, unknown>;
+  const artifactPath = coerceString(record.artifactPath);
+  const path = coerceString(record.filename) ?? artifactPath;
+  if (!path) {
+    return null;
+  }
+
+  const directContent = typeof record.content === 'string' ? record.content : undefined;
+  const content = directContent ?? (artifactPath ? resolveArtifactContent?.(artifactPath) : undefined) ?? '';
+  const language = coerceString(record.language) ?? inferLanguageFromPath(path);
+
+  return { path, content, language, artifactPath };
+}
+
+function inferLanguageFromPath(path: string): string | undefined {
+  const filename = path.split('/').pop() ?? '';
+  if (filename in FILE_NAME_LANGUAGES) {
+    return FILE_NAME_LANGUAGES[filename];
+  }
+
+  const ext = filename.includes('.') ? filename.split('.').pop()?.toLowerCase() : filename.toLowerCase();
+  return ext ? EXTENSION_LANGUAGES[ext] : undefined;
+}
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function formatFileLabel(path: string): string {
+  return `📄 ${path}`;
+}
+
+function isFileEditorComponent(component: A2uiComponent): component is A2uiComponent & {
+  filename?: string;
+  content?: string;
+  language?: string;
+  artifactPath?: string;
+  files?: unknown[];
+} {
+  return component.component === 'FileEditor';
+}
+
+function isDeploymentProgressComponent(component: A2uiComponent): boolean {
+  return component.component === 'DeploymentProgress';
 }

--- a/packages/web/src/utils/chat-a2ui.ts
+++ b/packages/web/src/utils/chat-a2ui.ts
@@ -281,7 +281,7 @@ export function rebuildChatSessionState(
   let phase: ConversationPhaseId | null = null;
 
   for (const message of messages) {
-    const fallbackPhase = normalizeConversationPhase(message.phase) ?? phase;
+    const fallbackPhase: ConversationPhaseId | null = normalizeConversationPhase(message.phase) ?? phase;
     if (!message.a2uiMessages?.length) {
       phase = fallbackPhase;
       continue;
@@ -372,7 +372,8 @@ function renderComponentsForChat(
     }
 
     if (phase === 'generate' && isDeploymentProgressComponent(component)) {
-      return [{ ...component, title: GENERATE_PROGRESS_TITLE } as A2uiComponent];
+      const progressComponent = component as A2uiComponent;
+      return [{ ...progressComponent, title: GENERATE_PROGRESS_TITLE }];
     }
 
     return [component];


### PR DESCRIPTION
Closes #265

Working as Fry (Frontend Dev)

## Summary
- intercept FileEditor chat payloads and render compact generated-file labels instead of inline code blocks
- mirror generated files into the in-memory workspace + persisted file views and auto-open the first file
- rebuild the workspace from stored assistant A2UI payloads on session resume/switch
- rename generate-phase DeploymentProgress cards to Project Setup

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Testing
- `npx vitest run packages/web/src/utils/chat-a2ui.test.ts packages/web/src/__tests__/chat-ui.test.ts`
- `npm run build -w @kickstart/web`
- `npm run lint` (passes with pre-existing warnings only)
- `cd packages/web && npx tsc --noEmit` still reports pre-existing vendor/Zod errors outside this change set