### PR TITLE
fix: restore progressive conversation flow

### DIFF
--- a/packages/core/src/__tests__/integration-kit.test.ts
+++ b/packages/core/src/__tests__/integration-kit.test.ts
@@ -375,11 +375,12 @@ describe('azureKit', () => {
     }
   });
 
-  it('registers component types for AuthCard and azureResourcePicker', () => {
+  it('registers component types for the Azure auth and resource flow', () => {
     expect(azureKit.components).toBeDefined();
     const types = azureKit.components!.map((c) => c.type);
     expect(types).toContain('AuthCard');
-    expect(types).toContain('azureResourcePicker');
+    expect(types).toContain('AzureResourcePicker');
+    expect(types).toContain('AzureAction');
   });
 
   it('declares azure-msal auth requirement', () => {

--- a/packages/core/src/__tests__/machine.test.ts
+++ b/packages/core/src/__tests__/machine.test.ts
@@ -44,6 +44,8 @@ describe("transition", () => {
       Phase.Design,
       Phase.Generate,
       Phase.Review,
+      Phase.Handoff,
+      Phase.Deploy,
     ];
 
     for (const expectedPhase of expectedOrder) {
@@ -53,19 +55,19 @@ describe("transition", () => {
     }
   });
 
-  it("ADVANCE from Review marks isComplete = true", () => {
+  it("ADVANCE from Deploy marks isComplete = true", () => {
     let state = createInitialState();
-    // Advance through active phases to Review
-    const phases = [Phase.Design, Phase.Generate, Phase.Review];
+    // Advance through active phases to Deploy
+    const phases = [Phase.Design, Phase.Generate, Phase.Review, Phase.Handoff, Phase.Deploy];
     for (const _ of phases) {
       state = transition(state, { type: "ADVANCE" });
     }
-    expect(state.currentPhase).toBe(Phase.Review);
+    expect(state.currentPhase).toBe(Phase.Deploy);
 
-    // Advance from Review
+    // Advance from Deploy
     state = transition(state, { type: "ADVANCE" });
     expect(state.isComplete).toBe(true);
-    expect(state.phaseStatus[Phase.Review]).toBe("complete");
+    expect(state.phaseStatus[Phase.Deploy]).toBe("complete");
   });
 
   it("SKIP marks current phase as skipped and advances to next", () => {
@@ -135,8 +137,8 @@ describe("canAdvance", () => {
 
   it("returns false when conversation is complete", () => {
     let state = createInitialState();
-    // Advance through active phases (Discover → Design → Generate → Review → complete)
-    for (let i = 0; i < 4; i++) {
+    // Advance through active phases (Discover → Design → Generate → Review → Handoff → Deploy → complete)
+    for (let i = 0; i < 6; i++) {
       state = transition(state, { type: "ADVANCE" });
     }
     expect(state.isComplete).toBe(true);
@@ -155,6 +157,8 @@ describe("full journey", () => {
       Phase.Design,
       Phase.Generate,
       Phase.Review,
+      Phase.Handoff,
+      Phase.Deploy,
     ];
 
     // Verify we start at Discover
@@ -192,7 +196,7 @@ describe("handleImplicitFlags", () => {
   it("does not advance when isComplete is true", () => {
     let state = createInitialState();
     // Advance through active phases so isComplete = true
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 6; i++) {
       state = transition(state, { type: "ADVANCE" });
     }
     expect(state.isComplete).toBe(true);
@@ -270,12 +274,18 @@ describe("handleImplicitFlags", () => {
 
     state = handleImplicitFlags(state, { phaseComplete: true });
     expect(state.currentPhase).toBe(Phase.Review);
+
+    state = handleImplicitFlags(state, { phaseComplete: true });
+    expect(state.currentPhase).toBe(Phase.Handoff);
+
+    state = handleImplicitFlags(state, { phaseComplete: true });
+    expect(state.currentPhase).toBe(Phase.Deploy);
   });
 
   it("stops advancing after reaching the final active phase", () => {
     let state = createInitialState();
     // Advance through active phases to completion
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 6; i++) {
       state = transition(state, { type: "ADVANCE" });
     }
     expect(state.isComplete).toBe(true);

--- a/packages/core/src/__tests__/phases.test.ts
+++ b/packages/core/src/__tests__/phases.test.ts
@@ -49,17 +49,18 @@ describe("getPhaseDefinition", () => {
 });
 
 describe("phase chain", () => {
-  it("each phase's nextPhase matches the next phase in order (up to Review)", () => {
-    const activeChain = [Phase.Discover, Phase.Design, Phase.Generate, Phase.Review];
+  it("each phase's nextPhase matches the next phase in order through Handoff", () => {
+    const activeChain = [
+      Phase.Discover,
+      Phase.Design,
+      Phase.Generate,
+      Phase.Review,
+      Phase.Handoff,
+    ];
     for (let i = 0; i < activeChain.length - 1; i++) {
       const def = getPhaseDefinition(activeChain[i]);
       expect(def.nextPhase).toBe(activeChain[i + 1]);
     }
-  });
-
-  it("Review (terminal active phase) has nextPhase = null", () => {
-    const def = getPhaseDefinition(Phase.Review);
-    expect(def.nextPhase).toBeNull();
   });
 
   it("Deploy (future phase) has nextPhase = null", () => {

--- a/packages/core/src/__tests__/system-prompt-pacing.test.ts
+++ b/packages/core/src/__tests__/system-prompt-pacing.test.ts
@@ -234,4 +234,40 @@ describe("System Prompt — Pacing Directives (Gate A1)", () => {
       ).toBe(true);
     });
   });
+
+  describe("Progressive flow regression guards", () => {
+    it("keeps architecture review separate from cost review", () => {
+      const prompt = buildSystemPrompt({
+        phase: Phase.Design,
+        appDefinition: { appName: "TestApp", description: "Test app" },
+      });
+
+      expect(prompt).toContain(
+        "Do NOT show cost estimates, best-practice summaries, or deployment/auth components in the same turn as the architecture diagram.",
+      );
+      expect(prompt).not.toContain("After gathering answers, present architecture using Tabs:");
+    });
+
+    it("does not end the guided flow at review", () => {
+      const prompt = buildSystemPrompt({
+        phase: Phase.Review,
+        appDefinition: { appName: "TestApp", description: "Test app" },
+      });
+
+      expect(prompt).toContain("### STEP 5 — HANDOFF");
+      expect(prompt).toContain("### STEP 6 — DEPLOY");
+      expect(prompt).not.toContain("This is the end of the guided flow — there is no further step after REVIEW.");
+      expect(prompt).not.toContain("Do not enter handoff or deploy phases — they are not yet implemented.");
+    });
+
+    it("treats review as a checkpoint before GitHub handoff", () => {
+      const prompt = buildSystemPrompt({
+        phase: Phase.Review,
+        appDefinition: { appName: "TestApp", description: "Test app" },
+      });
+
+      expect(prompt).toContain("REVIEW is a checkpoint, not the end of the flow.");
+      expect(prompt).toContain("One primary Button to continue to GitHub handoff and one secondary Button to revise the plan");
+    });
+  });
 });

--- a/packages/core/src/engine/phases.ts
+++ b/packages/core/src/engine/phases.ts
@@ -2,7 +2,7 @@
  * @module @kickstart/core/engine/phases
  *
  * Phase definitions for the Kickstart conversation flow.
- * Six phases: DISCOVER → DESIGN → GENERATE → REVIEW (→ HANDOFF → DEPLOY, not yet implemented)
+ * Six phases: DISCOVER → DESIGN → GENERATE → REVIEW → HANDOFF → DEPLOY
  *
  * Phase templates are minimal context injections — behavioral instructions
  * live in the unified narrative prompt (system-prompt.ts).
@@ -77,7 +77,7 @@ Services:
 
 Cost context:
 {{costContext}}`,
-    nextPhase: null,
+    nextPhase: Phase.Handoff,
   },
   {
     id: Phase.Handoff,

--- a/packages/core/src/engine/types.ts
+++ b/packages/core/src/engine/types.ts
@@ -14,9 +14,9 @@ export enum Phase {
   Generate = "generate",
   /** Validate manifests, show cost estimate */
   Review = "review",
-  /** @deprecated Not yet implemented — flow currently ends at Review. */
+  /** Get the generated project into GitHub. */
   Handoff = "handoff",
-  /** @deprecated Not yet implemented — flow currently ends at Review. */
+  /** Guide the Azure deployment flow to a real running app. */
   Deploy = "deploy",
 }
 

--- a/packages/core/src/kits/azure-kit.ts
+++ b/packages/core/src/kits/azure-kit.ts
@@ -14,10 +14,10 @@
  *   - PricingConnector     (Azure Retail Pricing API, no auth required)
  *
  * Component registrations (rendered by packages/web):
- *   - AuthCard             (MSAL sign-in card, provider: "azure")
- *   - azureResourcePicker  (cascading subscription → RG → resource selector)
- *   - azureResourceForm    (dynamic ARM-driven form for resource creation)
- *   - azureAction          (write-with-confirm pattern for ARM operations)
+ *   - AuthCard             (SWA-backed Azure sign-in card, provider: "azure")
+ *   - AzureResourcePicker  (cascading subscription → RG → resource selector)
+ *   - AzureResourceForm    (dynamic ARM-driven form for resource creation)
+ *   - AzureAction          (write-with-confirm pattern for ARM operations)
  */
 
 import type { IntegrationKit } from './types.js';
@@ -521,14 +521,14 @@ Use estimate_cost tool for live pricing when available; these reference prices a
     {
       type: 'AuthCard',
       description:
-        'Azure sign-in card (provider: "azure"). Uses MSAL with automatic subscription discovery.\n' +
+        'Azure sign-in card (provider: "azure"). Uses the existing Static Web Apps sign-in session; the browser never sends ARM bearer tokens directly.\n' +
         'Props:\n' +
         '  - provider (required string): Must be "azure".\n' +
         '  - title (optional string): Card heading. Defaults to "Azure".\n' +
         '  - description (optional string): Subheading text.',
     },
     {
-      type: 'azureResourcePicker',
+      type: 'AzureResourcePicker',
       description:
         'Cascading subscription → resource group → resource selector with search/filter.\n' +
         'Props:\n' +
@@ -539,7 +539,7 @@ Use estimate_cost tool for live pricing when available; these reference prices a
         '  - onSelect (optional action): Callback fired when the user selects a resource.',
     },
     {
-      type: 'azureResourceForm',
+      type: 'AzureResourceForm',
       description:
         'Dynamic form for creating Azure resources. Generates fields based on resource type.\n' +
         'Props:\n' +
@@ -550,7 +550,7 @@ Use estimate_cost tool for live pricing when available; these reference prices a
         '  - apiVersion (optional string): ARM API version for the resource type.',
     },
     {
-      type: 'azureAction',
+      type: 'AzureAction',
       description:
         'Write-with-confirm pattern for ARM operations. Shows action preview before execution.\n' +
         'Destructive operations (DELETE) require typing the resource name to confirm.\n' +

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -121,8 +121,8 @@ Ask ONE service question per turn (skip if already answered):
 3. Message queue? — ChoicePicker (Service Bus, None)
 4. AI/LLM features? — ChoicePicker (Azure OpenAI, Self-hosted models with Kubernetes AI Toolkit Operator (KAITO), None)
 5. Public URL? — Two Buttons in a Row (Yes / No)
-After gathering answers, present architecture using Tabs:
-- Tab 1 "Architecture": ArchitectureDiagram using the \`diagram\` prop (raw Mermaid string). Follow these rules exactly:
+After gathering answers, present ONE architecture review step:
+- Show ONE ArchitectureDiagram using the \`diagram\` prop (raw Mermaid string). Follow these rules exactly:
   - Always use \`graph TD\` layout.
   - Always wrap all compute workloads in \`subgraph AKS["AKS Automatic"]\`.
   - Always include \`ACR["Container Registry"] -.->|image pull| <AppNode>\`.
@@ -133,9 +133,9 @@ After gathering answers, present architecture using Tabs:
   - Managed Azure services (DB, cache, queue) go OUTSIDE the AKS subgraph.
   - If Kubernetes AI Toolkit Operator (KAITO) selected: place \`KAITO["KAITO Model Service<br/>(GPU-accelerated)"]\` INSIDE the AKS subgraph.
   - NEVER show: VNet, subnets, node pools, or K8s-internal objects (Services, Deployments, ConfigMaps, Secrets).
-- Tab 2 "Cost Estimate": CostEstimate with monthly breakdown
-- Tab 3 "What's Included": Markdown listing auto-scaling, health checks, CI/CD, security defaults
-Below Tabs: "Looks good" (primary Button) and "Change something" (secondary Button).
+- Explain WHY this architecture fits the app before showing the diagram.
+- Include one primary Button to approve the architecture and one secondary Button to revise it.
+- Do NOT show cost estimates, best-practice summaries, or deployment/auth components in the same turn as the architecture diagram. Cost review happens later in REVIEW.
 
 ### STEP 3 — GENERATE
 Produce all deployment artifacts AND application code (when starting fresh).
@@ -149,11 +149,28 @@ Each turn: DeploymentProgress at the top showing all steps with status, FileEdit
 Set "filesComplete": false while more files remain. Set to true on the last batch.
 The client auto-continues when filesComplete is false — do NOT include a Continue button during file generation.
 
-### STEP 4 — REVIEW  *(terminal step)*
-Walk the user through what was generated. Architecture recap, cost estimate, best practices.
-Present using Tabs: Architecture | Costs | Best Practices (Accordion) | Warnings (if any).
-Below Tabs: a "Session complete" summary Card with a "Download files" primary Button and a "Start a new project" secondary Button.
-This is the end of the guided flow — there is no further step after REVIEW.
+### STEP 4 — REVIEW
+Before handoff or deployment, review the monthly spend and the most important deployment safeguards.
+Present ONE review step:
+- CostEstimate with monthly breakdown
+- A short explanation of the biggest cost drivers and why the user should confirm them now
+- One primary Button to continue to GitHub handoff and one secondary Button to revise the plan
+Do NOT re-show the full architecture diagram, generated files, or a session-complete CTA in REVIEW. REVIEW is a checkpoint, not the end of the flow.
+
+### STEP 5 — HANDOFF
+Move the generated project into GitHub one step at a time.
+- If GitHub auth is missing: show only AuthCard with provider "github".
+- After GitHub auth: show only GitHubRepoPicker so the user can choose an owner, select an existing repo, or create a new one.
+- After the real GitHub flow confirms the repo/push step, explain what happens next and include a primary Button to continue to deployment if the user needs to confirm.
+Never claim repository creation, file push, or PR creation succeeded unless the real GitHub flow returned that result.
+
+### STEP 6 — DEPLOY
+Guide Azure deployment one step at a time.
+- If Azure auth is missing: show only AuthCard with provider "azure".
+- After Azure auth: show only AzureResourcePicker for target selection.
+- Once deployment starts: show only DeploymentProgress until Azure returns a real outcome.
+- When deployment succeeds: share the real application URL and brief next steps.
+Never show simulated Azure success, fake progress, or browser-owned bearer-token flows.
 
 PHASE TRANSITIONS — PRODUCE, DON'T NARRATE:
 NEVER respond with just an announcement like "Now let's move to the design phase." Every response MUST include actionable A2UI content — a question, a component, or a Button to advance. When a step is complete:
@@ -277,14 +294,62 @@ Study these examples carefully. Every response you give should match this level 
 ### Example 2: Discover step — asking runtime (after user described their app)
 {"message":"A Node.js REST API — nice. Let me confirm the runtime.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-2","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-2","components":[{"id":"root","component":"Column","children":["summary-card","runtime-card"],"gap":"16px"},{"id":"summary-card","component":"Card","children":["summary-col"]},{"id":"summary-col","component":"Column","children":["summary-text"]},{"id":"summary-text","component":"Markdown","content":"**Your app:** REST API for managing a product catalog with search and filtering."},{"id":"runtime-card","component":"Card","children":["runtime-col"]},{"id":"runtime-col","component":"Column","children":["runtime-label","runtime-picker"]},{"id":"runtime-label","component":"Text","text":"Which runtime does your app use?","variant":"body"},{"id":"runtime-picker","component":"ChoicePicker","label":"Runtime","options":[{"label":"Node.js / TypeScript","value":"node"},{"label":"Python","value":"python"},{"label":".NET / C#","value":"dotnet"},{"label":"Java / Spring","value":"java"},{"label":"Go","value":"go"}],"action":{"event":{"name":"pick-runtime","context":{"label":"Runtime"}}}}]}}],"actions":[],"phaseComplete":false,"filesComplete":null}
 
-### Example 3: Design step — presenting architecture with costs
-{"message":"Here's the architecture I'd recommend. I've included auto-scaling and health checks by default.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-5","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-5","components":[{"id":"root","component":"Column","children":["arch-tabs","actions-row"],"gap":"16px"},{"id":"arch-tabs","component":"Tabs","tabs":[{"label":"Architecture","children":["arch-card"]},{"label":"Cost Estimate","children":["cost-card"]},{"label":"What's Included","children":["features-card"]}]},{"id":"arch-card","component":"Card","children":["arch"]},{"id":"arch","component":"ArchitectureDiagram","diagram":"graph TD\\n  User((\\"User\\")) -->|HTTPS| GW{{\\"Gateway (Istio)\\"}}\\n\\n  subgraph AKS[\\"AKS Automatic\\"]\\n    GW --> API[\\"Node.js API<br/>&#40;2-10 replicas&#41;\\"]\\n  end\\n\\n  ACR[\\"Container Registry\\"] -.->|image pull| API\\n  API --> DB[(\\"Azure Database for PostgreSQL\\")]\\n  API --> Cache[(\\"Azure Cache for Redis\\")]\\n  API -->|Workload Identity| KV[\\"Key Vault\\"]\\n\\n  GHA[\\"GitHub Actions\\"] -.->|build and push| ACR"},{"id":"cost-card","component":"Card","children":["cost"]},{"id":"cost","component":"CostEstimate","items":[{"name":"App Platform (Standard)","sku":"AKS Automatic","monthlyCost":116.80},{"name":"PostgreSQL Flexible Server","sku":"B1ms","monthlyCost":12.40},{"name":"Redis Cache","sku":"Basic C0","monthlyCost":16.37}],"total":145.57,"currency":"USD"},{"id":"features-card","component":"Card","children":["features-md"]},{"id":"features-md","component":"Markdown","content":"### Included by default\\n\\n- **Auto-scaling** — handles traffic spikes automatically (2-10 instances)\\n- **Health checks** — platform restarts your app if it crashes\\n- **Zero-downtime deploys** — rolling updates with no interruption\\n- **Resource limits** — prevents one service from starving others\\n- **CI/CD pipeline** — deploy automatically when you push to main"},{"id":"actions-row","component":"Row","children":["approve-btn","change-btn"],"gap":"8px"},{"id":"approve-btn","component":"Button","label":"Looks good, let's build it","variant":"primary","action":{"event":{"name":"approve-architecture","context":{"label":"Approve architecture"}}}},{"id":"change-btn","component":"Button","label":"I'd like to change something","variant":"secondary","action":{"event":{"name":"modify-architecture","context":{"label":"Change architecture"}}}}]}}],"actions":[],"phaseComplete":false,"filesComplete":null}
+### Example 3: Design step — architecture review only
+{
+  "message": "Here's the architecture I'd recommend. This keeps the app scalable without forcing you to review cost and deployment details in the same step.",
+  "a2ui": [
+    { "version": "v0.9", "createSurface": { "surfaceId": "msg-5", "catalogId": "kickstart" } },
+    {
+      "version": "v0.9",
+      "updateComponents": {
+        "surfaceId": "msg-5",
+        "components": [
+          { "id": "root", "component": "Column", "children": ["arch-card", "actions-row"], "gap": "16px" },
+          { "id": "arch-card", "component": "Card", "children": ["arch-col"] },
+          { "id": "arch-col", "component": "Column", "children": ["arch-why", "arch"], "gap": "12px" },
+          { "id": "arch-why", "component": "Markdown", "content": "**Why this shape works:** it keeps the API, data, and ingress concerns separate so the app can scale cleanly as traffic grows." },
+          { "id": "arch", "component": "ArchitectureDiagram", "diagram": "graph TD\\n  User((\\"User\\")) -->|HTTPS| GW{{\\"Gateway (Istio)\\"}}\\n\\n  subgraph AKS[\\"AKS Automatic\\"]\\n    GW --> API[\\"Node.js API<br/>&#40;2-10 replicas&#41;\\"]\\n  end\\n\\n  ACR[\\"Container Registry\\"] -.->|image pull| API\\n  API --> DB[(\\"Azure Database for PostgreSQL\\")]\\n  API --> Cache[(\\"Azure Cache for Redis\\")]\\n  API -->|Workload Identity| KV[\\"Key Vault\\"]\\n\\n  GHA[\\"GitHub Actions\\"] -.->|build and push| ACR" },
+          { "id": "actions-row", "component": "Row", "children": ["approve-btn", "change-btn"], "gap": "8px" },
+          { "id": "approve-btn", "component": "Button", "label": "Looks good, let's build it", "variant": "primary", "action": { "event": { "name": "approve-architecture", "context": { "label": "Approve architecture" } } } },
+          { "id": "change-btn", "component": "Button", "label": "I'd like to change something", "variant": "secondary", "action": { "event": { "name": "modify-architecture", "context": { "label": "Change architecture" } } } }
+        ]
+      }
+    }
+  ],
+  "actions": [],
+  "phaseComplete": false,
+  "filesComplete": null
+}
 
 ### Example 4: Generate step — showing a generated file with progress and auto-continue
 {"message":"Here's the Dockerfile. Multi-stage build keeps the image small — about 150MB.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-8","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-8","components":[{"id":"root","component":"Column","children":["progress","file-card"],"gap":"16px"},{"id":"progress","component":"DeploymentProgress","steps":[{"id":"s1","label":"Dockerfile","status":"complete"},{"id":"s2","label":"Deployment config","status":"pending"},{"id":"s3","label":"CI/CD pipeline","status":"pending"},{"id":"s4","label":"Service connections","status":"pending"}]},{"id":"file-card","component":"Card","children":["file"]},{"id":"file","component":"FileEditor","filename":"Dockerfile","language":"dockerfile","content":"FROM node:20-alpine AS build\\nWORKDIR /app\\nCOPY package*.json ./\\nRUN npm ci\\nCOPY . .\\nRUN npm run build\\n\\nFROM node:20-alpine\\nRUN addgroup -g 1001 appgroup && adduser -u 1001 -G appgroup -s /bin/sh -D appuser\\nWORKDIR /app\\nCOPY --from=build /app/dist ./dist\\nCOPY --from=build /app/node_modules ./node_modules\\nUSER appuser\\nEXPOSE 3000\\nCMD [\\"node\\",\\"dist/index.js\\"]"}]}}],"actions":[],"phaseComplete":false,"filesComplete":false}
 
-### Example 5: Review step — organized with tabs, accordion, and session-complete CTA
-{"message":"Everything looks good. Here's your complete deployment summary — you can download the generated files from here.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-12","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-12","components":[{"id":"root","component":"Column","children":["review-tabs","complete-card","action-row"],"gap":"16px"},{"id":"review-tabs","component":"Tabs","tabs":[{"label":"Architecture","children":["arch-recap"]},{"label":"Costs","children":["cost-recap"]},{"label":"Best Practices","children":["bp-card"]}]},{"id":"arch-recap","component":"ArchitectureDiagram","nodes":[{"id":"api","label":"Node.js API","type":"compute"},{"id":"db","label":"PostgreSQL","type":"database"},{"id":"gw","label":"Gateway","type":"network"}],"edges":[{"from":"gw","to":"api"},{"from":"api","to":"db"}]},{"id":"cost-recap","component":"CostEstimate","items":[{"name":"App Platform","sku":"Standard","monthlyCost":116.80},{"name":"PostgreSQL","sku":"B1ms","monthlyCost":12.40}],"total":129.20,"currency":"USD"},{"id":"bp-card","component":"Card","children":["bp-acc"]},{"id":"bp-acc","component":"Accordion","items":[{"title":"Health checks — platform knows your app is running","children":["bp1"]},{"title":"Auto-scaling — handles 2x to 10x traffic automatically","children":["bp2"]},{"title":"Resource limits — prevents runaway usage","children":["bp3"]},{"title":"Secure defaults — non-root container, no privilege escalation","children":["bp4"]}],"collapsible":true,"multiple":true},{"id":"bp1","component":"Text","text":"Liveness and readiness probes configured. The platform will restart your app if it becomes unresponsive and only route traffic when it's ready.","variant":"body"},{"id":"bp2","component":"Text","text":"Horizontal auto-scaler set to 2-10 replicas targeting 70% CPU utilization. Your app scales up during traffic spikes and back down when quiet.","variant":"body"},{"id":"bp3","component":"Text","text":"CPU and memory limits set on every container. Prevents one service from consuming all available resources.","variant":"body"},{"id":"bp4","component":"Text","text":"Container runs as non-root user with read-only filesystem where possible. No privilege escalation allowed.","variant":"body"},{"id":"complete-card","component":"Card","children":["complete-inner"]},{"id":"complete-inner","component":"Column","children":["complete-badge-row","complete-text"],"gap":"8px"},{"id":"complete-badge-row","component":"Row","children":["complete-badge","complete-title"],"gap":"8px"},{"id":"complete-badge","component":"Badge","text":"Complete","variant":"success"},{"id":"complete-title","component":"Text","text":"Your deployment package is ready","variant":"subtitle1"},{"id":"complete-text","component":"Text","text":"All files are generated and validated. Download the package and follow the included README to deploy to AKS Automatic.","variant":"body"},{"id":"action-row","component":"Row","children":["download-btn","new-project-btn"],"gap":"8px"},{"id":"download-btn","component":"Button","label":"Download files","variant":"primary","action":{"event":{"name":"client:download-project","context":{"label":"Download files"}}}},{"id":"new-project-btn","component":"Button","label":"Start a new project","variant":"secondary","action":{"event":{"name":"start-new-project","context":{"label":"Start a new project"}}}}]}}],"actions":[],"phaseComplete":true,"filesComplete":null}
+### Example 5: Review step — cost confirmation before GitHub handoff
+{
+  "message": "Before we move your project into GitHub, let's review the monthly spend so there are no surprises later.",
+  "a2ui": [
+    { "version": "v0.9", "createSurface": { "surfaceId": "msg-12", "catalogId": "kickstart" } },
+    {
+      "version": "v0.9",
+      "updateComponents": {
+        "surfaceId": "msg-12",
+        "components": [
+          { "id": "root", "component": "Column", "children": ["cost-card", "action-row"], "gap": "16px" },
+          { "id": "cost-card", "component": "Card", "children": ["cost-col"] },
+          { "id": "cost-col", "component": "Column", "children": ["cost-why", "cost-recap"], "gap": "12px" },
+          { "id": "cost-why", "component": "Markdown", "content": "**Why review cost now:** once we move into GitHub and Azure deployment, these choices become real spend, so this is the right checkpoint to confirm the plan." },
+          { "id": "cost-recap", "component": "CostEstimate", "items": [{ "name": "App Platform", "sku": "Standard", "monthlyCost": 116.80 }, { "name": "PostgreSQL", "sku": "B1ms", "monthlyCost": 12.40 }], "total": 129.20, "currency": "USD" },
+          { "id": "action-row", "component": "Row", "children": ["continue-btn", "change-btn"], "gap": "8px" },
+          { "id": "continue-btn", "component": "Button", "label": "Continue to GitHub", "variant": "primary", "action": { "event": { "name": "approve-cost", "context": { "label": "Continue to GitHub" } } } },
+          { "id": "change-btn", "component": "Button", "label": "Change the plan", "variant": "secondary", "action": { "event": { "name": "revise-plan", "context": { "label": "Change the plan" } } } }
+        ]
+      }
+    }
+  ],
+  "actions": [],
+  "phaseComplete": false,
+  "filesComplete": null
+}
 
 ### Example 6: Discover step — binary either/or question (existing code vs starting fresh)
 {"message":"Got it. One more thing before I design your architecture.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-3","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-3","components":[{"id":"root","component":"Column","children":["q-card"],"gap":"16px"},{"id":"q-card","component":"Card","children":["q-col"]},{"id":"q-col","component":"Column","children":["q-label","q-row"],"gap":"12px"},{"id":"q-label","component":"Text","text":"Do you already have code for this app, or are you starting fresh?","variant":"body"},{"id":"q-row","component":"Row","children":["btn-existing","btn-fresh"],"gap":"8px"},{"id":"btn-existing","component":"Button","label":"I have existing code","variant":"secondary","action":{"event":{"name":"code-source","context":{"label":"I have existing code","value":"existing"}}}},{"id":"btn-fresh","component":"Button","label":"Starting fresh","variant":"primary","action":{"event":{"name":"code-source","context":{"label":"Starting fresh","value":"fresh"}}}}]}}],"actions":[],"phaseComplete":false,"filesComplete":null}
@@ -355,8 +420,7 @@ You OWN: conversation flow, code generation, validation, architecture planning, 
 - Always Workload Identity, never connection strings with secrets.
 - Don't enumerate all capabilities in early turns. Discover first, propose later.
 - Stay on topic: deploying apps to a scalable platform. For unrelated requests, politely redirect.
-- Do not enter handoff or deploy phases — they are not yet implemented. The flow ends at REVIEW.
-- You cannot create GitHub repositories, push files, or perform any GitHub API operations. Never show "repository created", "files pushed", or similar success cards. If the user asks about GitHub, explain that project files can be downloaded and pushed to GitHub manually.
+- Use the real GitHub and Azure handoff/deploy flows when those phases are active. Never invent repository creation, file push, Azure auth, or deployment success.
 `;
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/services/a2ui-schema.ts
+++ b/packages/core/src/services/a2ui-schema.ts
@@ -124,14 +124,14 @@ const boundedStringNonEmpty = z.string().min(1).transform(truncateToLimit);
 const boundedStringPath = z.string().startsWith("/").transform(truncateToLimit);
 
 /** For dynamic props that can be string or object (DataBinding/FunctionCall). */
-const dynamicString = z.union([boundedString, z.record(z.unknown())]);
+const dynamicString = z.union([boundedString, z.record(z.string(), z.unknown())]);
 
 const actionSchema = z
   .object({
     event: z.object({
       name: z.string(),
-      data: z.record(z.unknown()).optional(),
-      context: z.record(z.unknown()).optional(),
+      data: z.record(z.string(), z.unknown()).optional(),
+      context: z.record(z.string(), z.unknown()).optional(),
     }),
   })
   .passthrough();
@@ -550,7 +550,7 @@ const GitHubActionPropsSchema = z
     method: z.enum(["POST", "PUT", "PATCH", "DELETE"]),
     path: dynamicString,
     operationType: dynamicString,
-    body: z.record(z.unknown()).optional(),
+    body: z.record(z.string(), z.unknown()).optional(),
     confirmLabel: dynamicString.optional(),
     onSuccess: actionSchema.optional(),
     onError: actionSchema.optional(),
@@ -614,7 +614,7 @@ const AzureActionPropsSchema = z
     description: dynamicString.optional(),
     method: z.enum(["PUT", "POST", "PATCH", "DELETE"]),
     path: dynamicString,
-    body: z.record(z.unknown()).optional(),
+    body: z.record(z.string(), z.unknown()).optional(),
     apiVersion: dynamicString.optional(),
     confirmLabel: dynamicString.optional(),
     onSuccess: actionSchema.optional(),
@@ -818,7 +818,7 @@ const CreateSurfaceMessageSchema = z
     createSurface: z.object({
       surfaceId: surfaceIdField,
       catalogId: boundedString.optional(),
-      theme: z.record(z.unknown()).optional(),
+      theme: z.record(z.string(), z.unknown()).optional(),
       sendDataModel: z.boolean().optional(),
     }),
   })

--- a/packages/web/api/src/functions/converse.test.ts
+++ b/packages/web/api/src/functions/converse.test.ts
@@ -1,0 +1,239 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Phase } from "@kickstart/core";
+import { createSession, getSession } from "../lib/session-store.js";
+
+const registeredHandlers = new Map<string, (request: unknown, context: unknown) => Promise<unknown>>();
+const registerHttpHandler = vi.fn((name: string, config: { handler: (request: unknown, context: unknown) => Promise<unknown> }) => {
+  registeredHandlers.set(name, config.handler);
+});
+
+const chatCompletionWithTools = vi.fn();
+const chatCompletion = vi.fn();
+
+vi.mock("@azure/functions", () => ({
+  app: {
+    http: registerHttpHandler,
+  },
+}));
+
+vi.mock("../lib/openai-client.js", () => ({
+  chatCompletion,
+  chatCompletionWithTools,
+  getChatDeploymentName: () => "test-chat-model",
+}));
+
+vi.mock("../lib/content-safety.js", () => ({
+  checkContentSafety: vi.fn(async () => ({ safe: true })),
+}));
+
+vi.mock("../lib/rate-limiter.js", () => ({
+  checkRateLimit: vi.fn(() => ({ allowed: true, remaining: 29 })),
+  rateLimitResponse: vi.fn((retryAfterMs: number) => ({
+    status: 429,
+    headers: {
+      "Retry-After": String(Math.ceil(retryAfterMs / 1000)),
+    },
+    jsonBody: { error: "Too many requests. Please try again later." },
+  })),
+}));
+
+vi.mock("../lib/auto-continue.js", () => ({
+  chatCompletionWithAutoContinue: vi.fn(async () => ({ content: "" })),
+  isTruncated: vi.fn(() => false),
+}));
+
+let converseHandler: (request: unknown, context: unknown) => Promise<unknown>;
+
+beforeAll(async () => {
+  await import("./converse.js");
+  const handler = registeredHandlers.get("converse");
+  if (!handler) {
+    throw new Error("converse handler was not registered");
+  }
+  converseHandler = handler;
+});
+
+beforeEach(() => {
+  chatCompletionWithTools.mockReset();
+  chatCompletion.mockReset();
+});
+
+function createRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): {
+  headers: { get(name: string): string | undefined };
+  json: () => Promise<unknown>;
+} {
+  const normalizedHeaders = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+
+  return {
+    headers: {
+      get(name: string) {
+        return normalizedHeaders.get(name.toLowerCase());
+      },
+    },
+    json: async () => body,
+  };
+}
+
+function createContext(): { log: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+async function readStream(body: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  output += decoder.decode();
+  return output;
+}
+
+function parseSseEvents(payload: string): Array<{ event: string; data: string }> {
+  return payload
+    .trim()
+    .split("\n\n")
+    .map((block) => {
+      const lines = block.split("\n");
+      const event = lines.find((line) => line.startsWith("event: "))?.slice(7) ?? "";
+      const data = lines.find((line) => line.startsWith("data: "))?.slice(6) ?? "";
+      return { event, data };
+    })
+    .filter((event) => event.event && event.data);
+}
+
+describe("converse phase progression", () => {
+  it("rebuilds the next-turn system prompt from the advanced phase after phaseComplete", async () => {
+    const session = createSession();
+
+    chatCompletionWithTools
+      .mockResolvedValueOnce({
+        content: JSON.stringify({
+          message: "Great — let's move into architecture.",
+          a2ui: [],
+          actions: [],
+          phaseComplete: true,
+          filesComplete: null,
+        }),
+        finishReason: "stop",
+      })
+      .mockResolvedValueOnce({
+        content: JSON.stringify({
+          message: "Here's the next design step.",
+          a2ui: [],
+          actions: [],
+          phaseComplete: false,
+          filesComplete: null,
+        }),
+        finishReason: "stop",
+      });
+
+    const firstResponse = await converseHandler(
+      createRequest({
+        sessionId: session.state.sessionId,
+        message: "Continue",
+      }),
+      createContext(),
+    ) as {
+      status: number;
+      jsonBody: { phase: string; a2ui: Array<{ currentPhase: string; phases: Array<{ id: string; status: string }> }> };
+    };
+
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.jsonBody.phase).toBe(Phase.Design);
+    expect(firstResponse.jsonBody.a2ui[0]).toMatchObject({
+      currentPhase: Phase.Design,
+      phases: expect.arrayContaining([
+        expect.objectContaining({ id: Phase.Discover, status: "complete" }),
+        expect.objectContaining({ id: Phase.Design, status: "active" }),
+      ]),
+    });
+    expect(getSession(session.state.sessionId)?.engineState.currentPhase).toBe(
+      Phase.Design,
+    );
+
+    const secondResponse = await converseHandler(
+      createRequest({
+        sessionId: session.state.sessionId,
+        message: "What's next?",
+      }),
+      createContext(),
+    ) as { status: number; jsonBody: { phase: string } };
+
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.jsonBody.phase).toBe(Phase.Design);
+
+    const secondCallMessages = chatCompletionWithTools.mock.calls[1]?.[0] as Array<{
+      role: string;
+      content: string | null;
+    }>;
+
+    expect(secondCallMessages[0]).toMatchObject({ role: "system" });
+    expect(secondCallMessages[0]?.content).toContain("## Current Phase: Design");
+  });
+
+  it("streams the advanced phase in both the done payload and ConversationPhase event", async () => {
+    const session = createSession();
+
+    chatCompletion.mockResolvedValueOnce({
+      content: JSON.stringify({
+        message: "Perfect — now let's talk through the architecture.",
+        a2ui: [],
+        actions: [],
+        phaseComplete: true,
+        filesComplete: null,
+      }),
+      finishReason: "stop",
+    });
+
+    const response = await converseHandler(
+      createRequest(
+        {
+          sessionId: session.state.sessionId,
+          message: "Continue",
+        },
+        { accept: "text/event-stream" },
+      ),
+      createContext(),
+    ) as { status: number; body: ReadableStream<Uint8Array> };
+
+    expect(response.status).toBe(200);
+
+    const events = parseSseEvents(await readStream(response.body));
+    const donePayload = JSON.parse(
+      events.find((event) => event.event === "done")?.data ?? "{}",
+    ) as { phase?: string; phaseLabel?: string; sessionId?: string };
+    const phaseIndicator = events
+      .filter((event) => event.event === "a2ui")
+      .map((event) => JSON.parse(event.data) as { type?: string; currentPhase?: string; phases?: Array<{ id: string; status: string }> })
+      .find((payload) => payload.type === "ConversationPhase");
+
+    expect(donePayload).toMatchObject({
+      sessionId: session.state.sessionId,
+      phase: Phase.Design,
+      phaseLabel: "Design",
+    });
+    expect(phaseIndicator).toMatchObject({
+      currentPhase: Phase.Design,
+      phases: expect.arrayContaining([
+        expect.objectContaining({ id: Phase.Discover, status: "complete" }),
+        expect.objectContaining({ id: Phase.Design, status: "active" }),
+      ]),
+    });
+    expect(getSession(session.state.sessionId)?.engineState.currentPhase).toBe(
+      Phase.Design,
+    );
+  });
+});

--- a/packages/web/api/src/lib/session-store.test.ts
+++ b/packages/web/api/src/lib/session-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { Phase } from "@kickstart/core";
+import { createSession, hydrateSession } from "./session-store.js";
+
+describe("session-store phase hydration", () => {
+  it("starts new sessions in discover", () => {
+    const session = createSession("principal-123");
+    expect(session.engineState.currentPhase).toBe(Phase.Discover);
+    expect(session.state.currentPhase).toBe(Phase.Discover);
+  });
+
+  it("rehydrates the current phase from client history", () => {
+    const session = hydrateSession([
+      { role: "assistant", content: "Architecture approved", phase: Phase.Design },
+      { role: "assistant", content: "Files generated", phase: Phase.Generate },
+      { role: "assistant", content: "Cost reviewed", phase: Phase.Review },
+      { role: "assistant", content: "Repo selected", phase: Phase.Handoff },
+      { role: "assistant", content: "Ready to deploy", phase: Phase.Deploy },
+    ], "principal-123");
+
+    expect(session.engineState.currentPhase).toBe(Phase.Deploy);
+    expect(session.state.currentPhase).toBe(Phase.Deploy);
+    expect(session.engineState.phaseStatus[Phase.Discover]).toBe("complete");
+    expect(session.engineState.phaseStatus[Phase.Design]).toBe("complete");
+    expect(session.engineState.phaseStatus[Phase.Generate]).toBe("complete");
+    expect(session.engineState.phaseStatus[Phase.Review]).toBe("complete");
+    expect(session.engineState.phaseStatus[Phase.Handoff]).toBe("complete");
+    expect(session.engineState.phaseStatus[Phase.Deploy]).toBe("active");
+  });
+
+  it("falls back to discover when the client history has no usable phase", () => {
+    const session = hydrateSession([
+      { role: "assistant", content: "Hello there", phase: "unknown-phase" },
+      { role: "user", content: "continue" },
+    ], "principal-123");
+
+    expect(session.engineState.currentPhase).toBe(Phase.Discover);
+    expect(session.state.currentPhase).toBe(Phase.Discover);
+  });
+});

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -10,6 +10,7 @@ import {
   Phase,
   createInitialState,
   buildSystemPrompt,
+  transition,
 } from "@kickstart/core";
 import type {
   SessionState,
@@ -151,6 +152,26 @@ export function createSession(principalId?: string): ApiSession {
 export interface ClientMessage {
   role: "user" | "assistant";
   content: string;
+  phase?: string;
+}
+
+function restoreEngineStateFromHistory(clientMessages: ClientMessage[]): ConversationState {
+  const phases = new Set(Object.values(Phase));
+  const lastPhase = [...clientMessages]
+    .reverse()
+    .find((msg) => typeof msg.phase === "string" && phases.has(msg.phase as Phase))
+    ?.phase as Phase | undefined;
+
+  if (!lastPhase) {
+    return createInitialState();
+  }
+
+  let state = createInitialState();
+  while (state.currentPhase !== lastPhase && !state.isComplete) {
+    state = transition(state, { type: "ADVANCE" });
+  }
+
+  return state.currentPhase === lastPhase ? state : createInitialState();
 }
 
 /**
@@ -182,6 +203,8 @@ export function hydrateSession(clientMessages: ClientMessage[], principalId?: st
     }
   }
 
+  session.engineState = restoreEngineStateFromHistory(clientMessages);
+  session.state.currentPhase = session.engineState.currentPhase;
   session.state.updatedAt = now;
   return session;
 }

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -103,6 +103,7 @@ export function useStreaming() {
         .map((m) => ({
           role: m.role === 'user' ? 'user' as const : 'assistant' as const,
           content: m.text.trim(),
+          ...(m.phase ? { phase: m.phase } : {}),
         }));
 
       const res = await apiFetch('/api/converse', {


### PR DESCRIPTION
Closes #275

Working as Leela (Lead), Fry (Frontend Dev), and Bender (Backend Dev).

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Summary
- restore the guided six-phase flow so REVIEW advances to HANDOFF and DEPLOY
- preserve phase across client rehydration and add `/api/converse` + session hydration regressions
- strengthen prompt, machine, and integration-kit tests to catch the old dumped-flow contract

## Validation
- `npm run lint`
- `npm run build -w @kickstart/core`
- `cd packages/web && npx tsc --noEmit`
- `cd packages/web/api && npm run build`
- `npx vitest run`

## Notes
- Local Playwright is blocked in this environment because Chromium is missing `libnspr4.so`; CI installs Playwright deps with `npx playwright install --with-deps`.