### PR TITLE
Add post-deploy /api/health smoke check

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -56,3 +56,56 @@ jobs:
           skip_app_build: true
           skip_api_build: false
           api_build_command: "echo 'API already built'"
+
+      - name: Smoke test live /api/health
+        env:
+          LIVE_APP_URL: https://kickstart.aks.azure.sabbour.me
+        run: |
+          node <<'NODE'
+          (async () => {
+            const url = `${process.env.LIVE_APP_URL}/api/health`;
+            const attempts = Number(process.env.SMOKE_ATTEMPTS ?? '6');
+            const delayMs = Number(process.env.SMOKE_DELAY_MS ?? '10000');
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            for (let attempt = 1; attempt <= attempts; attempt += 1) {
+              console.log(`Attempt ${attempt}/${attempts}: probing ${url}`);
+
+              try {
+                const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+                const text = await response.text();
+
+                if (!response.ok) {
+                  throw new Error(`HTTP ${response.status}${text ? ` — ${text.slice(0, 200)}` : ''}`);
+                }
+
+                let payload;
+                try {
+                  payload = JSON.parse(text);
+                } catch {
+                  throw new Error(`Non-JSON response: ${text.slice(0, 200)}`);
+                }
+
+                if (payload.status !== 'ok') {
+                  throw new Error(`Unexpected payload: ${text.slice(0, 200)}`);
+                }
+
+                console.log(`✅ Live /api/health is healthy: ${text}`);
+                return;
+              } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                console.error(`Attempt ${attempt}/${attempts} failed: ${message}`);
+
+                if (attempt === attempts) {
+                  process.exit(1);
+                }
+
+                await sleep(delayMs);
+              }
+            }
+          })().catch((error) => {
+            const message = error instanceof Error ? error.stack ?? error.message : String(error);
+            console.error(message);
+            process.exit(1);
+          });
+          NODE

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -24,3 +24,9 @@ QA engineer and test infrastructure owner. Expertise in Playwright E2E testing, 
 - v0.3.0 test expansion: tool system TDD, validation engine, action loop verification
 
 ## Learnings
+
+### 2026-04-15T15:28:36.991Z — Live `/api/health` smoke gate
+
+- `.github/workflows/deploy-swa.yml` is the right guardrail point for a missing live `/api/health` route because local builds and unit tests can pass while Azure Static Web Apps still deploys a runtime with the route missing.
+- For this outage class, a post-deploy probe is more valuable than another local integration test; it should hit `https://kickstart.aks.azure.sabbour.me/api/health`, retry briefly for propagation, and fail unless the response is `200` JSON with `{"status":"ok"}`.
+- The smoke logic is easy to validate locally by running the same Node fetch probe against a stub server for the success path and against the live site with `SMOKE_ATTEMPTS=1` for the failure path.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,11 +105,12 @@ buildProperties: {
 
 **Source:** [`.github/workflows/deploy-swa.yml`](../.github/workflows/deploy-swa.yml)
 
-Deploys the web frontend and API to Azure Static Web Apps on every push to `main` and on PRs.
+Deploys the web frontend and API to Azure Static Web Apps on every push to `main` and on manual dispatches, then probes the live health endpoint.
 
 **Trigger:**
 - Push to `main` → production deployment
-- PR opened/synced → staging environment (auto-destroyed on PR close)
+- Push tag `v*` → release deployment
+- Manual dispatch (`workflow_dispatch`) → on-demand production redeploy
 
 **Jobs:**
 
@@ -120,17 +121,19 @@ steps:
   - Checkout code
   - Setup Node.js 20 (with npm cache)
   - npm ci && build core + API
+  - vite build
   - Deploy via Azure/static-web-apps-deploy@v1
+  - Probe https://kickstart.aks.azure.sabbour.me/api/health with retries
 ```
 
 Key configuration:
 
 ```yaml
-app_location: "packages/web"         # Static frontend
+app_location: "packages/web/dist"    # Prebuilt static frontend
 api_location: "packages/web/api"     # Azure Functions API
-skip_app_build: true                 # No build step for static HTML
+skip_app_build: true                 # Vite build already ran
 skip_api_build: false                # API needs TypeScript compilation
-api_build_command: "npm run build"
+api_build_command: "echo 'API already built'"
 ```
 
 **Build order is critical:** The API depends on `@kickstart/core`, so both must be built before the SWA action:
@@ -139,17 +142,10 @@ api_build_command: "npm run build"
 npm ci
 npm run build -w @kickstart/core    # Build core first
 npm run build -w @kickstart/api     # Then API (depends on core)
+npx vite build                      # Build frontend dist
 ```
 
-#### `close_staging`
-
-Runs when a PR is closed — tears down the staging environment:
-
-```yaml
-- uses: Azure/static-web-apps-deploy@v1
-  with:
-    action: "close"
-```
+**Post-deploy smoke gate:** After upload, the workflow retries the live anonymous probe at `https://kickstart.aks.azure.sabbour.me/api/health` and requires a JSON payload with `"status": "ok"`. This is the production guardrail for cases where source builds succeed but the deployed Functions surface is missing the live `health` route.
 
 **Required secrets:**
 


### PR DESCRIPTION
Summary: add a post-deploy smoke probe for the live /api/health route in deploy-swa.yml, document the updated deployment gate, and append the Hermes testing learning for this outage class. Why: local build and unit coverage already pass, so the missing live route is a deployment/runtime detection gap and the smallest useful follow-up is a GitHub Actions post-deploy smoke check rather than another local integration test. Testing: npm run lint; npm run build -w @kickstart/core; cd packages/web && npx tsc --noEmit; cd packages/web/api && npm run build; cd packages/web && npx vite build; npx vitest run; validated the smoke probe against a local stub success path and against the current live 404 with SMOKE_ATTEMPTS=1.