### PR TITLE
fix: ship real GitHub commit PR flow

### DIFF
--- a/packages/core/src/__tests__/github-connector.test.ts
+++ b/packages/core/src/__tests__/github-connector.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitHubConnector } from '../connectors/GitHubConnector.js';
+
+describe('GitHubConnector secure ship path', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('posts commit and PR writes to the server-owned GitHub endpoint', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      pullRequest: {
+        number: 42,
+        html_url: 'https://github.com/sabbour/demo-app/pull/42',
+        title: 'feat: add artifacts',
+        state: 'open',
+        head: { ref: 'feature/kickstart', sha: 'commit-new' },
+        base: { ref: 'main' },
+      },
+      commitSha: 'commit-new',
+      committedFilesCount: 1,
+      headBranch: 'feature/kickstart',
+      baseBranch: 'main',
+    }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const connector = new GitHubConnector({
+      auth: { kind: 'oauth2', scopes: ['read:user'] },
+      serverBaseUrl: '/api/github',
+    });
+
+    const result = await connector.commitFilesAndCreatePullRequest({
+      owner: 'sabbour',
+      repo: 'demo-app',
+      title: 'feat: add artifacts',
+      head: 'feature/kickstart',
+      base: 'main',
+      body: 'Please review.',
+      commitMessage: 'feat: add artifacts',
+      files: [{ path: 'Dockerfile', content: 'FROM node:20' }],
+    });
+
+    expect(result).toMatchObject({
+      commitSha: 'commit-new',
+      committedFilesCount: 1,
+      headBranch: 'feature/kickstart',
+      baseBranch: 'main',
+      pullRequest: {
+        number: 42,
+        html_url: 'https://github.com/sabbour/demo-app/pull/42',
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/api/github/pulls', expect.objectContaining({
+      method: 'POST',
+      redirect: 'manual',
+    }));
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('authorization')).toBeNull();
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      owner: 'sabbour',
+      repo: 'demo-app',
+      head: 'feature/kickstart',
+      base: 'main',
+      files: [{ path: 'Dockerfile', content: 'FROM node:20' }],
+    });
+  });
+
+  it('fails closed instead of simulating pull request creation in stub mode', async () => {
+    const connector = new GitHubConnector({
+      auth: { kind: 'oauth2', scopes: ['read:user'] },
+      allowStubMode: true,
+    });
+
+    await expect(
+      connector.createPullRequest(
+        'sabbour',
+        'demo-app',
+        'feat: add artifacts',
+        'feature/kickstart',
+        'main',
+      ),
+    ).rejects.toMatchObject({
+      name: 'ConnectorError',
+      code: 'STUB_MODE_DISABLED',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/__tests__/integration-kit.test.ts
+++ b/packages/core/src/__tests__/integration-kit.test.ts
@@ -432,11 +432,12 @@ describe('githubKit', () => {
     }
   });
 
-  it('registers component types for AuthCard and GitHubRepoPicker', () => {
+  it('registers component types for the GitHub handoff flow', () => {
     expect(githubKit.components).toBeDefined();
     const types = githubKit.components!.map((c) => c.type);
     expect(types).toContain('AuthCard');
     expect(types).toContain('GitHubRepoPicker');
+    expect(types).toContain('GitHubCommit');
   });
 
   it('declares github-oauth auth requirement', () => {

--- a/packages/core/src/__tests__/skill-resolver.test.ts
+++ b/packages/core/src/__tests__/skill-resolver.test.ts
@@ -336,6 +336,13 @@ describe("githubKit phasePrompts", () => {
     expect(hasGitHub).toBe(true);
   });
 
+  it("has Handoff phase prompts mentioning GitHubCommit", async () => {
+    const { githubKit } = await import("../kits/github-kit.js");
+    const handoffPrompts = githubKit.phasePrompts?.[Phase.Handoff] ?? [];
+    const hasCommitFlow = handoffPrompts.some((p) => p.includes("GitHubCommit"));
+    expect(hasCommitFlow).toBe(true);
+  });
+
   it("has Generate phase prompts mentioning OIDC", async () => {
     const { githubKit } = await import("../kits/github-kit.js");
     const generatePrompts = githubKit.phasePrompts?.[Phase.Generate] ?? [];

--- a/packages/core/src/connectors/GitHubConnector.ts
+++ b/packages/core/src/connectors/GitHubConnector.ts
@@ -123,6 +123,14 @@ interface GitHubErrorResponse {
  */
 const DEFAULT_GITHUB_SCOPES = ['read:user'];
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end--;
+  }
+  return value.slice(0, end);
+}
+
 function connectorErrorCodeForStatus(status: number): ConnectorErrorCode {
   if (status === 400) return 'BAD_REQUEST';
   if (status === 403) return 'FORBIDDEN';
@@ -153,7 +161,7 @@ export class GitHubConnector extends BaseConnector {
       ...rest,
       auth: auth ?? { kind: 'oauth2', scopes: DEFAULT_GITHUB_SCOPES },
     } as ConnectorConfig);
-    this.serverBaseUrl = serverBaseUrl ? serverBaseUrl.replace(/\/+$/, '') : null;
+    this.serverBaseUrl = serverBaseUrl ? trimTrailingSlashes(serverBaseUrl) : null;
   }
 
   /** GitHub-specific headers (Accept, API version). */

--- a/packages/core/src/connectors/GitHubConnector.ts
+++ b/packages/core/src/connectors/GitHubConnector.ts
@@ -1,4 +1,9 @@
-import type { ConnectorConfig, HttpMethod, APIConnectorRequestOptions } from './types.js';
+import type {
+  APIConnectorRequestOptions,
+  ConnectorConfig,
+  ConnectorErrorCode,
+  HttpMethod,
+} from './types.js';
 import { BaseConnector } from './BaseConnector.js';
 import { gitHubRateLimiter } from './github-rate-limit.js';
 import { ConnectorError } from './types.js';
@@ -38,6 +43,30 @@ export interface GitHubPullRequest {
   state: string;
   head: { ref: string; sha: string };
   base: { ref: string };
+}
+
+export interface GitHubCommitFile {
+  path: string;
+  content: string;
+}
+
+export interface GitHubCommitPullRequestInput {
+  owner: string;
+  repo: string;
+  title: string;
+  head: string;
+  base: string;
+  body?: string;
+  commitMessage?: string;
+  files: GitHubCommitFile[];
+}
+
+export interface GitHubCommitPullRequestResult {
+  pullRequest: GitHubPullRequest;
+  commitSha: string;
+  committedFilesCount: number;
+  headBranch: string;
+  baseBranch: string;
 }
 
 export interface GitHubBranch {
@@ -80,10 +109,28 @@ export interface GitHubRepoOptions {
   gitignore_template?: string;
 }
 
+export interface GitHubConnectorConfig extends ConnectorConfig {
+  serverBaseUrl?: string;
+}
+
+interface GitHubErrorResponse {
+  error?: string;
+  message?: string;
+}
+
 /**
  * Default GitHub OAuth scopes — read-only access.
  */
 const DEFAULT_GITHUB_SCOPES = ['read:user'];
+
+function connectorErrorCodeForStatus(status: number): ConnectorErrorCode {
+  if (status === 400) return 'BAD_REQUEST';
+  if (status === 403) return 'FORBIDDEN';
+  if (status === 404) return 'NOT_FOUND';
+  if (status === 429) return 'RATE_LIMITED';
+  if (status >= 500) return 'SERVER_ERROR';
+  return 'UNKNOWN';
+}
 
 /**
  * Connector for the GitHub REST API.
@@ -94,13 +141,19 @@ const DEFAULT_GITHUB_SCOPES = ['read:user'];
  */
 export class GitHubConnector extends BaseConnector {
   readonly name = 'github';
+  private readonly serverBaseUrl: string | null;
 
   protected get defaultBaseUrl(): string {
     return 'https://api.github.com';
   }
 
-  constructor(config?: ConnectorConfig) {
-    super(config ?? { auth: { kind: 'oauth2', scopes: DEFAULT_GITHUB_SCOPES } });
+  constructor(config?: GitHubConnectorConfig) {
+    const { serverBaseUrl, auth, ...rest } = config ?? {};
+    super({
+      ...rest,
+      auth: auth ?? { kind: 'oauth2', scopes: DEFAULT_GITHUB_SCOPES },
+    } as ConnectorConfig);
+    this.serverBaseUrl = serverBaseUrl ? serverBaseUrl.replace(/\/+$/, '') : null;
   }
 
   /** GitHub-specific headers (Accept, API version). */
@@ -133,6 +186,73 @@ export class GitHubConnector extends BaseConnector {
     const response = await super.request(method, path, body, options);
     gitHubRateLimiter.update(response);
     return response;
+  }
+
+  private ensureAuthenticatedWritePath(): void {
+    try {
+      if (this.isStubMode()) {
+        throw new ConnectorError(
+          'GitHub write operations require authenticated GitHub access or the server-owned handoff endpoints.',
+          'STUB_MODE_DISABLED',
+          { retryable: false },
+        );
+      }
+    } catch (error) {
+      if (error instanceof ConnectorError && error.code === 'STUB_MODE_DISABLED') {
+        throw new ConnectorError(
+          'GitHub write operations require authenticated GitHub access or the server-owned handoff endpoints.',
+          'STUB_MODE_DISABLED',
+          { retryable: false },
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private requireServerBaseUrl(): string {
+    if (!this.serverBaseUrl) {
+      throw new ConnectorError(
+        'GitHub handoff writes are not configured. Set serverBaseUrl to the server-owned GitHub API.',
+        'BAD_REQUEST',
+        { retryable: false },
+      );
+    }
+
+    return this.serverBaseUrl;
+  }
+
+  private async requestServerJson<T>(path: string, body: unknown): Promise<T> {
+    const response = await fetch(`${this.requireServerBaseUrl()}${path}`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      redirect: 'manual',
+    });
+
+    if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+      throw new ConnectorError(
+        'GitHub session expired. Please sign in again.',
+        'AUTH_FAILED',
+        { retryable: false, status: response.status },
+      );
+    }
+
+    const responseBody = await response.json().catch(() => undefined) as GitHubErrorResponse | undefined;
+    if (!response.ok) {
+      throw new ConnectorError(
+        responseBody?.error
+          ?? responseBody?.message
+          ?? `GitHub request failed (${response.status})`,
+        connectorErrorCodeForStatus(response.status),
+        { retryable: response.status >= 500, status: response.status },
+      );
+    }
+
+    return responseBody as T;
   }
 
   // ── Domain methods ─────────────────────────────────────────────────────────
@@ -245,7 +365,7 @@ export class GitHubConnector extends BaseConnector {
 
   /**
    * Create a pull request on a repository.
-   * Returns stub data when not authenticated.
+   * Fails closed when the connector is not authenticated.
    */
   async createPullRequest(
     owner: string,
@@ -255,16 +375,7 @@ export class GitHubConnector extends BaseConnector {
     base: string,
     body?: string,
   ): Promise<GitHubPullRequest> {
-    if (this.isStubMode()) {
-      return {
-        number: 1,
-        html_url: `https://github.com/${owner}/${repo}/pull/1`,
-        title,
-        state: 'open',
-        head: { ref: head, sha: 'abc1234' },
-        base: { ref: base },
-      };
-    }
+    this.ensureAuthenticatedWritePath();
 
     const res = await this.request('POST', `/repos/${owner}/${repo}/pulls`, {
       title,
@@ -273,6 +384,24 @@ export class GitHubConnector extends BaseConnector {
       body,
     });
     return (await res.json()) as GitHubPullRequest;
+  }
+
+  /**
+   * Commit selected files on a feature branch, then open a pull request via the
+   * server-owned GitHub handoff endpoint.
+   */
+  async commitFilesAndCreatePullRequest(
+    input: GitHubCommitPullRequestInput,
+  ): Promise<GitHubCommitPullRequestResult> {
+    if (!input.files.length) {
+      throw new ConnectorError(
+        'Select at least one file to commit.',
+        'BAD_REQUEST',
+        { retryable: false },
+      );
+    }
+
+    return this.requestServerJson<GitHubCommitPullRequestResult>('/pulls', input);
   }
 }
 

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -35,7 +35,21 @@ export { APIConnectorRegistry, defaultConnectorRegistry } from './registry.js';
 export { AzureARMConnector } from './AzureARMConnector.js';
 export type { AzureResource, AzureResourceGroup, AzureSubscription, AzureLocation } from './AzureARMConnector.js';
 export { GitHubConnector } from './GitHubConnector.js';
-export type { GitHubRepo, GitHubBranch, GitHubRepoOptions, GitHubUser, GitHubDeviceCodeResponse, GitHubPullRequest, GitHubTree, GitHubTreeEntry, GitHubFileContent } from './GitHubConnector.js';
+export type {
+  GitHubRepo,
+  GitHubBranch,
+  GitHubRepoOptions,
+  GitHubUser,
+  GitHubDeviceCodeResponse,
+  GitHubPullRequest,
+  GitHubCommitFile,
+  GitHubCommitPullRequestInput,
+  GitHubCommitPullRequestResult,
+  GitHubConnectorConfig,
+  GitHubTree,
+  GitHubTreeEntry,
+  GitHubFileContent,
+} from './GitHubConnector.js';
 export { PricingConnector } from './PricingConnector.js';
 export type {
   ResourceCostInput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,7 +170,18 @@ export { APIConnectorRegistry, defaultConnectorRegistry } from "./connectors/ind
 export { AzureARMConnector } from "./connectors/index.js";
 export type { AzureResource, AzureResourceGroup, AzureSubscription, AzureLocation } from "./connectors/index.js";
 export { GitHubConnector } from "./connectors/index.js";
-export type { GitHubRepo, GitHubBranch, GitHubRepoOptions, GitHubUser, GitHubDeviceCodeResponse, GitHubPullRequest } from "./connectors/index.js";
+export type {
+  GitHubRepo,
+  GitHubBranch,
+  GitHubRepoOptions,
+  GitHubUser,
+  GitHubDeviceCodeResponse,
+  GitHubPullRequest,
+  GitHubCommitFile,
+  GitHubCommitPullRequestInput,
+  GitHubCommitPullRequestResult,
+  GitHubConnectorConfig,
+} from "./connectors/index.js";
 export { PricingConnector } from "./connectors/index.js";
 export type {
   ResourceCostInput,
@@ -265,5 +276,4 @@ export type {
   SessionState,
   ConversationMessage,
 } from "./types.js";
-
 

--- a/packages/core/src/kits/github-kit.ts
+++ b/packages/core/src/kits/github-kit.ts
@@ -15,6 +15,7 @@
  * Component registrations (rendered by packages/web):
  *   - AuthCard           (server-owned GitHub OAuth sign-in card, provider: "github")
  *   - GitHubRepoPicker   (owner-aware repository picker with real create/list flows)
+ *   - GitHubCommit       (real commit + pull-request flow for generated artifacts)
  */
 
 import type { IntegrationKit } from './types.js';
@@ -132,10 +133,11 @@ export const githubKit: IntegrationKit = {
       '  1. Ask: new repo or push to existing? Use ChoicePicker.\n' +
       '  2. Show AuthCard for GitHub sign-in if needed.\n' +
       '  3. After GitHub sign-in, use GitHubRepoPicker so the user can pick a personal/org owner, choose an existing repo, or create a new repo.\n' +
-      '  4. Verify OIDC federation is set up — ask the user to confirm that AZURE_CLIENT_ID, AZURE_TENANT_ID, and ' +
+      '  4. Once the repository is selected, use GitHubCommit so the user can choose generated artifacts, create a feature branch, and open a pull request with the real files.\n' +
+      '  5. Verify OIDC federation is set up — ask the user to confirm that AZURE_CLIENT_ID, AZURE_TENANT_ID, and ' +
       'AZURE_SUBSCRIPTION_ID are configured as repository secrets. If not, walk the user through the setup.\n' +
-      '  5. After push: "Your workflow will deploy automatically on every push to {branch}."\n' +
-      '  6. Offer a Codespaces link so they can edit and iterate in the browser.',
+      '  6. After the pull request is merged or the user pushes to the default branch: "Your workflow will deploy automatically on every push to {branch}."\n' +
+      '  7. Offer a Codespaces link so they can edit and iterate in the browser.',
     ],
 
     [Phase.Deploy]: [
@@ -175,6 +177,24 @@ export const githubKit: IntegrationKit = {
         category: 'domain',
         example: '{"id":"ghp1","component":"GitHubRepoPicker","owner":"sabbour","allowCreate":true,"suggestedName":"my-kickstart-app"}',
         notes: 'This component can handle both existing-repository selection and new-repository creation after GitHub auth succeeds.',
+      },
+    },
+    {
+      type: 'GitHubCommit',
+      description:
+        'Commit-and-pull-request flow for generated artifacts using the authenticated GitHub ship path.\n' +
+        'Props:\n' +
+        '  - repoFullName (optional string): Target repository in owner/repo form.\n' +
+        '  - defaultBranch (optional string): Base branch for the pull request. Defaults to the repo default branch.\n' +
+        '  - suggestedBranchName (optional string): Suggested feature branch name.\n' +
+        '  - suggestedTitle (optional string): Suggested pull request title.\n' +
+        '  - suggestedBody (optional string): Suggested pull request body.\n' +
+        '  - onSuccess (optional action): Callback fired after the pull request is created.\n' +
+        '  - onError (optional action): Callback fired if the commit or pull request flow fails.',
+      promptMeta: {
+        category: 'domain',
+        example: '{"id":"ghc1","component":"GitHubCommit","repoFullName":"sabbour/my-kickstart-app","defaultBranch":"main","suggestedBranchName":"kickstart/generated-artifacts","suggestedTitle":"feat: add Kickstart-generated artifacts","suggestedBody":"Adds the files generated during the guided flow."}',
+        notes: 'Use this after GitHubRepoPicker once the user is ready to send generated files to GitHub.',
       },
     },
   ],

--- a/packages/web/api/src/functions/github-pulls.ts
+++ b/packages/web/api/src/functions/github-pulls.ts
@@ -1,0 +1,70 @@
+import { app } from "@azure/functions";
+import type { HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import {
+  GitHubAuthError,
+  commitGitHubFilesAndCreatePullRequestForRequest,
+} from "../lib/github-auth.js";
+
+function jsonResponse(
+  status: number,
+  jsonBody: unknown,
+  cookies = [] as HttpResponseInit["cookies"],
+): HttpResponseInit {
+  return {
+    status,
+    jsonBody,
+    cookies,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  };
+}
+
+app.http("github-pulls", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  route: "github/pulls",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext,
+  ): Promise<HttpResponseInit> => {
+    try {
+      const body = await request.json() as {
+        owner?: unknown;
+        repo?: unknown;
+        head?: unknown;
+        base?: unknown;
+        title?: unknown;
+        body?: unknown;
+        commitMessage?: unknown;
+        files?: unknown;
+      };
+
+      const result = await commitGitHubFilesAndCreatePullRequestForRequest(request, {
+        owner: typeof body.owner === "string" ? body.owner : "",
+        repo: typeof body.repo === "string" ? body.repo : "",
+        head: typeof body.head === "string" ? body.head : "",
+        base: typeof body.base === "string" ? body.base : undefined,
+        title: typeof body.title === "string" ? body.title : "",
+        body: typeof body.body === "string" ? body.body : undefined,
+        commitMessage: typeof body.commitMessage === "string" ? body.commitMessage : undefined,
+        files: Array.isArray(body.files)
+          ? body.files as { path: string; content: string }[]
+          : [],
+      });
+
+      return jsonResponse(201, result);
+    } catch (error) {
+      if (error instanceof GitHubAuthError) {
+        return jsonResponse(error.status, { error: error.message }, error.cookies);
+      }
+
+      context.error("[github-pulls] request failed");
+      if (error instanceof Error && error.stack) {
+        context.error(error.stack);
+      }
+
+      return jsonResponse(500, { error: "GitHub request failed." });
+    }
+  },
+});

--- a/packages/web/api/src/lib/github-auth.test.ts
+++ b/packages/web/api/src/lib/github-auth.test.ts
@@ -193,7 +193,10 @@ describe("commitGitHubFilesAndCreatePullRequestForRequest", () => {
     });
 
     const githubAuthHeaders = fetchMock.mock.calls
-      .filter(([url]) => String(url).startsWith("https://api.github.com"))
+      .filter(([url]) => {
+        const parsed = new URL(String(url));
+        return parsed.origin === "https://api.github.com";
+      })
       .map(([, init]) => new Headers(init?.headers).get("authorization"));
     expect(githubAuthHeaders.length).toBeGreaterThan(0);
     expect(githubAuthHeaders.every((value) => value === "Bearer ghs_test_token")).toBe(true);

--- a/packages/web/api/src/lib/github-auth.test.ts
+++ b/packages/web/api/src/lib/github-auth.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Cookie, HttpRequest } from "@azure/functions";
+import {
+  commitGitHubFilesAndCreatePullRequestForRequest,
+  completeGitHubAuth,
+  getGitHubAuthLogin,
+} from "./github-auth.js";
+
+const fetchMock = vi.fn<typeof fetch>();
+const ORIGINAL_ENV = {
+  clientId: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  sessionSecret: process.env.GITHUB_SESSION_SECRET,
+};
+const VIEWER = {
+  login: "sabbour",
+  avatar_url: "https://avatars.githubusercontent.com/u/103856?v=4",
+  html_url: "https://github.com/sabbour",
+  name: "Ahmed Sabbour",
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeRequest(
+  headers: Record<string, string> = {},
+  url = "https://kickstart.test/api/github/pulls",
+): HttpRequest {
+  return {
+    headers: new Headers(headers),
+    url,
+  } as unknown as HttpRequest;
+}
+
+function cookieHeader(cookies: Cookie[]): string {
+  return cookies
+    .filter((cookie) => cookie.maxAge !== 0 && cookie.value)
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join("; ");
+}
+
+async function createSessionCookie(): Promise<string> {
+  const loginRequest = makeRequest({
+    "x-ms-client-principal-id": "principal-123",
+    host: "kickstart.test",
+    "x-forwarded-proto": "https",
+  }, "https://kickstart.test/api/github-auth/login");
+  const { location, cookies } = getGitHubAuthLogin(loginRequest, "principal-123", "/handoff");
+  const state = new URL(location).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected GitHub OAuth state.");
+  }
+
+  fetchMock.mockResolvedValueOnce(jsonResponse({ access_token: "ghs_test_token" }));
+  fetchMock.mockResolvedValueOnce(jsonResponse(VIEWER));
+  fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+  const callbackRequest = makeRequest({
+    cookie: cookieHeader(cookies),
+    host: "kickstart.test",
+    "x-forwarded-proto": "https",
+  }, "https://kickstart.test/api/github-auth/callback");
+  const { cookies: sessionCookies } = await completeGitHubAuth(callbackRequest, "code-123", state);
+  return cookieHeader(sessionCookies);
+}
+
+describe("commitGitHubFilesAndCreatePullRequestForRequest", () => {
+  beforeEach(() => {
+    process.env.GITHUB_CLIENT_ID = "client-id";
+    process.env.GITHUB_CLIENT_SECRET = "client-secret";
+    process.env.GITHUB_SESSION_SECRET = "session-secret";
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+    process.env.GITHUB_CLIENT_ID = ORIGINAL_ENV.clientId;
+    process.env.GITHUB_CLIENT_SECRET = ORIGINAL_ENV.clientSecret;
+    process.env.GITHUB_SESSION_SECRET = ORIGINAL_ENV.sessionSecret;
+  });
+
+  it("commits files and opens a pull request with the server-owned GitHub session", async () => {
+    const cookie = await createSessionCookie();
+    fetchMock.mockReset();
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(VIEWER));
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      id: 1,
+      name: "demo-app",
+      full_name: "sabbour/demo-app",
+      private: true,
+      html_url: "https://github.com/sabbour/demo-app",
+      description: "Kickstart demo",
+      default_branch: "main",
+      language: "TypeScript",
+    }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ref: "refs/heads/main",
+      object: { sha: "base-sha" },
+    }));
+    fetchMock.mockResolvedValueOnce(jsonResponse(
+      { message: "Not Found" },
+      { status: 404 },
+    ));
+    fetchMock.mockResolvedValueOnce(jsonResponse(
+      {
+        ref: "refs/heads/feature/kickstart",
+        object: { sha: "base-sha" },
+      },
+      { status: 201 },
+    ));
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      sha: "base-sha",
+      tree: { sha: "tree-base" },
+    }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sha: "tree-new" }, { status: 201 }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      sha: "commit-new",
+      tree: { sha: "tree-new" },
+    }, { status: 201 }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ref: "refs/heads/feature/kickstart",
+      object: { sha: "commit-new" },
+    }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      number: 42,
+      html_url: "https://github.com/sabbour/demo-app/pull/42",
+      title: "feat: add artifacts",
+      state: "open",
+      head: { ref: "feature/kickstart", sha: "commit-new" },
+      base: { ref: "main" },
+    }, { status: 201 }));
+
+    const result = await commitGitHubFilesAndCreatePullRequestForRequest(
+      makeRequest({
+        "x-ms-client-principal-id": "principal-123",
+        cookie,
+        host: "kickstart.test",
+        "x-forwarded-proto": "https",
+      }),
+      {
+        owner: "sabbour",
+        repo: "demo-app",
+        head: "feature/kickstart",
+        base: "main",
+        title: "feat: add artifacts",
+        body: "Please review the generated files.",
+        commitMessage: "feat: add artifacts",
+        files: [
+          { path: "Dockerfile", content: "FROM node:20" },
+          { path: ".github/workflows/deploy.yml", content: "name: deploy" },
+        ],
+      },
+    );
+
+    expect(result).toMatchObject({
+      commitSha: "commit-new",
+      committedFilesCount: 2,
+      headBranch: "feature/kickstart",
+      baseBranch: "main",
+      pullRequest: {
+        number: 42,
+        html_url: "https://github.com/sabbour/demo-app/pull/42",
+      },
+    });
+
+    const treeCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith("/git/trees"));
+    expect(treeCall).toBeDefined();
+    const treeBody = JSON.parse(String(treeCall?.[1]?.body));
+    expect(treeBody).toEqual({
+      base_tree: "tree-base",
+      tree: [
+        {
+          path: "Dockerfile",
+          mode: "100644",
+          type: "blob",
+          content: "FROM node:20",
+        },
+        {
+          path: ".github/workflows/deploy.yml",
+          mode: "100644",
+          type: "blob",
+          content: "name: deploy",
+        },
+      ],
+    });
+
+    const githubAuthHeaders = fetchMock.mock.calls
+      .filter(([url]) => String(url).startsWith("https://api.github.com"))
+      .map(([, init]) => new Headers(init?.headers).get("authorization"));
+    expect(githubAuthHeaders.length).toBeGreaterThan(0);
+    expect(githubAuthHeaders.every((value) => value === "Bearer ghs_test_token")).toBe(true);
+  });
+
+  it("rejects protected branch writes before any GitHub API call", async () => {
+    await expect(
+      commitGitHubFilesAndCreatePullRequestForRequest(
+        makeRequest(),
+        {
+          owner: "sabbour",
+          repo: "demo-app",
+          head: "main",
+          title: "feat: add artifacts",
+          files: [{ path: "Dockerfile", content: "FROM node:20" }],
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "GitHubAuthError",
+      status: 400,
+      message: 'Cannot commit directly to protected branch "main".',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/api/src/lib/github-auth.ts
+++ b/packages/web/api/src/lib/github-auth.ts
@@ -1,5 +1,5 @@
 import type { Cookie, HttpRequest } from "@azure/functions";
-import type { GitHubRepo } from "@kickstart/core";
+import type { GitHubPullRequest, GitHubRepo } from "@kickstart/core";
 import {
   createCipheriv,
   createDecipheriv,
@@ -13,9 +13,13 @@ const SESSION_COOKIE_NAME = "kickstart-github-session";
 const FLOW_TTL_S = 10 * 60;
 const SESSION_TTL_S = 8 * 60 * 60;
 const MAX_REPO_NAME_LENGTH = 100;
+const MAX_BRANCH_NAME_LENGTH = 100;
+const MAX_PULL_REQUEST_TITLE_LENGTH = 200;
+const MAX_PULL_REQUEST_BODY_LENGTH = 20_000;
 const GITHUB_API_BASE = "https://api.github.com";
 const GITHUB_AUTH_BASE = "https://github.com";
 const DEFAULT_GITHUB_SCOPES = "repo read:user read:org";
+const PROTECTED_BRANCHES = new Set(["main", "master", "production"]);
 
 interface GitHubConfig {
   clientId: string;
@@ -68,6 +72,24 @@ interface GitHubRepoResponse {
   updated_at?: string;
 }
 
+interface GitHubRefResponse {
+  ref: string;
+  object: {
+    sha: string;
+  };
+}
+
+interface GitHubCommitObjectResponse {
+  sha: string;
+  tree: {
+    sha: string;
+  };
+}
+
+interface GitHubTreeResponse {
+  sha: string;
+}
+
 export interface GitHubViewerSummary {
   login: string;
   name: string | null;
@@ -96,6 +118,30 @@ export interface GitHubCreateRepoInput {
   name: string;
   description?: string;
   private?: boolean;
+}
+
+export interface GitHubCommitFileInput {
+  path: string;
+  content: string;
+}
+
+export interface GitHubCommitPullRequestInput {
+  owner: string;
+  repo: string;
+  head: string;
+  base?: string;
+  title: string;
+  body?: string;
+  commitMessage?: string;
+  files: GitHubCommitFileInput[];
+}
+
+export interface GitHubCommitPullRequestResult {
+  pullRequest: GitHubPullRequest;
+  commitSha: string;
+  committedFilesCount: number;
+  headBranch: string;
+  baseBranch: string;
 }
 
 export class GitHubAuthError extends Error {
@@ -131,6 +177,20 @@ function stripControlChars(value: string): string {
 function sanitizeMessage(value: string, fallback: string): string {
   const cleaned = stripControlChars(value).slice(0, 200);
   return cleaned || fallback;
+}
+
+function sanitizeRequiredText(value: string, label: string, maxLength: number): string {
+  const cleaned = stripControlChars(value).slice(0, maxLength).trim();
+  if (!cleaned) {
+    throw new GitHubAuthError(`${label} is required.`, 400);
+  }
+
+  return cleaned;
+}
+
+function sanitizeOptionalText(value: string | undefined, maxLength: number): string | undefined {
+  const cleaned = stripControlChars(value || "").slice(0, maxLength).trim();
+  return cleaned || undefined;
 }
 
 function isSecureRequest(request: HttpRequest): boolean {
@@ -421,6 +481,19 @@ function mapRepo(repo: GitHubRepoResponse): GitHubRepo {
   };
 }
 
+function validateOwnerOrRepo(value: string, label: string): string {
+  const trimmed = stripControlChars(value).trim();
+  if (!trimmed) {
+    throw new GitHubAuthError(`${label} is required.`, 400);
+  }
+
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+    throw new GitHubAuthError(`${label} contains invalid characters.`, 400);
+  }
+
+  return trimmed;
+}
+
 function validateRepoName(name: string): string | null {
   const trimmed = name.trim();
   if (!trimmed) return "Repository name is required.";
@@ -431,6 +504,97 @@ function validateRepoName(name: string): string | null {
     return "Repository name may only contain letters, numbers, '.', '_', and '-'.";
   }
   return null;
+}
+
+function validateBranchName(
+  name: string,
+  label: string,
+  options: { allowProtected?: boolean } = {},
+): string {
+  const trimmed = stripControlChars(name).trim();
+  if (!trimmed) {
+    throw new GitHubAuthError(`${label} is required.`, 400);
+  }
+  if (trimmed.length > MAX_BRANCH_NAME_LENGTH) {
+    throw new GitHubAuthError(
+      `${label} must be ${MAX_BRANCH_NAME_LENGTH} characters or fewer.`,
+      400,
+    );
+  }
+  if (/[~^:?*[\]\\]/.test(trimmed)) {
+    throw new GitHubAuthError(`${label} contains invalid characters.`, 400);
+  }
+  if (trimmed.startsWith("-") || trimmed.startsWith(".")) {
+    throw new GitHubAuthError(`${label} cannot start with '-' or '.'.`, 400);
+  }
+  if (trimmed.endsWith(".lock") || trimmed.endsWith(".")) {
+    throw new GitHubAuthError(`${label} cannot end with '.lock' or '.'.`, 400);
+  }
+  if (trimmed.includes("..") || /\s/.test(trimmed)) {
+    throw new GitHubAuthError(`${label} cannot contain spaces or '..'.`, 400);
+  }
+  if (!options.allowProtected && PROTECTED_BRANCHES.has(trimmed)) {
+    throw new GitHubAuthError(
+      `Cannot commit directly to protected branch "${trimmed}".`,
+      400,
+    );
+  }
+
+  return trimmed;
+}
+
+function validateArtifactPath(path: string): string {
+  const trimmed = stripControlChars(path).trim();
+  if (!trimmed) {
+    throw new GitHubAuthError("Artifact path is required.", 400);
+  }
+  if (trimmed.startsWith("/")) {
+    throw new GitHubAuthError("Artifact path must be relative.", 400);
+  }
+  if (/[\x00-\x1f\\]/.test(trimmed)) {
+    throw new GitHubAuthError("Artifact path contains forbidden characters.", 400);
+  }
+
+  const segments = trimmed.split("/");
+  for (const segment of segments) {
+    if (!segment || segment === "." || segment === "..") {
+      throw new GitHubAuthError("Artifact path contains invalid segments.", 400);
+    }
+  }
+
+  return trimmed;
+}
+
+function normalizeCommitFiles(files: GitHubCommitFileInput[]): GitHubCommitFileInput[] {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new GitHubAuthError("Select at least one file to commit.", 400);
+  }
+
+  const seen = new Set<string>();
+  return files.map((file) => {
+    if (!file || typeof file !== "object") {
+      throw new GitHubAuthError("Each committed file must include a path and content.", 400);
+    }
+
+    const path = validateArtifactPath(typeof file.path === "string" ? file.path : "");
+    if (seen.has(path)) {
+      throw new GitHubAuthError(`Duplicate artifact path "${path}" is not allowed.`, 400);
+    }
+    seen.add(path);
+
+    if (typeof file.content !== "string") {
+      throw new GitHubAuthError(`Artifact "${path}" is missing file content.`, 400);
+    }
+
+    return {
+      path,
+      content: file.content,
+    };
+  });
+}
+
+function gitRefPath(branch: string): string {
+  return encodeURIComponent(`heads/${branch}`);
 }
 
 async function authorizeGitHubSession(request: HttpRequest): Promise<{
@@ -738,5 +902,137 @@ export async function createGitHubRepoForRequest(
   return {
     repo: mapRepo(repo),
     cookies: [],
+  };
+}
+
+export async function commitGitHubFilesAndCreatePullRequestForRequest(
+  request: HttpRequest,
+  input: GitHubCommitPullRequestInput,
+): Promise<GitHubCommitPullRequestResult> {
+  const owner = validateOwnerOrRepo(input.owner || "", "GitHub owner");
+  const repo = validateOwnerOrRepo(input.repo || "", "GitHub repository");
+  const headBranch = validateBranchName(input.head || "", "Branch name");
+  const requestedBaseBranch = input.base
+    ? validateBranchName(input.base, "Base branch", { allowProtected: true })
+    : undefined;
+  const title = sanitizeRequiredText(
+    input.title || "",
+    "Pull request title",
+    MAX_PULL_REQUEST_TITLE_LENGTH,
+  );
+  const body = sanitizeOptionalText(input.body, MAX_PULL_REQUEST_BODY_LENGTH);
+  const commitMessage = sanitizeRequiredText(
+    input.commitMessage || title,
+    "Commit message",
+    MAX_PULL_REQUEST_TITLE_LENGTH,
+  );
+  const files = normalizeCommitFiles(input.files);
+
+  const authorized = await authorizeGitHubSession(request);
+  if (!authorized.owners.some((candidate) => candidate.login === owner)) {
+    throw new GitHubAuthError("Selected GitHub owner is not available.", 400);
+  }
+
+  const repoPath = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  const repoInfo = await githubJson<GitHubRepoResponse>(
+    authorized.accessToken,
+    repoPath,
+  );
+  const baseBranch = requestedBaseBranch || repoInfo.default_branch;
+  const baseRef = await githubJson<GitHubRefResponse>(
+    authorized.accessToken,
+    `${repoPath}/git/ref/${gitRefPath(baseBranch)}`,
+  );
+
+  let headCommitSha = baseRef.object.sha;
+  try {
+    const headRef = await githubJson<GitHubRefResponse>(
+      authorized.accessToken,
+      `${repoPath}/git/ref/${gitRefPath(headBranch)}`,
+    );
+    headCommitSha = headRef.object.sha;
+  } catch (error) {
+    if (!(error instanceof GitHubAuthError) || error.status !== 404) {
+      throw error;
+    }
+
+    await githubJson<GitHubRefResponse>(
+      authorized.accessToken,
+      `${repoPath}/git/refs`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ref: `refs/heads/${headBranch}`,
+          sha: baseRef.object.sha,
+        }),
+      },
+    );
+  }
+
+  const currentCommit = await githubJson<GitHubCommitObjectResponse>(
+    authorized.accessToken,
+    `${repoPath}/git/commits/${headCommitSha}`,
+  );
+  const nextTree = await githubJson<GitHubTreeResponse>(
+    authorized.accessToken,
+    `${repoPath}/git/trees`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        base_tree: currentCommit.tree.sha,
+        tree: files.map((file) => ({
+          path: file.path,
+          mode: "100644",
+          type: "blob",
+          content: file.content,
+        })),
+      }),
+    },
+  );
+  const nextCommit = await githubJson<GitHubCommitObjectResponse>(
+    authorized.accessToken,
+    `${repoPath}/git/commits`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        message: commitMessage,
+        tree: nextTree.sha,
+        parents: [headCommitSha],
+      }),
+    },
+  );
+
+  await githubJson<GitHubRefResponse>(
+    authorized.accessToken,
+    `${repoPath}/git/refs/${gitRefPath(headBranch)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({
+        sha: nextCommit.sha,
+        force: false,
+      }),
+    },
+  );
+
+  const pullRequest = await githubJson<GitHubPullRequest>(
+    authorized.accessToken,
+    `${repoPath}/pulls`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        title,
+        head: headBranch,
+        base: baseBranch,
+        ...(body ? { body } : {}),
+      }),
+    },
+  );
+
+  return {
+    pullRequest,
+    commitSha: nextCommit.sha,
+    committedFilesCount: files.length,
+    headBranch,
+    baseBranch,
   };
 }

--- a/packages/web/src/catalog/components/GitHubCommit.tsx
+++ b/packages/web/src/catalog/components/GitHubCommit.tsx
@@ -204,20 +204,18 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
       return;
     }
 
+    if (selectedArtifacts.length === 0) {
+      setError('Select at least one file to commit.');
+      return;
+    }
+
     setState('executing');
     setError(undefined);
     setResultMessage('');
 
     try {
       if (!connector) {
-        // Stub mode
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-        const stubUrl = `https://github.com/${repoFullName || 'stub-user/my-app'}/pull/1`;
-        setState('success');
-        setPrUrl(stubUrl);
-        setResultMessage('Pull request created successfully (stub mode)');
-        if (props.onSuccess) (props.onSuccess as () => void)();
-        return;
+        throw new Error('GitHub pull request creation is unavailable. Refresh the page and try again.');
       }
 
       const [owner, repo] = repoFullName.split('/');
@@ -228,18 +226,25 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
       const fileList = selectedArtifacts.map((a) => `- \`${a.path}\``).join('\n');
       const prBodyFull = `${prBody}\n\n---\n\n**Files included (${selectedArtifacts.length}):**\n${fileList}`;
 
-      const pr = await connector.createPullRequest(
+      const result = await connector.commitFilesAndCreatePullRequest({
         owner,
         repo,
-        prTitle,
-        branchName,
-        defaultBranch,
-        prBodyFull,
-      );
+        title: prTitle,
+        head: branchName,
+        base: defaultBranch,
+        body: prBodyFull,
+        commitMessage: prTitle,
+        files: selectedArtifacts.map((artifact) => ({
+          path: artifact.path,
+          content: artifact.content,
+        })),
+      });
 
       setState('success');
-      setPrUrl(pr.html_url);
-      setResultMessage(`Pull request #${pr.number}  created successfully`);
+      setPrUrl(result.pullRequest.html_url);
+      setResultMessage(
+        `Committed ${result.committedFilesCount} file${result.committedFilesCount === 1 ? '' : 's'} and opened pull request #${result.pullRequest.number}.`,
+      );
       if (props.onSuccess) (props.onSuccess as () => void)();
     } catch (err) {
       setState('error');
@@ -302,10 +307,10 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
       <Card className={classes.root}>
         <CardHeader
           header={<Subtitle1>Creating Pull Request\u2026</Subtitle1>}
-          description={<Caption1>Pushing {selectedArtifacts.length} files to {branchName}</Caption1>}
+          description={<Caption1>Committing {selectedArtifacts.length} files to {branchName}</Caption1>}
         />
         <div className={classes.actions} style={{ justifyContent: 'center' }}>
-          <Spinner size="small" label="Creating branch and pull request\u2026" />
+          <Spinner size="small" label="Creating commit and pull request\u2026" />
         </div>
       </Card>
     );
@@ -384,12 +389,6 @@ export const GitHubCommit = createReactComponent(GitHubCommitApi, ({ props }) =>
             Create pull request
           </Button>
         </div>
-
-        {!connector && (
-          <Caption1 style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}>
-            Running in offline mode \u2014 PR creation will be simulated
-          </Caption1>
-        )}
       </Card>
     );
   }

--- a/packages/web/src/contexts/APIConnectorContext.tsx
+++ b/packages/web/src/contexts/APIConnectorContext.tsx
@@ -51,7 +51,10 @@ export function APIConnectorProvider({
         proxyBaseUrl: '/api/arm-proxy',
       },
     }));
-    r.register(new GitHubConnector());
+    r.register(new GitHubConnector({
+      auth: { kind: 'oauth2', scopes: ['read:user'] },
+      serverBaseUrl: '/api/github',
+    }));
     r.register(new PricingConnector());
     return r;
   }, [externalRegistry]);
@@ -61,7 +64,7 @@ export function APIConnectorProvider({
   useEffect(() => {
     for (const name of registry.names()) {
       const connector = registry.get(name);
-      if (connector && !connector.isAuthenticated()) {
+      if (connector && connector.name !== 'github' && !connector.isAuthenticated()) {
         connector.authenticate().catch(() => {
           // Intentionally silent — stub connectors warn inside authenticate()
         });


### PR DESCRIPTION
Closes #274

Working as Fry (Frontend Dev) and Bender (Backend Dev).

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Summary
- add a server-owned GitHub write endpoint for committing selected artifacts on a feature branch and creating the pull request
- route `GitHubCommit` through the real session-backed GitHub ship path instead of stub/offline success
- expose `GitHubCommit` in `github-kit` so the handoff flow can actually discover and use the real commit/PR component

## Validation
- `npm run lint`
- `npm run build -w @kickstart/core`
- `cd packages/web && npx tsc --noEmit`
- `cd packages/web/api && npm run build`
- `npx vitest run`

## Notes
- This closes the remaining fake seam after the secure GitHub auth + repo-create slice that was already on `main`.
- Generic `GitHubAction` write operations are still separate from the new server-owned ship path.