### PR TITLE
test: add SWA post-deploy health smoke

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -8,9 +8,11 @@ on:
     tags:
       - "v*"
     paths:
+      - '.github/workflows/deploy-swa.yml'
       - 'packages/**'
       - 'package.json'
       - 'package-lock.json'
+      - 'scripts/**'
       - 'tsconfig.json'
 
 permissions:
@@ -56,3 +58,14 @@ jobs:
           skip_app_build: true
           skip_api_build: false
           api_build_command: "echo 'API already built'"
+
+      - name: Resolve production smoke target
+        id: production_url
+        run: |
+          BASE_URL="$(node -e "const params = require('./infra/parameters.dev.json'); const host = params.parameters.customDomainHostname?.value; if (!host) { throw new Error('infra/parameters.dev.json is missing parameters.customDomainHostname.value'); } process.stdout.write('https://' + host);")"
+          echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke check live API health
+        env:
+          SWA_HEALTHCHECK_URL: ${{ steps.production_url.outputs.base_url }}/api/health
+        run: node scripts/check-swa-health.mjs

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,6 +107,8 @@ buildProperties: {
 
 Deploys the web frontend and API to Azure Static Web Apps on every push to `main` and on PRs.
 
+After upload, the workflow retries `GET /api/health` against the production custom domain and fails if the live API never returns `200 {"status":"ok"}`. This catches managed Functions startup regressions that can slip past a successful deploy job.
+
 **Trigger:**
 - Push to `main` → production deployment
 - PR opened/synced → staging environment (auto-destroyed on PR close)

--- a/scripts/check-swa-health.mjs
+++ b/scripts/check-swa-health.mjs
@@ -1,0 +1,65 @@
+const url = process.env.SWA_HEALTHCHECK_URL;
+const attempts = Number.parseInt(process.env.SWA_HEALTHCHECK_ATTEMPTS ?? '8', 10);
+const delayMs = Number.parseInt(process.env.SWA_HEALTHCHECK_DELAY_MS ?? '15000', 10);
+const timeoutMs = Number.parseInt(process.env.SWA_HEALTHCHECK_TIMEOUT_MS ?? '10000', 10);
+
+if (!url) {
+  throw new Error('SWA_HEALTHCHECK_URL is required');
+}
+
+if (!Number.isInteger(attempts) || attempts < 1) {
+  throw new Error(`Invalid SWA_HEALTHCHECK_ATTEMPTS: ${process.env.SWA_HEALTHCHECK_ATTEMPTS ?? '(unset)'}`);
+}
+
+if (!Number.isInteger(delayMs) || delayMs < 0) {
+  throw new Error(`Invalid SWA_HEALTHCHECK_DELAY_MS: ${process.env.SWA_HEALTHCHECK_DELAY_MS ?? '(unset)'}`);
+}
+
+if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
+  throw new Error(`Invalid SWA_HEALTHCHECK_TIMEOUT_MS: ${process.env.SWA_HEALTHCHECK_TIMEOUT_MS ?? '(unset)'}`);
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let lastFailure = 'No attempts were made.';
+
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  console.log(`Attempt ${attempt}/${attempts}: checking ${url}`);
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const bodyText = await response.text();
+
+    let body;
+    try {
+      body = bodyText ? JSON.parse(bodyText) : null;
+    } catch {
+      body = null;
+    }
+
+    if (response.ok && body?.status === 'ok') {
+      console.log(`✅ Health check passed with ${response.status} and body ${bodyText}`);
+      process.exit(0);
+    }
+
+    lastFailure = `HTTP ${response.status} ${response.statusText}; body=${bodyText || '(empty)'}`;
+  } catch (error) {
+    lastFailure = error instanceof Error ? error.message : String(error);
+  }
+
+  console.log(`⚠️ Health check failed: ${lastFailure}`);
+
+  if (attempt < attempts) {
+    console.log(`Waiting ${delayMs}ms before retrying...`);
+    await sleep(delayMs);
+  }
+}
+
+throw new Error(
+  `SWA health probe never passed after ${attempts} attempts. Last failure: ${lastFailure}. ` +
+    'If this follows a successful SWA deploy, confirm /api/health is anonymously routable and that every built API entrypoint imports cleanly at startup.',
+);


### PR DESCRIPTION
## Summary
- add a reusable SWA `/api/health` smoke probe script with retry + actionable failures
- run that probe at the end of `deploy-swa.yml` against the production custom domain
- document the new post-deploy health gate in the deployment guide

## Why
The best automated proof we can add independently today is a deploy-time smoke gate for the live managed API. It catches the exact outage class tracked in PR #312: a deploy can succeed while Functions startup fails and every live `/api/*` route still 404s.

## Dependency
- Merge after #312. On current `main`, `https://kickstart.aks.azure.sabbour.me/api/health` still returns 404, so this PR would correctly fail the deploy workflow until the outage fix lands.

## Testing
- `npm run lint && npm run build -w @kickstart/core && (cd packages/web && npx tsc --noEmit && npx vite build) && (cd packages/web/api && npm run build) && npx vitest run`
- `SWA_HEALTHCHECK_URL=http://127.0.0.1:4010/api/health SWA_HEALTHCHECK_ATTEMPTS=1 node scripts/check-swa-health.mjs` against a local stub → passes
- `SWA_HEALTHCHECK_URL=https://kickstart.aks.azure.sabbour.me/api/health SWA_HEALTHCHECK_ATTEMPTS=1 node scripts/check-swa-health.mjs` on current prod → fails with live 404 (expected until #312 lands)
