### PR TITLE
fix: restore CostEstimate legacy compatibility

### DIFF
--- a/packages/core/src/__tests__/a2ui-schema.test.ts
+++ b/packages/core/src/__tests__/a2ui-schema.test.ts
@@ -215,6 +215,20 @@ describe("COMPONENT_SCHEMA_REGISTRY", () => {
     expect(result.success).toBe(true);
   });
 
+  it("validates legacy CostEstimate items, stub source, and boolean fallback", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["CostEstimate"].safeParse({
+      id: "cost-legacy",
+      component: "CostEstimate",
+      items: [{ name: "VM", sku: "B1ms", monthlyCost: 12.40 }],
+      total: 12.40,
+      currency: "USD",
+      source: "stub",
+      fallback: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("validates Divider (minimal component)", () => {
     const result = COMPONENT_SCHEMA_REGISTRY["Divider"].safeParse({
       id: "div1",

--- a/packages/core/src/__tests__/response-processor.test.ts
+++ b/packages/core/src/__tests__/response-processor.test.ts
@@ -298,6 +298,49 @@ describe("processResponse", () => {
     expect(comps).toHaveLength(0);
   });
 
+  it("preserves legacy CostEstimate payloads during component validation", () => {
+    const json = JSON.stringify({
+      message: "test",
+      a2ui: [
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "s1",
+            components: [
+              {
+                id: "cost1",
+                component: "CostEstimate",
+                items: [{ name: "VM", sku: "B1ms", monthlyCost: 12.4 }],
+                total: 12.4,
+                currency: "USD",
+                source: "stub",
+                fallback: true,
+                citation: "Estimated monthly pricing.",
+              },
+            ],
+          },
+        },
+      ],
+      actions: [],
+    });
+
+    const result = processResponse(json);
+    expect(result.a2uiMessages).toHaveLength(1);
+    const comps = result.a2uiMessages[0].updateComponents!.components as Record<string, unknown>[];
+    expect(comps).toHaveLength(1);
+    expect(comps[0]).toMatchObject({
+      component: "CostEstimate",
+      total: 12.4,
+      currency: "USD",
+      source: "stub",
+      fallback: true,
+      citation: "Estimated monthly pricing.",
+    });
+    expect(comps[0].items).toEqual([
+      { name: "VM", sku: "B1ms", monthlyCost: 12.4 },
+    ]);
+  });
+
   // -----------------------------------------------------------------------
   // Issue #153: Nesting depth limit
   // -----------------------------------------------------------------------

--- a/packages/core/src/services/a2ui-schema.ts
+++ b/packages/core/src/services/a2ui-schema.ts
@@ -361,6 +361,12 @@ const CostEstimateResourceSchema = z.object({
   pricingTiers: z.array(CostEstimatePricingTierSchema).optional(),
 });
 
+const LegacyCostEstimateItemSchema = z.object({
+  name: dynamicString,
+  sku: dynamicString.optional(),
+  monthlyCost: z.number(),
+});
+
 const CostEstimatePricingKindSchema = z.enum([
   "aksAutomaticControlPlane",
   "aksAutomaticSystemNodes",
@@ -402,22 +408,30 @@ const CostEstimateFallbackMetadataSchema = z.object({
   message: dynamicString.optional(),
 });
 
+const CostEstimateSourceSchema = z.enum(["live", "estimated", "stub"]);
+
+const CostEstimateFallbackSchema = z.union([
+  z.boolean(),
+  CostEstimateFallbackMetadataSchema,
+]);
+
 const CostEstimatePropsSchema = z
   .object({
     id: boundedString,
     component: z.literal("CostEstimate"),
-    resources: z.array(CostEstimateResourceSchema),
+    resources: z.array(CostEstimateResourceSchema).optional(),
+    items: z.array(LegacyCostEstimateItemSchema).optional(),
     monthlyEstimate: z.number().optional(),
     total: z.number().optional(),
     currency: dynamicString.optional(),
     title: dynamicString.optional(),
     projectionMonths: z.number().optional(),
     showProjectionSlider: z.boolean().optional(),
-    source: z.enum(["live", "estimated"]).optional(),
+    source: CostEstimateSourceSchema.optional(),
     citation: dynamicString.optional(),
     loading: CostEstimateLoadingStateSchema.optional(),
     cache: CostEstimateCacheMetadataSchema.optional(),
-    fallback: CostEstimateFallbackMetadataSchema.optional(),
+    fallback: CostEstimateFallbackSchema.optional(),
     pricingRequest: CostEstimatePricingRequestSchema.optional(),
     estimatedAt: dynamicString.optional(),
   })


### PR DESCRIPTION
Follow-up to #316.

## Summary
- restore shared core CostEstimate schema compatibility for legacy `items`, `source: "stub"`, and boolean `fallback` payloads
- stop `response-processor` from dropping older CostEstimate cards while keeping the newer `resources[]` shape supported
- add focused regression coverage for both schema validation and response processing

Working as Fry (Frontend Dev).

## Testing
- `npx vitest run packages/core/src/__tests__/a2ui-schema.test.ts packages/core/src/__tests__/response-processor.test.ts packages/web/src/services/cost-estimates.test.ts`
- `npm run build -w @kickstart/core`
- `npx eslint packages/core/src/services/a2ui-schema.ts packages/core/src/__tests__/a2ui-schema.test.ts packages/core/src/__tests__/response-processor.test.ts`
