### PR TITLE
fix: stop false heartbeat failures

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -104,7 +104,7 @@ jobs:
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const path = 'triage-results.json';

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Identify assigned member and trigger work
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const issue = context.payload.issue;
@@ -118,7 +119,7 @@ jobs:
       - name: Add issue to project board
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const issue = context.payload.issue;
             const projectNumber = 3;

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Enforce mutual exclusivity
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issue = context.payload.issue;
             const appliedLabel = context.payload.label.name;

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Triage issue via Lead agent
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const issue = context.payload.issue;
@@ -265,7 +266,7 @@ jobs:
       - name: Add issue to project board
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const issue = context.payload.issue;
             const projectNumber = 3;

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Parse roster and sync labels
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             let teamFile = '.squad/team.md';

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -25,10 +25,12 @@ Backend engineer owning MCP server, API layer, and database design. Expertise in
 
 ## Work Log
 
+- (2026-04-15 16:26) Heartbeat workflow fix: traced failing Ralph checks on merged PRs to the project-board step requiring `COPILOT_ASSIGN_TOKEN`; patched `.github/workflows/squad-heartbeat.yml` to fall back to `GITHUB_TOKEN`, then audited sibling workflows and added explicit `github-token` inputs/fallbacks in `squad-triage.yml`, `squad-issue-assign.yml`, `squad-label-enforce.yml`, and `sync-squad-labels.yml`.
 - (2026-04-14 13:04) Triage pipeline fix: added project board assignment to squad-triage.yml, squad-heartbeat.yml, squad-issue-assign.yml. Added triage checklist to routing.md.
 - (2026-04-14 11:02) Wave 1: SWA continuous deploy + version footer → PR #177 opened. Auto-deploy from main, version shows SHA.
 
 ## Learnings
+- Heartbeat board-assignment steps that use `actions/github-script` must always fall back from `COPILOT_ASSIGN_TOKEN` to `GITHUB_TOKEN`. If the PAT secret is unset, the action fails before the script can early-return or downgrade GraphQL/project errors to warnings.
 - SWA deploy workflow (`deploy-swa.yml`) needs explicit `push → branches: [main]` trigger — tag-only triggers mean no continuous deployment from main.
 - `__BUILD_VERSION__` in `vite.config.ts` can embed git SHA via `execSync('git rev-parse --short HEAD')` — works both locally and in CI without relying on `GITHUB_SHA` env var.
 - Footer version display should use a single unified string (`version-sha`) rather than showing version and SHA separately — reduces redundancy and makes each build uniquely identifiable at a glance.


### PR DESCRIPTION
## Summary
- fall back to `GITHUB_TOKEN` when the heartbeat project-board step has no `COPILOT_ASSIGN_TOKEN`
- prevent `actions/github-script` from aborting before Ralph can early-return on empty triage results
- keep preferred PAT behavior when the project-scoped token is configured

## Evidence
- example failure: https://github.com/sabbour/kickstart/actions/runs/24462542869/job/71480496864
- same heartbeat failure was present on recent merged PRs #310, #309, #308, #307, #306, #305, #304, and #303
- failure text: `Input required and not supplied: github-token`

## Testing
- YAML parse check for `.github/workflows/squad-heartbeat.yml`
- `git diff --check`
- `npm run lint && npm run build && npm test` (still fails on pre-existing local baseline TypeScript errors in `packages/mcp-server`, unchanged by this PR)