### PR TITLE
fix: wire GitHub Packages auth into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,14 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@sabbour"
+          always-auth: true
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: npm run lint
@@ -58,9 +63,14 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@sabbour"
+          always-auth: true
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build core
         run: npm run build -w @kickstart/core


### PR DESCRIPTION
Unblocks PR #314 and future PRs that need @sabbour/* GitHub Packages during CI.

## Summary
- configure actions/setup-node to authenticate against GitHub Packages for the @sabbour scope in both CI jobs
- pass NODE_AUTH_TOKEN to npm ci so private package installs succeed
- keep the hotfix surgical by excluding the unrelated workflow_dispatch change from #314

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- git diff --check