### PR TITLE
fix: keep SWA API startup imports clean

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -27,6 +27,7 @@ Backend engineer owning MCP server, API layer, and database design. Expertise in
 
 - (2026-04-14 13:04) Triage pipeline fix: added project board assignment to squad-triage.yml, squad-heartbeat.yml, squad-issue-assign.yml. Added triage checklist to routing.md.
 - (2026-04-14 11:02) Wave 1: SWA continuous deploy + version footer → PR #177 opened. Auto-deploy from main, version shows SHA.
+- (2026-04-15 16:06) SWA outage triage: latest deploy was packaging 18 API entrypoints, including `converse.test.ts`, and bundling `bicep-node` into the function ESM output. Both crashed module import before handlers registered, which explains the live `/api/*` 404s. Fixed `packages/web/api/esbuild.config.mjs` to exclude `*.test.ts`/`*.spec.ts` and keep `bicep-node` external.
 
 ## Learnings
 - SWA deploy workflow (`deploy-swa.yml`) needs explicit `push → branches: [main]` trigger — tag-only triggers mean no continuous deployment from main.
@@ -69,3 +70,5 @@ Backend engineer owning MCP server, API layer, and database design. Expertise in
 - (2026-04-15) Auto-continue via filesComplete flag eliminates friction during multi-turn file generation. The LLM sets filesComplete: false, the client auto-sends "Generate next set of files" — no manual button clicks needed.
 - (2026-04-15) Artifact summary injection (appending generated file list + resource declarations to the system prompt each turn) gives the LLM running context and prevents hallucinated file references or duplicate generation. Modeled after Try-AKS's buildArtifactSummary pattern.
 - (2026-04-15) WSL on Windows can silently lose file edits when switching git branches — the working tree may revert to the branch commit state. Always verify file content after branch switches.
+- (2026-04-15T16:06:15Z) Azure Functions v4 loads every file matched by the `package.json` `main` glob during startup. If `src/functions` contains a Vitest file and the build bundles it, deployment can still succeed while every live `/api/*` route 404s because handler registration never finishes.
+- (2026-04-15T16:06:15Z) `bicep-node` must stay external in the managed Functions ESM bundle. When esbuild inlines it, the generated function entrypoint throws `Dynamic require of "os" is not supported` on import, which blocks the whole API app from starting.

--- a/.squad/decisions/inbox/copilot-swa-api-bundle-safety.md
+++ b/.squad/decisions/inbox/copilot-swa-api-bundle-safety.md
@@ -1,0 +1,35 @@
+# Decision: Keep non-runtime files and `bicep-node` out of SWA function startup
+
+**Date:** 2026-04-15T16:06:15Z  
+**Author:** Bender (Backend Dev)  
+**Status:** Implemented
+
+## Context
+
+The live Static Web App was returning 404 for anonymous API routes like `/api/health` and `/api/github-auth/callback` even though the latest `deploy-swa.yml` run succeeded and the frontend auth layer was still active.
+
+The deploy log for commit `d936a67` showed the API build bundling **18 function entrypoints**. One of those files was `packages/web/api/src/functions/converse.test.ts`, and importing the built `dist/functions/converse.test.js` outside Vitest immediately threw `Vitest mocker was not initialized in this environment`. The same startup sweep also failed when `bicep-node` was inlined into `azure-deployments.js`, throwing `Dynamic require of "os" is not supported`.
+
+## Decision
+
+1. **Exclude test/spec files from API entrypoints** — `packages/web/api/esbuild.config.mjs` must not bundle `*.test.ts` or `*.spec.ts` from `src/functions/`.
+2. **Keep `bicep-node` external** — the API bundle must leave `bicep-node` in `node_modules` instead of inlining it into the ESM function entrypoints.
+
+## Why
+
+Azure Functions v4 loads every file matched by the `package.json` `main` glob at startup. Any bundled file that throws during import prevents handler registration for the whole managed API, which shows up at the edge as repo-correct routes returning 404.
+
+## Evidence
+
+- Latest SWA deploy log: `✅ Bundled 18 function(s) to dist/functions/`
+- `git ls-tree origin/main packages/web/api/src/functions` included `converse.test.ts`
+- Reproduced crash by importing the built test bundle:
+  - `Vitest mocker was not initialized in this environment. vi.queueMock() is forbidden.`
+- Reproduced crash by importing the bundled Azure deployment entrypoint before externalizing `bicep-node`:
+  - `Dynamic require of "os" is not supported`
+
+## Consequences
+
+- Managed Functions startup now only imports real runtime entrypoints.
+- Azure deployment routes can still use `bicep-node`, but only through the runtime dependency in `node_modules`.
+- Future API tests can stay near the functions code, but the build must continue filtering non-runtime files out of the startup glob.

--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -2,8 +2,9 @@
  * esbuild config for @kickstart/api
  *
  * Bundles each Azure Function entry point into a self-contained ESM file.
- * @kickstart/core is inlined (not published to npm), while @azure/functions
- * and Node.js built-ins stay external (resolved from node_modules at runtime).
+ * @kickstart/core is inlined (not published to npm), while @azure/functions,
+ * bicep-node, and Node.js built-ins stay external (resolved from node_modules
+ * at runtime).
  */
 
 import * as esbuild from "esbuild";
@@ -12,6 +13,7 @@ import { join } from "node:path";
 
 const entryPoints = readdirSync("src/functions")
   .filter((f) => f.endsWith(".ts"))
+  .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"))
   .map((f) => join("src/functions", f));
 
 await esbuild.build({
@@ -21,7 +23,7 @@ await esbuild.build({
   format: "esm",
   platform: "node",
   target: "node20",
-  external: ["@azure/functions"],
+  external: ["@azure/functions", "bicep-node"],
   sourcemap: true,
 });
 


### PR DESCRIPTION
## Summary
- fix the managed Functions startup crash behind the live SWA API outage
- keep non-runtime files out of the `package.json` startup glob
- keep `bicep-node` external so Azure deployment routes don't crash on import

## Root cause
The latest SWA deploy succeeded, but its log showed `✅ Bundled 18 function(s) to dist/functions/` from `packages/web/api`. That bundle included `src/functions/converse.test.ts`, and importing the built `dist/functions/converse.test.js` outside Vitest immediately threw `Vitest mocker was not initialized in this environment`.

After excluding the test bundle, importing the built Azure deployment entrypoint still failed because `bicep-node` had been inlined into the ESM output, which threw `Dynamic require of "os" is not supported` on module import.

Azure Functions v4 imports every file matched by the API package `main` glob at startup, so either import failure prevents handler registration for the whole managed API and surfaces live as `/api/*` 404s.

## Changes
- exclude `*.test.ts` and `*.spec.ts` from `packages/web/api/esbuild.config.mjs`
- mark `bicep-node` as external in the same bundle config
- capture the outage learning in Bender history and the decisions inbox

## Validation
- `npm run build -w @kickstart/core`
- `npm run build -w @kickstart/api`
- imported every built file under `packages/web/api/dist/functions/*.js` successfully after the fix
- `npx vitest run packages/web/api/src/functions/converse.test.ts`
- CI-equivalent local gate:
  - `npm run lint`
  - `npm run build -w @kickstart/core`
  - `cd packages/web && npx tsc --noEmit && npx vite build`
  - `cd packages/web/api && npm run build`
  - `npx vitest run`

## Notes
`npm run build` at the repo root still fails on pre-existing `packages/mcp-server` TypeScript errors on `origin/main`; this PR does not change that path, and the repo CI workflow does not build that workspace.
