### PR TITLE
fix: stabilize file surfaces and workspace artifacts

### DIFF
--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -25,6 +25,7 @@ Lead engineer and architect. Owns roadmap prioritization, design reviews, techni
 
 ## Learnings
 
+- **2026-04-15T22:27:37.636Z — Priority lane tracking on GitHub:** Encode sprint priority directly on GitHub issues using existing labels (`priority:p1`, `priority:p2`) plus cross-link comments. Each issue gets a pinned comment listing its related issues in the same lane. This makes priority visible on the issue page without requiring users to check local squad notes. Decision file: `.squad/decisions/inbox/leela-priority-tracking-github.md`
 - **2026-04-15T09:46:31.308Z — Issue #265 smallest ship:** Treat `FileEditor` payloads as workspace data, not chat bubble content. The no-mock v1 is frontend-first: transform incoming `FileEditor` A2UI into compact file cards, mirror those files into `VirtualFileSystem`, auto-open the sidebar/viewer, and override generate-phase progress title client-side. Key paths: `packages/web/src/utils/chat-a2ui.ts`, `packages/web/src/App.tsx`, `packages/web/src/components/FileManager/`, `packages/web/api/src/lib/session-store.ts`.
 - **2026-04-15T09:46:31.308Z — Issue #265 sequencing stays tight:** GitHub OAuth now being available and Azure deployment staying in scope does not widen #265. The file-manager slice remains a parallel generate/review UX track that should land before or alongside handoff/deploy work, not after it.
 
@@ -100,3 +101,8 @@ Lead engineer and architect. Owns roadmap prioritization, design reviews, techni
 - **Files affected**: `system-prompt.ts` (§2 STEP 2 + Example 3), `component-catalog.ts` (ArchitectureDiagram entry), `demo-scenarios.ts` (ARCHITECTURE scenario)
 - **Assigned to**: Bender (implementation), Fry (rendering verification)
 - **Decision file**: `.squad/decisions/inbox/leela-architecture-diagram-depth.md`
+
+---
+
+### 2026-04-15T22:27:37Z: Priority Tracking Session
+**Outcome:** Priority labels and cross-links added to GitHub issues #333, #328, #327, #326, #331, #332. Decision recorded in decisions.md for future priority tracking workflow.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -366,3 +366,971 @@ The feature introduces a new supply-chain ingress path and trust-boundary crossi
 **Reviewer:** Fry (Frontend) — verify ArchitectureDiagram rendering
 
 ---
+
+
+---
+
+## Inbox Entries (Merged)
+
+### 2026-04-15: Removed paths-ignore from CI workflow
+**By:** Bender (Backend Dev)
+**What:** Removed paths-ignore from .github/workflows/ci.yml so all PRs trigger CI checks, preventing merge deadlocks on docs-only PRs.
+**Why:** The protect-main ruleset requires 'Lint, Build & Unit Tests' and 'Playwright E2E Tests', but paths-ignore excluded docs files. Docs-only PRs could never merge.
+
+---
+
+---
+date: 2026-04-15T21:57:48.087Z
+author: Bender
+topic: file-generation-contract-fix
+issue: 333
+---
+
+# Decision (#333)
+
+Keep generated artifacts canonical in the workspace/file manager, not inline chat. The shared `FileEditor` contract must accept workspace-backed payloads (`artifactPath`), multi-file payloads (`files`), and `path` aliases end-to-end, and cold-start rehydration must preserve artifact-bearing A2UI snippets so the backend can rebuild generated-file context.
+
+## Why
+
+- The frontend chat lane already knows how to replace `FileEditor` surfaces with compact summaries and mirror files into the workspace.
+- Core validation was narrower than the frontend contract, so workspace-backed or multi-file `FileEditor` payloads could be dropped before they reached the file manager path.
+- Client-to-server rehydration only forwarded assistant text, which meant the backend lost generated-file context after cold starts and could drift back toward inline regeneration behavior.
+
+## Impact
+
+- Generated files remain visible in the workspace/file manager while chat stays readable.
+- Backend artifact summaries survive session rehydration without depending on inline chat dumps.
+- Future backend/file-surface work should keep artifact payloads structured and avoid widening chat text with raw file contents.
+
+---
+
+### 2026-04-15T22:23:13.115Z: User directive
+**By:** sabbour-squad-frontend[bot] (via Copilot)
+**What:** Prioritize issues #333, #328, #327, #326 and related work first, then #331 and #332.
+**Why:** User request — captured for team memory
+
+---
+
+### 2026-04-15T22:27:37.636Z: User directive
+**By:** sabbour-squad-frontend[bot] (via Copilot)
+**What:** Track priority order on the GitHub issues themselves; Git is the source of truth.
+**Why:** User request — captured for team memory
+
+---
+
+# Decision: Keep non-runtime files and `bicep-node` out of SWA function startup
+
+**Date:** 2026-04-15T16:06:15Z  
+**Author:** Bender (Backend Dev)  
+**Status:** Implemented
+
+## Context
+
+The live Static Web App was returning 404 for anonymous API routes like `/api/health` and `/api/github-auth/callback` even though the latest `deploy-swa.yml` run succeeded and the frontend auth layer was still active.
+
+The deploy log for commit `d936a67` showed the API build bundling **18 function entrypoints**. One of those files was `packages/web/api/src/functions/converse.test.ts`, and importing the built `dist/functions/converse.test.js` outside Vitest immediately threw `Vitest mocker was not initialized in this environment`. The same startup sweep also failed when `bicep-node` was inlined into `azure-deployments.js`, throwing `Dynamic require of "os" is not supported`.
+
+## Decision
+
+1. **Exclude test/spec files from API entrypoints** — `packages/web/api/esbuild.config.mjs` must not bundle `*.test.ts` or `*.spec.ts` from `src/functions/`.
+2. **Keep `bicep-node` external** — the API bundle must leave `bicep-node` in `node_modules` instead of inlining it into the ESM function entrypoints.
+
+## Why
+
+Azure Functions v4 loads every file matched by the `package.json` `main` glob at startup. Any bundled file that throws during import prevents handler registration for the whole managed API, which shows up at the edge as repo-correct routes returning 404.
+
+## Evidence
+
+- Latest SWA deploy log: `✅ Bundled 18 function(s) to dist/functions/`
+- `git ls-tree origin/main packages/web/api/src/functions` included `converse.test.ts`
+- Reproduced crash by importing the built test bundle:
+  - `Vitest mocker was not initialized in this environment. vi.queueMock() is forbidden.`
+- Reproduced crash by importing the bundled Azure deployment entrypoint before externalizing `bicep-node`:
+  - `Dynamic require of "os" is not supported`
+
+## Consequences
+
+- Managed Functions startup now only imports real runtime entrypoints.
+- Azure deployment routes can still use `bicep-node`, but only through the runtime dependency in `node_modules`.
+- Future API tests can stay near the functions code, but the build must continue filtering non-runtime files out of the startup glob.
+
+---
+
+---
+# Decision: Secure ELK ArchitectureDiagram contract
+
+**Date:** 2026-04-15T15:20:24Z
+**Author:** Fry (Frontend Dev)
+**Status:** Implemented
+
+## Context
+
+Issue #273 needed the real try-aks architecture diagram path: ELK layout, Azure/Kubernetes icons, nested group boundaries, and multiline subtitles. The existing renderer already had safe Mermaid handling, so the key trade-off was how to add the richer visuals without weakening the security posture or shipping fake icon heuristics.
+
+## Decision
+
+1. **`diagram` is the v1 contract.** `ArchitectureDiagram` should prefer raw Mermaid text with nested subgraphs, while `nodes`/`edges` remain a legacy fallback for simple graphs.
+2. **Renderer posture stays strict.** Keep `securityLevel: 'antiscript'`, preserve `sanitizeDiagramInput()`, and expand `%%icon:name%%` placeholders only after render with a strict allowlist.
+3. **Registry-backed icons or plain text — never fake guesses.** Use the shared adaptive-ui icon registry for supported keys; if a shared icon is missing, render the label without an icon instead of mapping to a local keyword-based placeholder.
+
+## Consequences
+
+- Prompt, schema, catalog, and demo updates should emit `diagram`, `title`, and `description` so the model and demos use the grouped architecture path consistently.
+- Reusable renderer helpers live in `packages/web/src/catalog/components/architectureDiagramUtils.ts`.
+- Web-only type shims in `packages/web/src/types/` are acceptable when source-published packages expose more TypeScript surface area than the renderer actually needs.
+
+---
+
+# Fry decision — file surface fix
+
+- **Date:** 2026-04-15T21:57:48.087Z
+- **Issue:** #333
+- **Decision:** Keep the current duplicate-file-surface work anchored to #333 as a narrow bug-fix lane. In chat mode, the workspace/file manager remains the canonical generated-file surface; do not mount the legacy `FileEditor` / `FileTreePanel` layout alongside `FileManagerSidebar` / `FileViewer`, and do not fold blocked #326 proposal changes into this fix.
+- **Why:** The user-visible bug is duplicate file chrome plus artifact leakage into chat, not a request for a broader multi-surface redesign. Keeping the fix scoped to the active bug issue lets us stabilize current behavior without importing unapproved proposal-lane changes.
+
+---
+
+---
+
+# Decision: Issue #271 — Real flow termination with project download
+
+**Date:** 2026-04-15T08:39:29.427Z
+**Author:** Leela (Lead)
+**Issue:** #271 — Deployment flow is blocked
+**Status:** Proposed
+**Supersedes:** `leela-271-deployment-flow.md` (demo-only stopgap)
+
+## Problem
+
+The onboarding flow enters HANDOFF (Step 5) and DEPLOY (Step 6) phases
+that have no working backend. Users see fake "repo created" cards, "Deploy
+now" buttons, and sign-in prompts that lead nowhere. The flow is a dead end.
+
+**Corrected root cause:** The issue claims AuthCard is unregistered. That is
+wrong — AuthCard is fully registered in the React catalog, component-catalog,
+and a2ui-schema. The real problem is the flow reaches phases that pretend
+work is happening when there is no backend to execute it.
+
+## What Actually Exists (Infrastructure Audit)
+
+| Capability | Status | Evidence |
+|------------|--------|----------|
+| Phase engine (state machine) | ✅ Real | `engine/machine.ts` — `transition()` handles ADVANCE, SKIP, PHASE_COMPLETE |
+| LLM conversation | ✅ Real | `/api/converse` → Azure OpenAI, phase-aware prompt injection |
+| File generation | ✅ Real | LLM generates files → VirtualFS (IndexedDB) + VirtualFileSystem (memory) |
+| ZIP export | ✅ Real | `VirtualFS.exportZip()` via JSZip, buttons in FileTreePanel + FileManagerSidebar |
+| SWA AAD auth | ✅ Real | `/.auth/me`, `/.auth/login/aad` — fully functional |
+| AuthCard component | ✅ Real | Renders, handles sign-in/sign-out, falls back to stub mode gracefully |
+| DeploymentProgress component | ✅ Real | Renders step tracker with status icons |
+| GitHub connector | ⚠️ Scaffolded | `createRepo()`, `listUserRepos()` exist but no token provider is wired |
+| GitHub OAuth proxy | ⚠️ Scaffolded | `/api/github-oauth` Azure Function exists, proxies device flow to github.com |
+| GitHub OAuth App | ❌ Missing | No `GITHUB_CLIENT_ID` in any config, env, or secret reference |
+| GitHub file push | ❌ Missing | `GitHubConnector` has no `pushTree()`/`createCommit()` method |
+| Azure ARM connector | ⚠️ Scaffolded | Real ARM methods exist but no MSAL token provider is wired |
+| Azure deployment | ❌ Missing | No resource provisioning logic anywhere |
+
+## Options Evaluated
+
+### Option A: Wire GitHub OAuth + create repo + push files
+- Wire `/api/github-oauth` to GitHubLoginCard (real device codes)
+- Add `setTokenProvider()` in web layer after token acquisition
+- Add `pushTree()` to GitHubConnector (GitHub Trees/Blobs API)
+- Make HANDOFF real, remove DEPLOY
+
+**Verdict: BLOCKED.** No GitHub OAuth App is registered — no `GITHUB_CLIENT_ID`
+exists in any config or secret. The device flow proxy exists but has no app to
+authenticate against. This is infrastructure work (register OAuth App, store
+secrets in SWA, configure scopes) that must happen before code changes.
+
+### Option B: End at REVIEW with real project download
+- Make REVIEW the terminal phase in the engine (`nextPhase: null`)
+- System prompt ends with "Your project is ready — download your files"
+- LLM shows completion summary with download CTA
+- Users get their actual LLM-generated files as a ZIP
+- Remove HANDOFF + DEPLOY from prompt and demo scenarios
+
+**Verdict: SHIP THIS.** Every piece is real and working. No fake data, no stubs.
+The user walks away with actual deployment artifacts generated by the LLM.
+
+### Option C: Full Azure deployment
+**Verdict: WAY TOO BIG.** ARM provisioning = resource groups, ACR, AKS, networking,
+OIDC federation. Not an issue-271 fix.
+
+## Decision: Ship Option B, file follow-up for Option A
+
+### What #271 delivers (real, functioning)
+
+The onboarding flow completes at REVIEW with a **"Your Project Is Ready"**
+experience. The user downloads their generated files as a ZIP. Every step in
+the flow (discover → design → generate → review → download) is backed by real
+code — no fake data, no placeholder URLs, no pretend deployments.
+
+### Changes required (5 files, ordered)
+
+| # | File | Change | Why |
+|---|------|--------|-----|
+| 1 | `packages/core/src/engine/phases.ts` | Set Review `nextPhase: null` (was `Phase.Handoff`). | Engine formally ends at REVIEW. Machine sets `isComplete: true`. |
+| 2 | `packages/core/src/prompts/system-prompt.ts` | **Remove** STEP 5 (HANDOFF) and STEP 6 (DEPLOY). **Rewrite** STEP 4 (REVIEW) as terminal: after approval, show "Your Project Is Ready" Card with Markdown summary of generated files + a primary Button labeled "Download project" with action `{"event":{"name":"download-project"}}`. **Remove** Example 6 (handoff). **Update** Example 5: replace "Approve and continue to handoff" with completion summary + download CTA. **Add guardrail** in section 2: "The flow ends at REVIEW. Do not enter handoff or deploy phases — they are not yet implemented. After the user approves the review, show a session-complete summary and direct them to download their project files." |
+| 3 | `packages/web/src/services/demo-scenarios.ts` | **Replace** `HANDOFF` const with a `SESSION_COMPLETE` response: success Badge, file-count summary, "Download project" Button (action: `download-project`), Accordion with next-steps (clone, customize, deploy later). **Remove** `DEPLOY_PROGRESS` const. **Update** `scenarioFlow` array: end at `SESSION_COMPLETE` (drop DEPLOY_PROGRESS). **Update** SCENARIOS keyword routing: remove deploy/handoff matchers, add `complete\|done\|finish\|download` → SESSION_COMPLETE. **Update** CONFIGURE_FORM: ProgressSteps "Deploy" label → "Review". |
+| 4 | `packages/web/src/App.tsx` | Wire the `download-project` A2UI action event to the existing `handleDownloadZip` callback. When the chat receives a button click with event name `download-project`, call `handleDownloadZip()`. |
+| 5 | `packages/core/src/engine/types.ts` | No code change needed — `Phase.Handoff` and `Phase.Deploy` enum values stay (they may be referenced in tests/playground). Add a TSDoc comment: `/** @deprecated Not yet implemented — flow ends at Review. */` to Handoff and Deploy. |
+
+### Follow-up issue (file after #271 ships)
+
+**Title:** "feat: Wire real GitHub OAuth handoff — device flow + repo creation + file push"
+**Scope:**
+1. Register a GitHub OAuth App, store `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` in SWA app settings
+2. Wire `GitHubLoginCard` to call `/api/github-oauth/login/device/code` for real device codes
+3. Add `setTokenProvider()` integration: after token exchange, inject token into GitHubConnector
+4. Add `pushTree(owner, repo, files)` to `GitHubConnector` using GitHub Git Trees/Blobs API
+5. Re-enable HANDOFF phase in system prompt with real capabilities
+6. Consider: should HANDOFF become a second terminal phase (Review OR Handoff), or always flow through?
+**Blocked by:** GitHub OAuth App registration (infra/ops task for Ahmed)
+
+### Defer (do NOT touch in #271)
+
+- **AuthCard / GitHubLoginCard** — work correctly, keep for future OAuth.
+- **DeploymentProgress** — works correctly, reusable for future deploy phase.
+- **a2ui-schema.ts / component-catalog.ts** — no changes needed.
+- **playground-scenarios.ts** — separate component showcase, not user-facing flow.
+- **Phase enum values** (Handoff, Deploy) — keep in enum, mark deprecated.
+
+## Acceptance Bar
+
+1. **End-to-end flow works:** Discover → Design → Generate → Review → "Your Project Is Ready" → Download ZIP.
+2. **ZIP contains real files:** Generated by the LLM (not placeholder content). In demo mode, contains the demo file set.
+3. **No dead ends:** Every screen has an action the user can take.
+4. **No fake data:** No "github.example.com", no "7 resources provisioned", no "Created repo" badges for repos that don't exist.
+5. **Engine state:** After review approval, `isComplete === true`.
+6. **Tests pass:** `npm run build && npm test` green.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `download-project` event not caught by existing action handler | Medium | Medium — button click does nothing | Wire explicitly in App.tsx; fall back to opening FileTreePanel if VFS is empty |
+| LLM still tries to enter handoff despite guardrail | Low | Low — user sees unrendered phase | Engine `nextPhase: null` prevents machine from advancing past review regardless of LLM output |
+| Demo scenarios reference removed constants | Low | High — build break | Search for all HANDOFF/DEPLOY_PROGRESS references before removing |
+
+## Needs Sign-Off
+
+- **Ahmed Sabbour** — confirm "download project" is acceptable as #271 scope; confirm GitHub OAuth App registration goes into a follow-up issue.
+
+---
+
+---
+
+# Decision: Issue #271 — Ship complete flow with real project delivery
+
+**Date:** 2026-04-15T08:39:29.427Z
+**Author:** Leela (Lead)
+**Issue:** #271 — Deployment flow is blocked
+**Status:** Proposed
+**Supersedes:** `leela-271-deployment-flow.md` (v1), `leela-271-deployment-flow-v2.md` (v2)
+
+---
+
+## 1. Why v1 and v2 Were Insufficient
+
+v1 proposed removing fake screens. v2 proposed ending at Review with ZIP
+download. Both are defensible but fall short of "fully functional, ship-ready."
+They treat #271 as damage control. This v3 treats it as a product release.
+
+## 2. Functional Scope #271 Must Deliver
+
+**A complete, working Kickstart flow where every step produces real output
+and the user walks away with a real deliverable.**
+
+```
+DISCOVER → DESIGN → GENERATE → REVIEW → PROJECT DELIVERY
+```
+
+| Step | What Happens | Real? |
+|------|-------------|-------|
+| DISCOVER | LLM asks about app type, runtime, existing code | ✅ Real (Azure OpenAI) |
+| DESIGN | LLM proposes architecture, cost estimate | ✅ Real (Pricing API for costs) |
+| GENERATE | LLM generates Dockerfile, manifests, CI/CD, app code | ✅ Real (stored in VirtualFS/IndexedDB) |
+| REVIEW | Architecture recap, cost recap, best-practice audit | ✅ Real |
+| PROJECT DELIVERY | User downloads ZIP of generated files | ✅ Real (JSZip exportZip()) |
+
+**What gets removed:** HANDOFF (Step 5) and DEPLOY (Step 6) — the two phases
+with zero working backend.
+
+**Why this is not a stopgap:** This is the product. A guided project generator
+that gives you deployment-ready files. The same model as `create-react-app`,
+`yo`, Spring Initializr. The flow is complete, every step is backed by real
+infrastructure, and the user gets a real deliverable.
+
+## 3. What Exists vs. What's Missing
+
+### Already built and working
+
+| Capability | Location | Status |
+|------------|----------|--------|
+| Phase state machine | `core/engine/machine.ts` | ✅ `transition()` handles ADVANCE, sets `isComplete` when `nextPhase === null` |
+| LLM conversation backend | `web/api/functions/converse.ts` | ✅ Azure OpenAI with phase-aware prompt |
+| File generation + storage | `web/services/virtual-fs.ts` | ✅ VirtualFS (IndexedDB) + VirtualFileSystem (memory) |
+| ZIP export | `VirtualFS.exportZip()` + JSZip | ✅ Used by FileTreePanel + FileManagerSidebar |
+| Download handler | `App.tsx:386-398` (`handleDownloadZip`) | ✅ Creates blob URL, triggers download |
+| Action dispatch system | `hooks/useActionDispatch.ts` | ✅ Prefix-based routing: reply, navigate, auto-continue, api |
+| A2UI component catalog (28 components) | `core/prompts/component-catalog.ts` | ✅ All registered, including AuthCard + DeploymentProgress |
+| Phase indicator UI | `converse.ts:237-248` | ✅ Shows all phases with status |
+| Demo scenario engine | `web/services/demo-scenarios.ts` | ✅ Keyword matching + sequential flow |
+
+### Missing (must build in #271)
+
+| Gap | What to Build | Effort |
+|-----|--------------|--------|
+| Review is not terminal | Set `Review.nextPhase = null` in `phases.ts` | 1 line |
+| System prompt goes past Review | Remove STEP 5/6, add completion CTA to STEP 4 | Medium (prompt editing) |
+| No `client:` action prefix | Add `client:` category to `useActionDispatch.ts` for client-side actions (download, open panel) | ~15 lines |
+| App.tsx not wired for client actions | Add `onClientAction` callback to useActionDispatch options | ~10 lines |
+| Demo scenarios show fake handoff/deploy | Replace HANDOFF + DEPLOY_PROGRESS with SESSION_COMPLETE | Medium |
+| Tests assert 6-phase chain | Update to 4-phase chain (Discover→Design→Generate→Review) | 3 test files |
+| Review example button says "continue to handoff" | Change to "Download your project" with `client:download-project` action | 1 change in prompt |
+
+### Not in #271 (follow-up issues)
+
+| Feature | Blocker | Follow-Up |
+|---------|---------|-----------|
+| GitHub OAuth handoff | No `GITHUB_CLIENT_ID` registered anywhere. `/api/github-oauth` proxy exists but has no OAuth App to authenticate against. GitHubConnector has `createRepo()` but no `pushTree()` for multi-file commits. | New issue: register OAuth App (infra), implement pushTree, wire device flow |
+| Azure ARM deployment | No MSAL token provider wired. AzureARMConnector methods exist but return stubs. No resource provisioning logic. | Future milestone |
+
+## 4. Implementation Sequence
+
+### Bender (backend + engine): Changes 1-3
+
+**Change 1: `packages/core/src/engine/phases.ts`**
+- Line 80: Change `nextPhase: Phase.Handoff` → `nextPhase: null`
+- This makes Review the terminal phase. When the engine ADVANCEs from Review,
+  `machine.ts:49-53` sets `isComplete = true`.
+- Keep Handoff and Deploy phase definitions in the array (tests/playground
+  reference them, and they'll be re-enabled when infra is ready).
+
+**Change 2: `packages/core/src/prompts/system-prompt.ts`**
+- Remove STEP 5 (HANDOFF, ~lines 147-150) and STEP 6 (DEPLOY, ~lines 152-156).
+- Rewrite STEP 4 (REVIEW) as the terminal step. After the user approves:
+  - Show "Your Project Is Ready" Card with:
+    - Success Badge
+    - Markdown summary of generated files
+    - Primary Button: "Download project" with action
+      `{"event":{"name":"client:download-project","context":{"label":"Download project"}}}`
+    - Accordion with next steps: "Run locally", "Push to GitHub manually", "Deploy later"
+  - Set `phaseComplete: true` so the engine marks the conversation complete.
+- Add guardrail in section 2 (conversation flow): "The flow ends at REVIEW.
+  After the user approves, show a project-complete summary with a download
+  action. Do not enter handoff or deploy phases."
+- Remove Example 6 (handoff repo picker, ~line 290-291).
+- Update Example 5 (review): Replace "Approve and continue to handoff" button
+  with completion summary + download CTA using `client:download-project`.
+- In section 2a (ARCHITECT MINDSET, line 167): soften "MUST include a GitHub
+  Actions workflow" to "SHOULD include a CI/CD workflow" since we're not
+  pushing to GitHub yet.
+
+**Change 3: `packages/core/src/engine/types.ts`**
+- Add TSDoc deprecation markers to Handoff and Deploy enum members:
+  ```typescript
+  /** @deprecated Not yet implemented — flow currently ends at Review. */
+  Handoff = "handoff",
+  /** @deprecated Not yet implemented — flow currently ends at Review. */
+  Deploy = "deploy",
+  ```
+
+### Fry (frontend): Changes 4-6
+
+**Change 4: `packages/web/src/hooks/useActionDispatch.ts`**
+- Add `client:` prefix to PREFIX_MAP (line 26-31):
+  ```typescript
+  'client:': 'client',
+  ```
+- Add `'client'` to ActionCategory type (line 23).
+- Add `onClientAction` to ActionDispatchOptions (line 115-135):
+  ```typescript
+  /** Callback for client-side actions (download, open panel, etc.). */
+  onClientAction?: (operation: string, context: Record<string, unknown>) => void;
+  ```
+- Add case in switch (after line 325):
+  ```typescript
+  case 'client': {
+    consecutiveRef.current = 0;
+    setConsecutiveAutoContinueCount(0);
+    const operation = action.name.replace(/^client:/, '');
+    const safeContext = sanitizeActionContext(action.context);
+    logDebug(operation);
+    optionsRef.current.onClientAction?.(operation, safeContext);
+    break;
+  }
+  ```
+
+**Change 5: `packages/web/src/App.tsx`**
+- Wire `onClientAction` in the `useActionDispatch` call (~line 53-58):
+  ```typescript
+  onClientAction: (operation) => {
+    if (operation === 'download-project') {
+      handleDownloadZip();
+    }
+  },
+  ```
+- This connects the LLM's "Download project" button directly to the existing
+  `handleDownloadZip()` (line 386-398) which calls `vfs.exportZip()`.
+
+**Change 6: `packages/web/src/services/demo-scenarios.ts`**
+- Replace `HANDOFF` const (line 225-264) with `SESSION_COMPLETE`:
+  ```typescript
+  const SESSION_COMPLETE: DemoResponse = {
+    text: "Your project is ready! All files have been generated...",
+    phase: 'review',
+    model: 'gpt-5.3-chat',
+    typingDelay: 1400,
+    a2uiMessages: surface('complete-surface', [
+      // Success card with Badge, file summary, download button, next-steps accordion
+    ]),
+  };
+  ```
+- Remove `DEPLOY_PROGRESS` const (line 266-312).
+- Update `scenarioFlow` (line 442): Replace `HANDOFF, DEPLOY_PROGRESS` with
+  `SESSION_COMPLETE`. Final array:
+  `[ARCHITECTURE, DESIGN_DETAIL, CONFIGURE_FORM, CODE_PREVIEW, FILE_GENERATION, REVIEW_EXPANDED, SESSION_COMPLETE]`
+- Update SCENARIOS keyword routing (line 404-413):
+  - Remove: `{ match: /deploy|ship|launch|go live/i, response: DEPLOY_PROGRESS }`
+  - Remove: `{ match: /handoff|github|repo|push|codespace/i, response: HANDOFF }`
+  - Add: `{ match: /complete|done|finish|download|ready/i, response: SESSION_COMPLETE }`
+- Update CONFIGURE_FORM ProgressSteps (line 325): "Deploy" → "Review".
+
+### Bender or Fry: Change 7
+
+**Change 7: Update tests (3 files)**
+
+a) `packages/core/src/__tests__/machine.test.ts`
+- Lines 41-56: Update ADVANCE chain test. After Review ADVANCE, expect
+  `isComplete === true` (not transition to Handoff).
+- Lines 150-176: Update full journey test. Chain is now 4 phases:
+  Discover → Design → Generate → Review → isComplete.
+
+b) `packages/core/src/__tests__/phases.test.ts`
+- Lines 52-63: Update phase chain test. Review should have
+  `nextPhase === null`. Handoff/Deploy still exist in definitions but are
+  no longer in the active chain.
+- Line 60: "last phase (Deploy) has nextPhase = null" → update assertion
+  to also verify Review has nextPhase = null.
+
+c) `packages/mcp-server/src/__tests__/action.test.ts`
+- Lines 156-171: Update full journey test. Advance through 4 phases
+  (Discover → Design → Generate → Review), verify isComplete after Review.
+
+## 5. Risks and Blockers
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|------------|
+| R1 | LLM ignores guardrail and tries to enter Handoff despite prompt changes | Low | Low | Engine enforces: Review.nextPhase=null means machine cannot advance past Review regardless of LLM output. Defense in depth. |
+| R2 | `client:download-project` action not fired because Button schema doesn't support `client:` prefix | Low | High | Verify A2UI action schema accepts any string for event name (it does — ActionSchema uses z.string()). Test E2E. |
+| R3 | VirtualFS empty when user clicks download (no files generated in demo mode) | Medium | Medium | Check `vfs.list().length > 0` before triggering download. If empty, show toast/message "No files to download." |
+| R4 | Existing test suites fail after phase chain change | Certain | Low | Changes 7a-7c update all affected tests. No E2E tests walk past Review (confirmed by audit). |
+| R5 | Playground scenarios (`playground-scenarios.ts`) reference Deploy | Low | None | Playground is a component showcase, not the user flow. Deploy references there are fine — they demo the DeploymentProgress component. |
+| R6 | `phaseComplete: true` from LLM after Review triggers unexpected UI behavior | Low | Medium | Verify client handles `isComplete` gracefully. Phase indicator should show "Complete" state. |
+
+**Hard blocker: None.** All infrastructure exists. This is a wiring + prompt task.
+
+## 6. Acceptance Bar
+
+1. **Complete flow E2E**: Discover → Design → Generate → Review → "Your Project Is Ready" → click "Download project" → ZIP downloads with generated files.
+2. **Demo mode works**: Sequential scenario flow reaches SESSION_COMPLETE, download button fires.
+3. **No dead ends**: Every screen has an actionable next step.
+4. **No fake data**: Zero instances of "github.example.com", "7 resources provisioned", "my-awesome-app" fake repo URLs, or "Deploy now" buttons.
+5. **Engine state correct**: After Review approval, `engineState.isComplete === true`.
+6. **All tests green**: `npm run build && npm test` pass, including updated phase chain tests.
+7. **Guardrail holds**: LLM prompt explicitly prevents entering Handoff/Deploy; engine enforces mechanically via `nextPhase: null`.
+
+---
+
+---
+
+# Decision: Stop the flow before handoff/deploy — Issue #271
+
+**Date:** 2026-04-15T08:39:29.427Z
+**Author:** Leela (Lead)
+**Issue:** #271 — Deployment flow is blocked
+**Status:** Proposed
+
+## Problem
+
+The onboarding flow enters HANDOFF (STEP 5) and DEPLOY (STEP 6) phases
+that have **no backend implementation**. Users see fake "repo created" cards,
+"Deploy now" buttons, and AuthCard sign-in prompts that lead nowhere.
+This is a dead end — the demo cannot proceed past file generation.
+
+The issue text claims AuthCard is unregistered. **That is wrong.** AuthCard
+exists in the React catalog, component-catalog, and a2ui-schema. It renders
+fine. The problem is the flow reaches phases that pretend real work is
+happening when it is not.
+
+## Root Causes
+
+1. **System prompt instructs LLM to enter unimplemented phases.**
+   STEP 5 (HANDOFF) and STEP 6 (DEPLOY) describe GitHub repo creation
+   and Azure deployment flows backed by no real service.
+2. **Demo scenarios include HANDOFF and DEPLOY_PROGRESS responses.**
+   Fake repo URLs, fake "7 resources provisioned" progress, and "Deploy now"
+   buttons that fire events no handler catches.
+3. **Review example ends with "Approve and continue to handoff"**
+   leading directly into the dead end.
+4. **CONFIGURE_FORM ProgressSteps** includes a "Deploy" step label
+   that implies deployment exists.
+
+## Decision: End the flow at REVIEW
+
+### Ship now (3 changes)
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `packages/core/src/prompts/system-prompt.ts` | Remove STEP 5 (HANDOFF) and STEP 6 (DEPLOY) from the conversation flow. Make REVIEW the terminal step. Replace the "Approve and continue to handoff" button in Example 5 with a "Session complete" summary. Remove Example 6 (handoff). Add an explicit guardrail: the LLM must NOT enter handoff or deploy phases. |
+| 2 | `packages/web/src/services/demo-scenarios.ts` | Replace HANDOFF with a "Session Complete" summary (no fake repo/deployment). Remove DEPLOY_PROGRESS. Update `scenarioFlow` to end at REVIEW_EXPANDED. Remove keyword routing for deploy/handoff to fake screens. Remove the "Deploy" step from CONFIGURE_FORM ProgressSteps. |
+| 3 | `packages/web/src/services/demo-scenarios.ts` | In CONFIGURE_FORM, change ProgressSteps "Deploy" to "Review" so the step tracker does not promise deployment. |
+
+### Defer (do NOT touch)
+
+- **AuthCard component** — works correctly, keep for future Azure auth.
+- **DeploymentProgress component** — works correctly, keep for future use.
+- **a2ui-schema.ts / component-catalog.ts** — no changes needed.
+- **playground-scenarios.ts** — separate concern; many deploy references,
+  but it's a component playground, not the user-facing onboarding flow.
+
+## Acceptance Bar
+
+1. Walk through the demo flow end-to-end. After REVIEW, the user sees a
+   "session complete" summary with next steps (not handoff/deploy).
+2. No "Deploy now", "Open in Codespaces", or fake repo cards appear.
+3. The LLM never enters handoff/deploy phases (verified by prompt guardrail).
+4. All existing tests pass (`npm run build && npm test`).
+
+## Consequences
+
+- Users can complete the demo without hitting a dead end.
+- Deployment/handoff features can be re-added when backend support exists
+  (AuthCard, DeploymentProgress, and schema entries remain intact).
+- The system prompt shrinks slightly, reducing token spend per request.
+
+## Needs Sign-Off
+
+- **Ahmed Sabbour** — product scope confirmation (ending at review is acceptable).
+
+---
+
+---
+
+# Decision: E2E Demo Sprint Plan — No Faking, No Mocking
+
+**Date:** 2026-04-15T09:34:03.404Z
+**Updated:** 2026-04-15T09:34:03.404Z
+**Author:** Leela (Lead)
+**Status:** Active (v3 — scope expanded per Ahmed directive)
+**Scope:** Sprint plan for making Kickstart end-to-end demo ready with real integrations
+
+---
+
+## Goal
+
+A user walks through Kickstart from "describe your app" through file generation, GitHub repo creation, and Azure deployment — **zero fakes, zero mocks, zero dead ends.** Full pipeline, all real.
+
+## Scope (Revised)
+
+~~**v1 scope trade:** Demo ended at PR creation. Azure bits deferred.~~
+
+**v3 scope (current):** Full E2E including Azure auth and deployment. Ahmed's directive: "include the Azure bits too." The GitHub OAuth App now exists — #274 is unblocked. No more external blockers.
+
+**Demo flow target:**
+```
+DISCOVER → DESIGN → GENERATE → REVIEW → HANDOFF (GitHub) → DEPLOY (Azure)
+```
+
+Every phase backed by real infrastructure. Handoff/Deploy re-enabled conditionally (only when auth tokens are present).
+
+---
+
+## What Already Shipped / Ships Now
+
+### PR #297 — Ship Immediately (Option A)
+
+| Closes | What it does |
+|--------|-------------|
+| **#271** | Makes Review terminal (`nextPhase = null`), adds `client:download-project` action routing, wires ZIP download. No more dead-end screens. |
+| **#269** | Prompt guardrail: LLM cannot hallucinate "repo created" cards. Engine prevents reaching Handoff/Deploy. |
+
+**Action:** Merge PR #297 now. It's the safety net — users get a clean flow even before GitHub/Azure integration lands. Handoff/Deploy phases are deprecated but retained in code, ready for conditional re-enablement.
+
+---
+
+## Priority Tiers
+
+### TIER 1 — Foundation (blocks everything else)
+
+| # | Issue | Type | Why it's first |
+|---|-------|------|----------------|
+| 1 | **PR #297** | Fix (critical) | Merge now. Stops the dead-end flow. Closes #271, #269. Foundation for everything below. |
+| 2 | **#298** — Chat surface ownership + phase bar regression | Bug (critical) | Surfaces mutate earlier turns, phase bar doesn't render. Every other issue touches chat rendering. |
+
+### TIER 2 — Demo Spine (the real flow)
+
+| # | Issue | Type | Depends on | Why this order |
+|---|-------|------|------------|----------------|
+| 3 | **#275** — Progressive conversation flow | Feature (critical) | #298 | The wizard skeleton. One-step-at-a-time pacing, phase state tracking. Must work for both current 4-phase flow AND future 6-phase flow when Handoff/Deploy re-activate. |
+| 4 | **#274** — GitHub OAuth + real repo flow | Feature (high) | #298 | **UNBLOCKED — OAuth App exists.** Real sign-in, org selection, repo creation, file commit, PR. Re-enables Handoff phase conditionally. Needs Zapp security review. |
+| 5 | **NEW** — Azure MSAL auth + AKS deployment flow | Feature (high) | #274 | Azure device-code/browser auth via MSAL. ARM API calls for AKS Automatic provisioning. Re-enables Deploy phase conditionally. **Needs issue creation.** Needs Zapp security review. |
+
+**The #269/#271/#274 cluster is now resolved:** #269 and #271 closed by PR #297. #274 stands alone as real GitHub integration (unblocked).
+
+### TIER 3 — Demo Polish (parallel track)
+
+| # | Issue | Type | Depends on | Notes |
+|---|-------|------|------------|-------|
+| 6 | **#265** — File manager experience | Feature | #298 | Wire generated files into FileManagerSidebar, compact file list in chat. |
+| 7 | **#300** — Architecture diagram prompt-layer depth | Feature | none | Prompt-only fix: AKS subgraphs, ACR, Key Vault, Gateway. Quick win, ships before #273. |
+| 8 | **#273** — Architecture diagram (ELK + icons) | Feature | none | ELK layout engine, Azure icons, zoom. Benefits from #300 landing first. |
+| 9 | **#299** — Debug action-event placement | Bug | none | Move debug output to separate panel. Quick fix. |
+| 10 | **#296** — Subtitle 1 title sweep | Bug | none | Typography normalization across 11 components. Quick fix. |
+
+### TIER 4 — Deferred (after E2E works)
+
+| # | Issue | Type | Why defer |
+|---|-------|------|-----------|
+| 11 | **#272** — Live Azure pricing | Feature | "Not a demo blocker" per issue. Estimated pricing acceptable for demo. |
+| 12 | **#277** — Session token/cost tracker | Feature | "Not a blocker" per issue. Nice-to-have for cost demos. |
+
+---
+
+## Dependency Graph
+
+```
+PR #297 (merge now) ─── closes #271, #269
+  │
+#298 (surface ownership)
+  ├── #275 (progressive flow) ──────────────────┐
+  ├── #274 (GitHub OAuth — UNBLOCKED) ──────────┤── re-enable Handoff
+  ├── #265 (file manager)                       │
+  │                                             ├── NEW: Azure MSAL + AKS deploy
+  │                                             │        ── re-enable Deploy
+  #300 (arch diagram prompt) ── lands before ── #273 (arch diagram ELK)
+  #299 (debug placement) ──────(independent)
+  #296 (subtitle sweep) ───────(independent)
+```
+
+## Parallel Tracks
+
+After #297 merges and #298 lands:
+
+- **Track A (Wizard Flow):** #275 — Bender (prompt/backend) + Fry (frontend). Must design phase state to support conditional 4-phase or 6-phase flow.
+- **Track B (GitHub):** #274 — Bender (OAuth service, device flow, pushTree, GitHubConnector) + Fry (A2UI components: GitHubLoginCard, AccountSelector, RepoForm, CommitCard, PRCard) + Zapp (security review). Re-enables Handoff phase.
+- **Track C (Azure):** NEW — Bender (MSAL auth, ARM provisioning API, AKS Automatic resource creation) + Fry (AuthCard for Azure, DeploymentProgress with real status) + Zapp (security review). Re-enables Deploy phase.
+- **Track D (Polish):** #300, #265, #273, #296, #299 — interleaved with Tracks A–C.
+
+Tracks B and C can run in parallel once #298 and #275 are stable. Track C depends on Track B patterns (auth flow established by GitHub OAuth informs Azure auth structure).
+
+---
+
+## Execution Plan — Squad Assignment
+
+### Phase 0: Ship Now
+
+| Item | Assignee | Work |
+|------|----------|------|
+| **Merge PR #297** | **Leela** (approve) | Merge Option A. Review terminal, download action, prompt guardrails. Closes #271, #269. |
+
+### Phase 1: Foundation (Day 1)
+
+| Issue | Assignee | Work |
+|-------|----------|------|
+| **#298** | **Fry** | Fix surface ownership in useA2UI/useStreaming, restore phase bar rendering, turn-scoped surface IDs |
+| **#300** | **Bender** | Prompt-layer depth fix: system-prompt.ts, component-catalog.ts, demo-scenarios.ts. Ref: `/mnt/c/Users/asabbour/Git/adaptive-ui` |
+| **#296** | **@copilot** (Fry reviews) | Subtitle 1 sweep — 11 files, mechanical. |
+| **#299** | **@copilot** (Fry reviews) | Debug panel extraction — small, well-scoped. |
+
+### Phase 2: Core Flow (Day 1–2, starts when #298 merges)
+
+| Issue | Assignee | Work |
+|-------|----------|------|
+| **#275** | **Bender** (prompt + backend phase state) + **Fry** (frontend phase UI) | Progressive flow with phase state machine that supports conditional 4→6 phase expansion. Design phase transitions so Handoff/Deploy activate when auth tokens are present. |
+| **#274** | **Bender** (OAuth device flow, GitHub API service, GitHubConnector.pushTree) + **Fry** (GitHubLoginCard, AccountSelector, RepoForm, CommitCard, PRCard) | Full GitHub OAuth integration. Wire real device codes. Create repos, commit files, open PRs. Re-enable Handoff phase conditionally. Ref: `/mnt/c/Users/asabbour/Git/adaptive-ui`. **Zapp must review before merge.** |
+| **#265** | **Fry** | Wire VirtualFS → FileManagerSidebar, compact file cards in chat, progress card rename |
+
+### Phase 3: Azure Integration (Day 2–3, starts when #274 patterns are established)
+
+| Issue | Assignee | Work |
+|-------|----------|------|
+| **NEW: Azure auth + deploy** | **Bender** (MSAL device-code auth, ARM REST API for AKS Automatic, deployment status polling) + **Fry** (AuthCard Azure rendering, DeploymentProgress real status) | Azure MSAL auth flow. AKS Automatic cluster + ACR provisioning via ARM. Re-enable Deploy phase conditionally. Follow auth patterns from #274. **Zapp must review before merge.** |
+| **#273** | **Fry** (continued) | Finish ELK diagram. #300 should be merged by now. Ref: `/mnt/c/Users/asabbour/Git/adaptive-ui` |
+
+### Phase 4: Convergence + Ship (Day 3–4)
+
+| Task | Assignee |
+|------|----------|
+| E2E test: full 6-phase flow (Discover → Deploy) | **Hermes** |
+| Security review: #274 OAuth + Azure MSAL + ARM calls | **Zapp** |
+| Conditional flow test: 4-phase (no auth) vs 6-phase (auth present) | **Hermes** |
+| Final architecture review | **Leela** |
+| Release cut | **Bender** |
+
+---
+
+## Key Decisions
+
+1. **PR #297 ships now** — immediate safety net, closes #271 and #269.
+2. **Full E2E through Azure deployment is IN SCOPE** — scope trade reversed per Ahmed directive.
+3. **GitHub OAuth App exists** — #274 has no external blockers. Remove registration risk.
+4. **Azure auth/deploy needs a new issue** — Leela or Ahmed should create it, scoped to: MSAL auth, ARM provisioning, Deploy phase re-enablement.
+5. **Handoff/Deploy re-enabled conditionally** — phases activate only when auth tokens are present. 4-phase flow remains the default for unauthenticated users.
+6. **#275 must design for 6 phases** — progressive flow should account for the full pipeline, not just 4 phases.
+7. **#274 patterns inform Azure auth** — GitHub OAuth device flow establishes the auth UX pattern; Azure MSAL follows the same structure.
+8. **#272 and #277 remain deferred** — not demo blockers.
+9. **#296 and #299 are coding agent candidates** — mechanical, well-scoped, Fry reviews.
+10. **Zapp mandatory on #274 AND Azure auth** — both are security boundary crossings.
+11. **Try-AKS reference:** `/mnt/c/Users/asabbour/Git/adaptive-ui` for #273, #274, #275, #300, and Azure auth reference.
+
+---
+
+## Issue Hygiene — Action Items
+
+| Action | Owner |
+|--------|-------|
+| Merge PR #297 | Ahmed / Leela |
+| Create issue: "Azure MSAL auth + AKS Automatic deployment flow" | Leela (recommend) |
+| Update #274 description: remove "blocked by OAuth App registration" note | Leela |
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| ~~GitHub OAuth App registration missing~~ | ~~N/A~~ | ~~N/A~~ | **RESOLVED — App exists.** |
+| SWA auth proxy needs config for GitHub OAuth callback | Medium | High — blocks #274 | Bender investigates SWA auth config in Phase 2 day 1. Fallback: SWA built-in GitHub auth provider. |
+| Azure MSAL + ARM provisioning is larger than 1 sprint | Medium | Medium | Scope to AKS Automatic only (no custom clusters). Use ARM REST directly (no Terraform/Bicep in-app). Provisioning can be fire-and-forget with status polling. |
+| Progressive flow prompt changes break existing scenarios | Medium | Medium | Hermes runs regression tests after #275. Iterative prompt changes. |
+| ELK layout engine (#273) larger than estimated | Low | Low — not on critical path | Ship without ELK; Mermaid is functional. |
+| Surface ownership fix (#298) has deeper root cause | Low | High — blocks everything | Fry has context from #182. Escalate to pair debugging if stuck > 1 session. |
+| Conditional phase activation adds state complexity | Medium | Medium | Keep it simple: check for auth token presence at phase boundary. No complex feature flags. |
+
+---
+
+## Success Criteria
+
+A human can:
+1. Open Kickstart, describe an app
+2. See progressive guided conversation (one step at a time)
+3. See generated files in file manager sidebar (not dumped as code blocks)
+4. See architecture diagram with AKS subgraphs, ACR, Key Vault, Gateway
+5. Sign in to GitHub with real OAuth
+6. Select a real org, create a real repo, commit files, create a PR
+7. Sign in to Azure with real MSAL auth
+8. Provision AKS Automatic cluster + ACR via ARM
+9. See real deployment status (not fake progress cards)
+10. **Without auth:** Flow ends at Review with project download (PR #297 baseline)
+11. **With auth:** Full 6-phase flow through deployment
+12. Zero fake cards, zero dead ends, zero hallucinated success messages
+
+---
+
+# Decision: Priority Lane Tracking on GitHub Issues
+
+**Date:** 2026-04-15T22:27:37.636Z  
+**Author:** Leela (Lead)  
+**Status:** Implemented  
+
+## Context
+
+The team had priority lane information (P1 active lane, P2 deferred) tracked only in local squad notes. A reader on GitHub alone could not see why some issues were being worked first and others deferred.
+
+## Decision
+
+Encode priority lane structure directly on GitHub issues using a combination of **labels** and **cross-link comments**.
+
+### Labels
+
+- **Existing label `priority:p1`** ("This sprint") — already applied to #333, #328, #327, #326
+- **Existing label `priority:p2`** ("Next sprint") — applied to #331, #332 as the deferred lane
+
+### Cross-Link Comments
+
+Each of the 6 affected issues now carries a pinned comment listing:
+1. The issue's own position in the lane
+2. All related issues in the same lane (grouped by P1 and P2)
+3. The label convention used
+
+This makes the priority structure visible from any individual issue without requiring a user to navigate to local squad files or a GitHub project board.
+
+## Affected Issues
+
+**P1 Lane (Active):**
+- #333 — stabilize file surfaces (bug fix) ✅ `priority:p1`
+- #328 — keep setup generation in chat ✅ `priority:p1`
+- #327 — implement codex-backed setup ✅ `priority:p1`
+- #326 — design proposal for setup generation ✅ `priority:p1`
+
+**P2 Lane (Deferred):**
+- #331 — playground fat components validation ✅ `priority:p2`
+- #332 — real Azure/GitHub auth integration ✅ `priority:p2`
+
+## Why This Approach
+
+1. **Reuses existing taxonomy** — no new noisy labels invented; `priority:p2` was already defined but unused.
+2. **Visible on GitHub alone** — a reader viewing the issue page sees the full context without needing local notes.
+3. **Minimal, clear change** — comments are non-invasive; labels are the system of record.
+4. **Avoids project-board-only state** — the issue page itself carries the information.
+5. **Supports scale** — as more lanes emerge, this pattern extends naturally.
+
+## Implications
+
+- Users and team members can now look at any issue and understand its relative priority and related work
+- The label filters (`priority:p1`, `priority:p2`) work as expected for sorting/querying
+- Next sprint assignment happens at the label level, not in side notes
+- When an issue moves lanes, both the label and the cross-link comment should be updated
+
+## Related
+
+- User directive: "You need to track those priorities on the issues themselves. Git is the source of truth." (2026-04-15T22:27:37Z)
+- Historical pattern: Previously, priority was tracked in `.squad/decisions.md` sprint plan; now mirrored on GitHub for discoverability
+
+---
+
+---
+
+# Sprint Planning Ceremony — v0.6.1 (E2E Demo Ready)
+
+**Date:** 2026-04-15T10:11:35.848Z
+**Facilitator:** Leela (Lead)
+**Trigger:** Manual — Ahmed flagged overdue sprint-start ceremony
+**Sprint goal:** Burn down all 15 open issues. Ship Kickstart E2E demo with no faking or mocking.
+
+---
+
+## 1. Board Drift — Where Process Broke Down
+
+| Gap | Impact |
+|-----|--------|
+| **12 of 15 issues had no milestone** | Ralph can't burn down what isn't assigned to a sprint. No velocity tracking possible. |
+| **All issues had `go:needs-research` label** | Even in-flight work (#298, #299, #274) was still flagged as needing research. Label is meaningless if never cleared. |
+| **No priority labels on 11 of 15 issues** | Only #298, #299, #296, #301 had priority labels. Everyone guessed what was important. |
+| **#271 and #269 still open** | PR #297 closes both but wasn't merged. Two issues sitting open that have a ready fix. |
+| **No time estimates** | Ceremony requires calibrated estimates. We have none. Accepting this gap for now — estimate by T-shirt size below. |
+| **v0.6.0 milestone stale** | Only #46 (multi-week MCP epic) open on it. 2 issues closed. Milestone is functionally dead for this sprint. |
+
+**Fixes applied during this ceremony:**
+- ✅ All 13 demo-critical issues → v0.6.1 milestone
+- ✅ 2 deferred issues (#272, #277) → v0.7.0 milestone (created)
+- ✅ `go:needs-research` cleared on in-flight issues (#298, #299, #274, #296)
+- ✅ #46 stays on v0.6.0 (out of sprint scope)
+
+---
+
+## 2. Burndown — Full Issue Board
+
+### 🔥 BURN NOW — In Flight (do not interrupt)
+
+| # | Issue | Owner | Size | Status | Notes |
+|---|-------|-------|------|--------|-------|
+| PR #297 | **Leela** approve, **Ahmed** merge | — | Ready to merge | Closes #271 + #269. Merge immediately. |
+| #298 | **Fry** | M | Active (main worktree) | Surface ownership + phase bar. Foundational — blocks #275, #265. |
+| #299 | **Fry** or **@copilot** | S | Active (main worktree) | Debug panel extraction. Ship alongside #298. |
+| #274 | **Bender** (backend) + **Fry** (frontend) | L | Active (worktree) | GitHub OAuth. Unblocked — app exists. Zapp reviews before merge. |
+
+**Directive:** Let these 4 lanes finish. No context switches.
+
+### ⏭️ BURN NEXT — Queue when active lanes land
+
+| # | Issue | Owner | Size | Depends on | Sequence |
+|---|-------|-------|------|------------|----------|
+| #300 | **Bender** | S | None | Can start immediately — prompt-only fix, no frontend. |
+| #296 | **@copilot** (Fry reviews) | S | None | Mechanical sweep of 11 files. Fire-and-forget. |
+| #275 | **Bender** (prompt/state) + **Fry** (phase UI) | L | #298 merged | Design for conditional 4→6 phase flow. The wizard skeleton. |
+| #265 | **Fry** | M | #298 merged | File manager wiring. Can run parallel with #275. |
+| #266 | **Bender** | M | None | Phase-based model routing. Backend-only. Can run parallel with #275. |
+
+### 🔒 BLOCKED — Waiting on dependencies
+
+| # | Issue | Owner | Size | Blocked by | When it unblocks |
+|---|-------|-------|------|------------|------------------|
+| #301 | **Bender** (MSAL/ARM) + **Fry** (AuthCard/DeployProgress) | XL | #274 (auth patterns) + #275 (phase flow) | After GitHub OAuth patterns are proven. Zapp mandatory review. |
+| #273 | **Fry** | L | #300 (prompt depth) | After #300 lands. ELK engine swap benefits from richer diagram input. |
+
+### ✅ CLOSE — Resolved by in-flight work
+
+| # | Issue | Closed by |
+|---|-------|-----------|
+| #271 | PR #297 (merge now) |
+| #269 | PR #297 (merge now) |
+
+### 📦 DEFER — v0.7.0 (not demo-critical)
+
+| # | Issue | Why defer |
+|---|-------|-----------|
+| #272 | Live Azure pricing | Issue says "not a demo blocker." Estimated prices acceptable. |
+| #277 | Session token/cost tracker | Issue says "not a blocker." Nice-to-have. |
+| #46 | Multi-surface MCP | 3-4 week architecture epic. Wrong sprint for this. Stays on v0.6.0. |
+
+---
+
+## 3. Dependency Graph
+
+```
+PR #297 (MERGE NOW) ──── closes #271, #269
+
+#298 (surface fix) ─────┬── #275 (progressive flow) ─── #301 (Azure deploy)
+                        ├── #265 (file manager)
+                        │
+#274 (GitHub OAuth) ────┘── #301 (Azure deploy)
+                             │
+#300 (diagram prompt) ────── #273 (diagram ELK)
+
+#296 (subtitle sweep) ────── independent
+#299 (debug panel) ────────── independent
+#266 (model router) ────────── independent
+```
+
+## 4. Parallel Tracks (post BURN NOW completion)
+
+| Track | Issues | Lead | Fry | Bender | Zapp |
+|-------|--------|------|-----|--------|------|
+| **A: Wizard Flow** | #275, then #301 | Review | Phase UI | Prompt + state machine | Review #301 |
+| **B: GitHub** | #274 (finishing) | — | A2UI components | OAuth service | Review before merge |
+| **C: Azure** | #301 | — | AuthCard, DeployProgress | MSAL, ARM API | Mandatory review |
+| **D: Polish** | #265, #266, #273, #300, #296, #299 | — | #265, #273 | #266, #300 | — |
+| **E: Test** | All | — | — | — | — |
+
+Hermes enters after Track A + B land for E2E test pass.
+
+---
+
+## 5. Sprint Capacity (T-shirt estimates)
+
+| Agent | Burn Now | Burn Next | Blocked | Total |
+|-------|----------|-----------|---------|-------|
+| **Fry** | #298 (M), #299 (S), #274-frontend (L) | #275-frontend (L), #265 (M) | #301-frontend (L), #273 (L) | 3S + 3M + 3L |
+| **Bender** | #274-backend (L) | #300 (S), #275-backend (L), #266 (M) | #301-backend (XL) | 1S + 1M + 3L + 1XL |
+| **@copilot** | — | #296 (S) | — | 1S |
+| **Hermes** | — | — | E2E test pass (M) | 1M |
+| **Zapp** | — | — | #274 review (S), #301 review (M) | 1S + 1M |
+| **Leela** | PR #297 approval | Architecture reviews | Final review | Reviews only |
+
+**Fry is the bottleneck.** Almost every issue has frontend work. Mitigation: @copilot handles #296, #299 is a quick fix, #273 is back-loaded.
+
+---
+
+## 6. Next Wave for Ralph
+
+**Once current agents report back (PR #297 merged, #298/#299 done, #274 in progress):**
+
+```
+Wave 1: #300 (Bender), #296 (@copilot), #275 (Bender+Fry), #265 (Fry), #266 (Bender)
+         — all can start in parallel, no cross-dependencies
+Wave 2: #274 finishes → #301 (Bender+Fry), #300 finishes → #273 (Fry)
+         — blocked items unblock
+Wave 3: Hermes E2E test, Zapp security review of #274 + #301
+Wave 4: Leela final review → Bender release cut
+```
+
+**Ralph's immediate action list:**
+1. Monitor PR #297 merge → auto-close #271, #269
+2. Monitor #298, #299 completion → trigger Wave 1
+3. Fire Wave 1 items as parallel lanes: #300, #296, #275, #265, #266
+4. Monitor #274 completion → trigger #301
+5. Monitor #300 completion → trigger #273
+6. After Waves 1-2 complete → trigger Hermes + Zapp

--- a/packages/core/src/__tests__/a2ui-schema.test.ts
+++ b/packages/core/src/__tests__/a2ui-schema.test.ts
@@ -395,6 +395,34 @@ describe("COMPONENT_SCHEMA_REGISTRY", () => {
     expect(result.success).toBe(true);
   });
 
+  it("validates workspace-backed FileEditor payloads", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["FileEditor"].safeParse({
+      id: "fe2",
+      component: "FileEditor",
+      artifactPath: "artifacts/Dockerfile",
+      readOnly: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates multi-file FileEditor payloads with path aliases", () => {
+    const result = COMPONENT_SCHEMA_REGISTRY["FileEditor"].safeParse({
+      id: "fe3",
+      component: "FileEditor",
+      files: [
+        {
+          path: "src/index.ts",
+          language: "typescript",
+          content: "console.log('hi')",
+        },
+        {
+          artifactPath: "artifacts/Dockerfile",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts dynamic string (object) for Text.text", () => {
     const result = COMPONENT_SCHEMA_REGISTRY["Text"].safeParse({
       id: "t1",

--- a/packages/core/src/__tests__/response-processor.test.ts
+++ b/packages/core/src/__tests__/response-processor.test.ts
@@ -246,6 +246,51 @@ describe("processResponse", () => {
     expect(markdownComp!.content).toBe("**App type:** Full-stack web application");
   });
 
+  it("preserves workspace-backed FileEditor payloads (regression)", () => {
+    const json = JSON.stringify({
+      message: "Generated files are ready in the workspace.",
+      a2ui: [
+        { version: "v0.9", createSurface: { surfaceId: "msg-5", catalogId: "kickstart" } },
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "msg-5",
+            components: [
+              {
+                id: "editor",
+                component: "FileEditor",
+                files: [
+                  {
+                    path: "src/index.ts",
+                    language: "typescript",
+                    content: "console.log('hello')",
+                  },
+                  {
+                    artifactPath: "artifacts/Dockerfile",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      actions: [],
+    });
+
+    const result = processResponse(json);
+    expect(result.a2uiMessages).toHaveLength(2);
+    const comps = result.a2uiMessages[1].updateComponents!.components as Array<Record<string, unknown>>;
+    expect(comps).toHaveLength(1);
+    expect(comps[0]).toMatchObject({
+      id: "editor",
+      component: "FileEditor",
+      files: [
+        expect.objectContaining({ path: "src/index.ts", language: "typescript" }),
+        expect.objectContaining({ artifactPath: "artifacts/Dockerfile" }),
+      ],
+    });
+  });
+
   it("strips unknown props from validated components", () => {
     const json = JSON.stringify({
       message: "test",

--- a/packages/core/src/catalog/index.ts
+++ b/packages/core/src/catalog/index.ts
@@ -259,11 +259,23 @@ export interface ArchitectureDiagramComponent extends BaseComponent {
   edges?: ArchEdge[];
 }
 
+export interface FileEditorFileEntry {
+  filename?: string;
+  path?: string;
+  language?: string;
+  content?: string;
+  artifactPath?: string;
+}
+
 export interface FileEditorComponent extends BaseComponent {
   component: "FileEditor";
-  filename: string;
-  language: string;
-  content: string;
+  filename?: string;
+  path?: string;
+  language?: string;
+  content?: string;
+  artifactPath?: string;
+  files?: FileEditorFileEntry[];
+  readOnly?: boolean;
 }
 
 export interface AuthCardComponent extends BaseComponent {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export type {
   ArchitectureDiagramComponent,
   ArchNode,
   ArchEdge,
+  FileEditorFileEntry,
   FileEditorComponent,
   AuthCardComponent,
   DeploymentProgressComponent,

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -217,7 +217,7 @@ ABSOLUTE RULES:
   - Open-ended / free-form answer → TextField
   This is NON-NEGOTIABLE. If you write a question like "Do you X or Y?" as bare text inside a Card without interactive components, that is a critical failure.
 - If you have information to present → use Card, Tabs, Markdown, Text, or Accordion.
-- If you have code → use FileEditor or CodeBlock component (component:"FileEditor").
+- If you have generated files or configs → use FileEditor. Use CodeBlock only for short illustrative snippets that should stay inline in chat.
 - If you have progress → use DeploymentProgress or ProgressSteps.
 - If you have costs → use CostEstimate.
 - If you have architecture → use ArchitectureDiagram.
@@ -388,12 +388,13 @@ Mention in-cluster alternatives only when explicitly asked.
 ## 10. CODE GENERATION
 
 Generate deployment artifacts AND application code across multiple turns:
-- Emit files using FileEditor components (one per file). They appear in the file viewer.
+- Emit files using FileEditor components (one per file). They appear in the file viewer/workspace.
 - 2-4 files per turn maximum. Split large projects across turns.
 - Do NOT include a "Generate next set of files" button. Set "filesComplete": false in your JSON response and the client auto-continues.
 - Set "filesComplete": true on the final file-generation turn.
 - Cross-file consistency: ACR name, cluster name, resource group, image paths must match across Bicep, K8s YAML, and CI/CD pipeline.
 - Keep message text to 2-3 sentences summarizing what was generated. Don't repeat file contents.
+- Never put generated file contents in the message field, Markdown, or CodeBlock. Generated artifacts belong in FileEditor so the workspace/file manager stays canonical.
 
 When the user is starting fresh, generate a working app:
 - Project structure, entry point, dependency file

--- a/packages/core/src/services/a2ui-schema.ts
+++ b/packages/core/src/services/a2ui-schema.ts
@@ -483,15 +483,50 @@ const ArchitectureDiagramPropsSchema = z
     }
   });
 
+const FileEditorEntrySchema = z
+  .object({
+    filename: dynamicString.optional(),
+    path: dynamicString.optional(),
+    language: dynamicString.optional(),
+    content: dynamicString.optional(),
+    artifactPath: dynamicString.optional(),
+  })
+  .strip()
+  .superRefine((value, ctx) => {
+    if (!value.filename && !value.path && !value.artifactPath) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "FileEditor entries require filename, path, or artifactPath.",
+      });
+    }
+  });
+
 const FileEditorPropsSchema = z
   .object({
     id: boundedString,
     component: z.literal("FileEditor"),
-    filename: dynamicString,
-    language: dynamicString,
-    content: dynamicString,
+    filename: dynamicString.optional(),
+    path: dynamicString.optional(),
+    language: dynamicString.optional(),
+    content: dynamicString.optional(),
+    artifactPath: dynamicString.optional(),
+    files: z.array(FileEditorEntrySchema).optional(),
+    readOnly: z.boolean().optional(),
   })
-  .strip();
+  .strip()
+  .superRefine((value, ctx) => {
+    if (Array.isArray(value.files) && value.files.length > 0) {
+      return;
+    }
+
+    if (!value.filename && !value.path && !value.artifactPath) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "FileEditor requires filename, path, artifactPath, or files.",
+        path: ["filename"],
+      });
+    }
+  });
 
 const AuthCardPropsSchema = z
   .object({

--- a/packages/web/api/src/lib/session-store.test.ts
+++ b/packages/web/api/src/lib/session-store.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { Phase } from "@kickstart/core";
-import { createSession, hydrateSession } from "./session-store.js";
+import {
+  createSession,
+  extractArtifactsFromA2UI,
+  hydrateSession,
+} from "./session-store.js";
 
 describe("session-store phase hydration", () => {
   it("starts new sessions in discover", () => {
@@ -39,5 +43,108 @@ describe("session-store phase hydration", () => {
     expect(session.engineState.currentPhase).toBe(Phase.Discover);
     expect(session.state.currentPhase).toBe(Phase.Discover);
     expect(session.routingPhaseTrusted).toBe(false);
+  });
+
+  it("rehydrates generated artifacts from compact assistant A2UI payloads", () => {
+    const session = hydrateSession([
+      {
+        role: "assistant",
+        content: "Generated the next batch of files.",
+        phase: Phase.Generate,
+        a2uiMessages: [
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "msg-1",
+              components: [
+                {
+                  id: "editor",
+                  component: "FileEditor",
+                  files: [
+                    {
+                      artifactPath: "artifacts/Dockerfile",
+                    },
+                    {
+                      path: "infra/main.bicep",
+                      content: "resource app 'Microsoft.App/containerApps@2024-03-01' = {}",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ], "principal-123");
+
+    expect(session.generatedArtifacts).toEqual([
+      {
+        filename: "artifacts/Dockerfile",
+        language: "dockerfile",
+        bicepResources: [],
+        k8sResources: [],
+      },
+      {
+        filename: "infra/main.bicep",
+        language: "bicep",
+        bicepResources: ["app (Microsoft.App/containerApps)"],
+        k8sResources: [],
+      },
+    ]);
+  });
+});
+
+describe("extractArtifactsFromA2UI", () => {
+  it("extracts artifact metadata from single-file and multi-file payloads", () => {
+    const artifacts = extractArtifactsFromA2UI([
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "msg-1",
+          components: [
+            {
+              id: "file-1",
+              component: "FileEditor",
+              filename: "k8s/deployment.yaml",
+              content: "kind: Deployment\nmetadata:\n  name: api\n",
+            },
+            {
+              id: "file-2",
+              component: "FileEditor",
+              files: [
+                {
+                  path: "src/index.ts",
+                  content: "console.log('hi')",
+                },
+                {
+                  artifactPath: "artifacts/Dockerfile",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(artifacts).toEqual([
+      {
+        filename: "k8s/deployment.yaml",
+        language: "yaml",
+        bicepResources: [],
+        k8sResources: ["Deployment: api"],
+      },
+      {
+        filename: "src/index.ts",
+        language: "typescript",
+        bicepResources: [],
+        k8sResources: [],
+      },
+      {
+        filename: "artifacts/Dockerfile",
+        language: "dockerfile",
+        bicepResources: [],
+        k8sResources: [],
+      },
+    ]);
   });
 });

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -173,6 +173,8 @@ export interface ClientMessage {
   content: string;
   phase?: string;
   usage?: TurnUsage;
+  /** Optional compact artifact-bearing A2UI payloads for cold-start rehydration. */
+  a2uiMessages?: unknown[];
 }
 
 function restoreEngineStateFromHistory(clientMessages: ClientMessage[]): ConversationState {
@@ -218,9 +220,17 @@ export function hydrateSession(clientMessages: ClientMessage[], principalId?: st
       timestamp: now,
     });
 
-    // Rebuild generatedArtifacts from assistant messages containing FileEditor components
+    // Rebuild generatedArtifacts from assistant messages containing FileEditor components.
+    // Prefer the compact A2UI payloads sent by the client; fall back to legacy
+    // JSON-envelope parsing for older persisted sessions.
     if (msg.role === "assistant") {
-      rebuildArtifactsFromMessage(msg.content, session.generatedArtifacts);
+      if (Array.isArray(msg.a2uiMessages) && msg.a2uiMessages.length > 0) {
+        for (const artifact of extractArtifactsFromA2UI(msg.a2uiMessages)) {
+          upsertArtifact(session.generatedArtifacts, artifact);
+        }
+      } else {
+        rebuildArtifactsFromMessage(msg.content, session.generatedArtifacts);
+      }
       if (isTurnUsage(msg.usage)) {
         session.usageHistory.push(msg.usage);
       }
@@ -238,7 +248,8 @@ export const MAX_TRACKED_ARTIFACTS = 50;
 
 /** Infer language from filename extension. */
 export function inferLanguage(filename: string): string {
-  const ext = filename.split(".").pop() ?? "";
+  const baseName = filename.split(/[\\/]/).pop() ?? filename;
+  const ext = baseName.includes(".") ? (baseName.split(".").pop() ?? "") : baseName;
   const langMap: Record<string, string> = {
     ts: "typescript", js: "javascript", py: "python", go: "go",
     rs: "rust", java: "java", cs: "csharp", bicep: "bicep",
@@ -298,24 +309,59 @@ export function upsertArtifact(list: GeneratedArtifact[], artifact: GeneratedArt
  * artifacts during session hydration.
  */
 export function extractArtifactsFromA2UI(
-  a2uiMessages: Array<{ updateComponents?: { components: unknown[] } }>,
+  a2uiMessages: unknown[],
 ): GeneratedArtifact[] {
   const artifacts: GeneratedArtifact[] = [];
   for (const msg of a2uiMessages) {
-    if (!msg.updateComponents?.components) continue;
-    for (const comp of msg.updateComponents.components) {
-      const c = comp as Record<string, unknown>;
-      if (c.component === "FileEditor" && typeof c.filename === "string") {
-        const artifact = extractArtifactMetadata(
-          c.filename,
-          typeof c.language === "string" ? c.language : "",
-          typeof c.content === "string" ? c.content : "",
-        );
-        artifacts.push(artifact);
-      }
+    if (!msg || typeof msg !== "object") continue;
+    const components = (msg as { updateComponents?: { components?: unknown[] } }).updateComponents?.components;
+    if (!Array.isArray(components)) continue;
+    for (const comp of components) {
+      artifacts.push(...extractArtifactsFromComponent(comp));
     }
   }
   return artifacts;
+}
+
+function extractArtifactsFromComponent(component: unknown): GeneratedArtifact[] {
+  if (!component || typeof component !== "object" || Array.isArray(component)) {
+    return [];
+  }
+
+  const candidate = component as Record<string, unknown>;
+  if (candidate.component !== "FileEditor") {
+    return [];
+  }
+
+  const rawEntries = Array.isArray(candidate.files) && candidate.files.length > 0
+    ? candidate.files
+    : [candidate];
+
+  return rawEntries
+    .map((entry) => normalizeArtifactEntry(entry))
+    .filter((entry): entry is GeneratedArtifact => entry !== null);
+}
+
+function normalizeArtifactEntry(entry: unknown): GeneratedArtifact | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
+
+  const record = entry as Record<string, unknown>;
+  const filename = coerceString(record.filename)
+    ?? coerceString(record.path)
+    ?? coerceString(record.artifactPath);
+  if (!filename) {
+    return null;
+  }
+
+  const language = coerceString(record.language) ?? inferLanguage(filename);
+  const content = coerceString(record.content) ?? "";
+  return extractArtifactMetadata(filename, language, content);
+}
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
 /**

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,8 +4,6 @@ import { Layout } from './components/Layout';
 import { Landing } from './components/Landing';
 import { ChatShell } from './components/Chat/ChatShell';
 import { SessionsSidebar } from './components/Sidebar/SessionsSidebar';
-import { FileEditor } from './components/FileEditor/FileEditor';
-import { FileTreePanel } from './components/FileTreePanel';
 import { FileManagerSidebar, FileViewer } from './components/FileManager';
 import { Playground } from './pages/Playground';
 import { useA2UI } from './hooks/useA2UI';
@@ -51,11 +49,9 @@ export function App() {
   const [mode, setMode] = useState<AppMode>(playgroundEnabled ? 'chat' : 'landing');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isApiAvailable, setIsApiAvailable] = useState<boolean | null>(mockEnabled ? true : null);
-  const [selectedFile, setSelectedFile] = useState<string | undefined>();
   const [filePanelOpen, setFilePanelOpen] = useState(true);
   const [fileSidebarOpen, setFileSidebarOpen] = useState(true);
   const [viewerFile, setViewerFile] = useState<string | undefined>();
-  const selectedFileRef = useRef<string | undefined>(undefined);
   const viewerFileRef = useRef<string | undefined>(undefined);
 
   const connectorRegistry = useAPIConnectorRegistry();
@@ -123,10 +119,6 @@ export function App() {
   const streamingA2UIMessagesRef = useRef<A2uiPayloadItem[]>([]);
 
   useEffect(() => {
-    selectedFileRef.current = selectedFile;
-  }, [selectedFile]);
-
-  useEffect(() => {
     viewerFileRef.current = viewerFile;
   }, [viewerFile]);
 
@@ -159,9 +151,8 @@ export function App() {
   }, []);
 
   const openGeneratedFile = useCallback((path: string) => {
-    selectedFileRef.current = path;
+    setFilePanelOpen(true);
     viewerFileRef.current = path;
-    setSelectedFile(path);
     setViewerFile(path);
   }, []);
 
@@ -174,9 +165,7 @@ export function App() {
     fs.clear();
     lastPersistedRef.current = new Map();
     clearActionLog();
-    selectedFileRef.current = undefined;
     viewerFileRef.current = undefined;
-    setSelectedFile(undefined);
     setViewerFile(undefined);
     setConversationPhase(null);
     try {
@@ -205,7 +194,7 @@ export function App() {
       fs.write(file.path, file.content, file.language);
     }
 
-    if (prepared.files.length > 0 && !selectedFileRef.current && !viewerFileRef.current) {
+    if (prepared.files.length > 0 && !viewerFileRef.current) {
       openGeneratedFile(prepared.files[0].path);
     }
 
@@ -445,7 +434,7 @@ export function App() {
   const isStreaming = mockEnabled ? mockStreaming.isStreaming : streaming.isStreaming;
   const currentStreamText = mockEnabled ? mockStreaming.streamText : streaming.streamText;
   const usageSummary = useMemo(() => summarizeTokenUsage(messages), [messages]);
-  const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot);
+  const fsFiles = useSyncExternalStore(fs.subscribe, fs.getSnapshot, fs.getSnapshot);
   const hasFiles = fsFiles.length > 0 || vfsFiles.length > 0;
   const activeSession = sessions.getActiveSession();
   const getDeploymentFiles = useCallback(async () => {
@@ -485,9 +474,11 @@ export function App() {
   }, [hasFiles]);
 
   const handleToggleFilePanel = useCallback(() => {
+    if (!filePanelOpen && hasFiles) {
+      setFileSidebarOpen(true);
+    }
     setFilePanelOpen((prev) => !prev);
-    setFileSidebarOpen((prev) => !prev);
-  }, []);
+  }, [filePanelOpen, hasFiles]);
 
   // --- File Manager sidebar / viewer handlers ---
   const handleSelectViewerFile = useCallback((path: string) => {
@@ -518,21 +509,26 @@ export function App() {
     if (viewerFile === path) {
       viewerFileRef.current = undefined;
       setViewerFile(undefined);
+      if (!fileSidebarOpen) {
+        setFilePanelOpen(false);
+      }
     }
-    if (selectedFile === path) {
-      selectedFileRef.current = undefined;
-      setSelectedFile(undefined);
-    }
-  }, [vfs, fs, viewerFile, selectedFile]);
+  }, [vfs, fs, viewerFile, fileSidebarOpen]);
 
   const handleDismissSidebar = useCallback(() => {
     setFileSidebarOpen(false);
+    if (!viewerFileRef.current) {
+      setFilePanelOpen(false);
+    }
   }, []);
 
   const handleDismissViewer = useCallback(() => {
     viewerFileRef.current = undefined;
     setViewerFile(undefined);
-  }, []);
+    if (!fileSidebarOpen) {
+      setFilePanelOpen(false);
+    }
+  }, [fileSidebarOpen]);
 
   // Playground mode — standalone A2UI test harness
   if (playgroundEnabled) {
@@ -563,8 +559,8 @@ export function App() {
           showSessionsToggle={mode === 'chat'}
           hasFiles={hasFiles && filePanelOpen}
           showFilePanel={mode === 'chat' && filePanelOpen}
-          showFileSidebar={mode === 'chat' && fileSidebarOpen && hasFiles}
-          showFileViewer={mode === 'chat' && !!viewerFile}
+          showFileSidebar={mode === 'chat' && filePanelOpen && fileSidebarOpen && hasFiles}
+          showFileViewer={mode === 'chat' && filePanelOpen && !!viewerFile}
           onToggleFilePanel={mode === 'chat' && hasFiles ? handleToggleFilePanel : undefined}
           sidebar={mode === 'chat' ? (
             <SessionsSidebar
@@ -576,16 +572,6 @@ export function App() {
               onNewSession={handleNewSession}
               onDeleteSession={sessions.deleteSession}
             />
-          ) : undefined}
-          fileEditor={mode === 'chat' ? (
-            <>
-              <FileEditor
-                fs={fs}
-                selectedPath={selectedFile}
-                onSelectFile={openGeneratedFile}
-              />
-              <FileTreePanel />
-            </>
           ) : undefined}
           fileManagerSidebar={mode === 'chat' ? (
             <FileManagerSidebar

--- a/packages/web/src/__tests__/app-file-surface.test.ts
+++ b/packages/web/src/__tests__/app-file-surface.test.ts
@@ -1,0 +1,223 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reactRuntime = vi.hoisted(() => ({
+  callIndex: 0,
+  initialMode: undefined as string | undefined,
+}));
+
+const vfsApi = vi.hoisted(() => ({
+  clear: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  exportZip: vi.fn().mockResolvedValue(new Blob()),
+  deleteFile: vi.fn().mockResolvedValue(undefined),
+  readAll: vi.fn().mockResolvedValue([]),
+  getFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+function marker(testId: string) {
+  return React.createElement('div', { 'data-testid': testId });
+}
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    ...actual,
+    default: actual,
+    useState: ((initial: unknown) => {
+      reactRuntime.callIndex += 1;
+      if (reactRuntime.callIndex === 1 && reactRuntime.initialMode !== undefined) {
+        return actual.useState(reactRuntime.initialMode);
+      }
+      return actual.useState(initial as never);
+    }) as typeof actual.useState,
+    useSyncExternalStore: ((_, getSnapshot) => getSnapshot()) as typeof actual.useSyncExternalStore,
+  };
+});
+
+vi.mock('@fluentui/react-components', () => ({
+  FluentProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  webLightTheme: {},
+  webDarkTheme: {},
+}));
+
+vi.mock('../components/Layout', () => ({
+  Layout: ({ sidebar, fileEditor, fileManagerSidebar, fileViewer, children }: any) =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'layout' },
+      sidebar,
+      fileEditor,
+      fileManagerSidebar,
+      fileViewer,
+      children,
+    ),
+}));
+
+vi.mock('../components/Landing', () => ({
+  Landing: () => marker('landing'),
+}));
+
+vi.mock('../components/Chat/ChatShell', () => ({
+  ChatShell: () => marker('chat-shell'),
+}));
+
+vi.mock('../components/Sidebar/SessionsSidebar', () => ({
+  SessionsSidebar: () => marker('sessions-sidebar'),
+}));
+
+vi.mock('../components/FileEditor/FileEditor', () => ({
+  FileEditor: () => marker('legacy-file-editor'),
+}));
+
+vi.mock('../components/FileTreePanel', () => ({
+  FileTreePanel: () => marker('legacy-file-tree-panel'),
+}));
+
+vi.mock('../components/FileManager', () => ({
+  FileManagerSidebar: () => marker('file-manager-sidebar'),
+  FileViewer: () => marker('file-viewer'),
+}));
+
+vi.mock('../pages/Playground', () => ({
+  Playground: () => marker('playground'),
+}));
+
+vi.mock('../hooks/useA2UI', () => ({
+  useA2UI: () => ({
+    reset: () => undefined,
+    processMessages: () => [],
+    getSurface: () => undefined,
+  }),
+}));
+
+vi.mock('../hooks/useActionDispatch', () => ({
+  useActionDispatch: () => ({
+    handler: () => undefined,
+    resetConsecutiveCount: () => undefined,
+  }),
+}));
+
+vi.mock('../hooks/useProgressiveQueue', () => ({
+  useProgressiveQueue: () => ({
+    visibleIds: [],
+    enqueue: () => undefined,
+    reset: () => undefined,
+    flush: () => undefined,
+  }),
+}));
+
+vi.mock('../hooks/useSessions', () => ({
+  useSessions: () => ({
+    sessions: [],
+    activeSessionId: null,
+    recentSessions: [],
+    getActiveSession: () => null,
+    createSession: () => ({ id: 'session-1', messages: [] }),
+    addMessage: () => undefined,
+    updateSession: () => undefined,
+    deleteSession: () => undefined,
+    clearAllSessions: () => undefined,
+    setActiveSessionId: () => undefined,
+  }),
+}));
+
+vi.mock('../hooks/useNavigation', () => ({
+  useNavigation: () => ({
+    pushSession: () => undefined,
+    pushLanding: () => undefined,
+    replaceCurrent: () => undefined,
+    getInitialState: () => ({ view: 'landing' as const }),
+  }),
+}));
+
+vi.mock('../hooks/useStreaming', () => ({
+  useStreaming: () => ({
+    isStreaming: false,
+    streamText: '',
+    send: () => undefined,
+  }),
+}));
+
+vi.mock('../hooks/useMockStreaming', () => ({
+  useMockStreaming: () => ({
+    isStreaming: false,
+    streamText: '',
+    send: () => undefined,
+  }),
+}));
+
+vi.mock('../contexts/APIConnectorContext', () => ({
+  useAPIConnectorRegistry: () => ({}),
+}));
+
+vi.mock('../contexts/ArtifactContext', () => ({
+  useArtifacts: () => ({
+    getArtifact: () => null,
+  }),
+}));
+
+vi.mock('../contexts/ConversationSessionContext', () => ({
+  ConversationSessionProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+vi.mock('../contexts/DebugContext', () => ({
+  useDebug: () => ({
+    debugEnabled: false,
+    logAction: () => undefined,
+    clearActionLog: () => undefined,
+    toggleDebug: () => undefined,
+  }),
+}));
+
+vi.mock('../contexts/VirtualFSContext', () => ({
+  useVirtualFS: () => ({
+    fs: vfsApi,
+    files: ['Dockerfile'],
+    fileRecords: [{
+      path: 'Dockerfile',
+      content: 'FROM node:20-alpine',
+      language: 'dockerfile',
+      createdAt: 0,
+      updatedAt: 0,
+    }],
+  }),
+}));
+
+vi.mock('../services/api-client', () => ({
+  healthCheck: () => Promise.resolve(true),
+}));
+
+vi.mock('../services/mock-streaming', () => ({
+  isMockMode: () => false,
+  isPlaygroundMode: () => false,
+}));
+
+let App: typeof import('../App').App;
+
+beforeAll(async () => {
+  ({ App } = await import('../App'));
+});
+
+describe('App file surface composition', () => {
+  beforeEach(() => {
+    reactRuntime.callIndex = 0;
+    reactRuntime.initialMode = 'chat';
+    vi.clearAllMocks();
+  });
+
+  it('keeps the workspace file manager as the only mounted file surface in chat mode', () => {
+    const markup = renderToStaticMarkup(React.createElement(App));
+
+    expect(markup).toContain('data-testid="file-manager-sidebar"');
+    expect(markup).toContain('data-testid="file-viewer"');
+    expect(markup).not.toContain('data-testid="legacy-file-editor"');
+    expect(markup).not.toContain('data-testid="legacy-file-tree-panel"');
+  });
+});

--- a/packages/web/src/catalog/components/FileEditor.tsx
+++ b/packages/web/src/catalog/components/FileEditor.tsx
@@ -10,7 +10,6 @@ import {
   Tab,
   TabList,
   makeStyles,
-  mergeClasses,
   shorthands,
   tokens,
 } from '@fluentui/react-components';
@@ -47,7 +46,8 @@ const MonacoEditor = lazy(() =>
 );
 
 const FileEntrySchema = z.object({
-  filename: DynamicStringSchema,
+  filename: DynamicStringSchema.optional(),
+  path: DynamicStringSchema.optional(),
   content: DynamicStringSchema.optional(),
   language: DynamicStringSchema.optional(),
   artifactPath: DynamicStringSchema.optional(),
@@ -57,6 +57,7 @@ const FileEditorApi = {
   name: 'FileEditor',
   schema: z.object({
     filename: DynamicStringSchema.optional(),
+    path: DynamicStringSchema.optional(),
     content: DynamicStringSchema.optional(),
     language: DynamicStringSchema.optional(),
     readOnly: z.boolean().optional(),
@@ -172,16 +173,16 @@ export const FileEditor = createReactComponent(FileEditorApi, ({ props }) => {
       return props.files;
     }
     // Single-file fallback
-    if (props.filename || props.content || props.artifactPath) {
+    if (props.filename || props.path || props.content || props.artifactPath) {
       return [{
-        filename: props.filename ?? '',
+        filename: props.filename ?? props.path ?? '',
         content: props.content,
         language: props.language,
         artifactPath: props.artifactPath,
       }];
     }
     return [];
-  }, [props.files, props.filename, props.content, props.language, props.artifactPath]);
+  }, [props.files, props.filename, props.path, props.content, props.language, props.artifactPath]);
 
   const [activeTab, setActiveTab] = useState(0);
   const isMultiFile = fileEntries.length > 1;
@@ -207,6 +208,7 @@ export const FileEditor = createReactComponent(FileEditorApi, ({ props }) => {
   }, [activeFile, getArtifact]);
 
   const resolvedFileName = str(activeFile?.filename) ??
+    str(activeFile?.path) ??
     (activeFile?.artifactPath ? str(activeFile.artifactPath)?.split('/').pop() : undefined);
 
   const resolvedLanguage = str(activeFile?.language) ??
@@ -247,6 +249,7 @@ export const FileEditor = createReactComponent(FileEditorApi, ({ props }) => {
           >
             {fileEntries.map((file, i) => {
               const label = str(file.filename) ||
+                str(file.path) ||
                 (file.artifactPath ? str(file.artifactPath)?.split('/').pop() : `File ${i + 1}`);
               return <Tab key={i} value={String(i)}>{label}</Tab>;
             })}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -7,7 +7,6 @@ interface LayoutProps {
   onNewSession: () => void;
   showSessionsToggle: boolean;
   sidebar?: React.ReactNode;
-  fileEditor?: React.ReactNode;
   fileManagerSidebar?: React.ReactNode;
   fileViewer?: React.ReactNode;
   hasFiles?: boolean;
@@ -24,7 +23,6 @@ export function Layout({
   onNewSession,
   showSessionsToggle,
   sidebar,
-  fileEditor,
   fileManagerSidebar,
   fileViewer,
   hasFiles,
@@ -50,7 +48,6 @@ export function Layout({
         <main className="chat-main" role="main">
           {children}
         </main>
-        {showFilePanel && fileEditor}
         {showFileViewer && fileViewer}
       </div>
     </div>

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -25,6 +25,23 @@ interface StreamCallbacks {
 // Target ~80 rAF frames to reveal all text (~1.3s at 60fps)
 const REVEAL_FRAMES = 80;
 
+function extractHydrationA2uiMessages(items: A2uiPayloadItem[] | undefined): A2uiPayloadItem[] | undefined {
+  const artifactMessages = items?.filter((item) => {
+    if (!('updateComponents' in item) || !Array.isArray(item.updateComponents?.components)) {
+      return false;
+    }
+
+    return item.updateComponents.components.some((component) =>
+      Boolean(component)
+      && typeof component === 'object'
+      && !Array.isArray(component)
+      && (component as { component?: unknown }).component === 'FileEditor',
+    );
+  });
+
+  return artifactMessages?.length ? artifactMessages : undefined;
+}
+
 export function useStreaming() {
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamText, setStreamText] = useState('');
@@ -102,23 +119,33 @@ export function useStreaming() {
     const debugA2uiMessages: A2uiPayloadItem[] = [];
 
     try {
-      // Build client message history for rehydration (strip system messages
-      // and A2UI JSON — the server builds its own system prompt).
+      // Build client message history for rehydration. The server rebuilds its
+      // own system prompt, so only user/assistant text is required. For
+      // assistant turns we also forward compact artifact-bearing A2UI payloads
+      // so generated files can be rebuilt after cold starts without re-leaking
+      // them into chat.
       // Filter assistant messages to only model-produced ones (m.model present)
       // to prevent client-generated error bubbles from spoofing assistant turns.
-        const clientMessages = chatHistory
-          ?.filter((m) => {
-            const text = m.text?.trim();
-            if (!text) return false;
-            if (m.role === 'user') return true;
-            return m.role === 'assistant' && Boolean(m.model);
-          })
-          .map((m) => ({
+      const clientMessages = chatHistory
+        ?.filter((m) => {
+          const text = m.text?.trim();
+          if (!text) return false;
+          if (m.role === 'user') return true;
+          return m.role === 'assistant' && Boolean(m.model);
+        })
+        .map((m) => {
+          const a2uiMessages = m.role === 'assistant'
+            ? extractHydrationA2uiMessages(m.a2uiMessages)
+            : undefined;
+
+          return {
             role: m.role === 'user' ? 'user' as const : 'assistant' as const,
             content: m.text.trim(),
             ...(m.phase ? { phase: m.phase } : {}),
             ...(m.usage ? { usage: m.usage } : {}),
-          }));
+            ...(a2uiMessages ? { a2uiMessages } : {}),
+          };
+        });
 
       const res = await apiFetch('/api/converse', {
         method: 'POST',

--- a/packages/web/src/utils/chat-a2ui.test.ts
+++ b/packages/web/src/utils/chat-a2ui.test.ts
@@ -5,6 +5,7 @@ import {
   getLatestConversationPhase,
   prepareChatA2ui,
   prepareChatA2uiPayload,
+  rebuildChatSessionState,
 } from './chat-a2ui';
 
 describe('prepareChatA2uiPayload', () => {
@@ -88,7 +89,7 @@ describe('prepareChatA2uiPayload', () => {
 });
 
 describe('prepareChatA2ui', () => {
-  it('replaces inline FileEditor components with compact file labels and extracts files', () => {
+  it('replaces inline FileEditor components with workspace summaries and extracts files', () => {
     const payload: A2uiPayloadItem[] = [
       {
         type: 'ConversationPhase',
@@ -149,8 +150,8 @@ describe('prepareChatA2ui', () => {
         {
           id: 'file',
           component: 'Text',
-          text: '📄 Dockerfile',
-          variant: 'subtitle2',
+          text: '📄 Dockerfile is available in the workspace.',
+          variant: 'body2',
         },
       ],
     });
@@ -163,7 +164,7 @@ describe('prepareChatA2ui', () => {
     });
   });
 
-  it('expands multi-file FileEditor payloads into a compact list', () => {
+  it('collapses multi-file FileEditor payloads into one workspace summary', () => {
     const payload: A2uiPayloadItem[] = [
       {
         version: 'v0.9',
@@ -175,7 +176,7 @@ describe('prepareChatA2ui', () => {
               component: 'FileEditor',
               files: [
                 {
-                  filename: 'src/index.ts',
+                  path: 'src/index.ts',
                   language: 'typescript',
                   content: 'console.log("hi")',
                 },
@@ -202,24 +203,169 @@ describe('prepareChatA2ui', () => {
       components: [
         {
           id: 'editor',
-          component: 'Column',
-          children: ['editor__file_0', 'editor__file_1'],
-          gap: 'small',
-        },
-        {
-          id: 'editor__file_0',
           component: 'Text',
-          text: '📄 src/index.ts',
-          variant: 'subtitle2',
-        },
-        {
-          id: 'editor__file_1',
-          component: 'Text',
-          text: '📄 Dockerfile',
-          variant: 'subtitle2',
+          text: '📄 2 generated files are available in the workspace.',
+          variant: 'body2',
         },
       ],
     });
+  });
+
+  it('delivers artifact-backed files to the workspace while keeping chat output compact', () => {
+    const payload: A2uiPayloadItem[] = [
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 'msg-3', catalogId: 'kickstart' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'msg-3',
+          components: [
+            {
+              id: 'artifact-file',
+              component: 'FileEditor',
+              filename: 'infra/main.bicep',
+              artifactPath: 'artifacts/infra/main.bicep',
+            },
+          ],
+        },
+      },
+    ];
+
+    const prepared = prepareChatA2ui(payload, 'assistant-turn-5', {
+      resolveArtifactContent: (artifactPath) => artifactPath === 'artifacts/infra/main.bicep'
+        ? 'param location string = resourceGroup().location'
+        : null,
+    });
+    const renderableUpdate = prepared.renderableMessages[1].updateComponents;
+    const storedUpdate = prepared.storedMessages[1];
+
+    expect(prepared.files).toEqual([
+      {
+        path: 'infra/main.bicep',
+        content: 'param location string = resourceGroup().location',
+        language: 'bicep',
+      },
+    ]);
+    expect(renderableUpdate).toMatchObject({
+      surfaceId: 'assistant-turn-5::msg-3',
+      components: [
+        {
+          id: 'artifact-file',
+          component: 'Text',
+          text: '📄 infra/main.bicep is available in the workspace.',
+          variant: 'body2',
+        },
+      ],
+    });
+    expect(renderableUpdate?.components).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ component: 'FileEditor' }),
+    ]));
+    expect('updateComponents' in storedUpdate && storedUpdate.updateComponents?.components[0]).toMatchObject({
+      id: 'artifact-file',
+      component: 'FileEditor',
+      filename: 'infra/main.bicep',
+      artifactPath: 'artifacts/infra/main.bicep',
+      content: 'param location string = resourceGroup().location',
+      language: 'bicep',
+    });
+  });
+});
+
+describe('rebuildChatSessionState', () => {
+  it('keeps repeated raw file surfaces isolated per assistant turn', () => {
+    const restored = rebuildChatSessionState([
+      {
+        id: 'assistant-turn-6',
+        a2uiMessages: [
+          {
+            version: 'v0.9',
+            createSurface: { surfaceId: 'msg-duplicate', catalogId: 'kickstart' },
+          },
+          {
+            version: 'v0.9',
+            updateComponents: {
+              surfaceId: 'msg-duplicate',
+              components: [
+                {
+                  id: 'file-one',
+                  component: 'FileEditor',
+                  filename: 'src/index.ts',
+                  language: 'typescript',
+                  content: 'console.log("one")',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'assistant-turn-7',
+        a2uiMessages: [
+          {
+            version: 'v0.9',
+            createSurface: { surfaceId: 'msg-duplicate', catalogId: 'kickstart' },
+          },
+          {
+            version: 'v0.9',
+            updateComponents: {
+              surfaceId: 'msg-duplicate',
+              components: [
+                {
+                  id: 'file-two',
+                  component: 'FileEditor',
+                  filename: 'Dockerfile',
+                  language: 'dockerfile',
+                  content: 'FROM node:20-alpine',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(restored.files).toEqual([
+      {
+        path: 'src/index.ts',
+        content: 'console.log("one")',
+        language: 'typescript',
+      },
+      {
+        path: 'Dockerfile',
+        content: 'FROM node:20-alpine',
+        language: 'dockerfile',
+      },
+    ]);
+    expect(restored.renderableMessages.map((message) =>
+      message.createSurface?.surfaceId
+      ?? message.updateComponents?.surfaceId
+      ?? message.updateDataModel?.surfaceId
+      ?? message.deleteSurface?.surfaceId
+      ?? null,
+    )).toEqual([
+      'assistant-turn-6::msg-duplicate',
+      'assistant-turn-6::msg-duplicate',
+      'assistant-turn-7::msg-duplicate',
+      'assistant-turn-7::msg-duplicate',
+    ]);
+    expect(restored.renderableMessages[1].updateComponents?.components).toEqual([
+      {
+        id: 'file-one',
+        component: 'Text',
+        text: '📄 src/index.ts is available in the workspace.',
+        variant: 'body2',
+      },
+    ]);
+    expect(restored.renderableMessages[3].updateComponents?.components).toEqual([
+      {
+        id: 'file-two',
+        component: 'Text',
+        text: '📄 Dockerfile is available in the workspace.',
+        variant: 'body2',
+      },
+    ]);
   });
 });
 

--- a/packages/web/src/utils/chat-a2ui.ts
+++ b/packages/web/src/utils/chat-a2ui.ts
@@ -382,41 +382,12 @@ function renderComponentsForChat(
 
 function buildGeneratedFileSummary(component: A2uiComponent): A2uiComponent[] {
   const entries = extractFileEntries(component);
-
-  if (entries.length === 0) {
-    return [{
-      id: component.id,
-      component: 'Text',
-      text: '📄 Generated files are available in the workspace.',
-      variant: 'body2',
-    } as A2uiComponent];
-  }
-
-  if (entries.length === 1) {
-    return [{
-      id: component.id,
-      component: 'Text',
-      text: formatFileLabel(entries[0].path),
-      variant: 'subtitle2',
-    } as A2uiComponent];
-  }
-
-  const childIds = entries.map((_, index) => `${component.id}__file_${index}`);
-
-  return [
-    {
-      id: component.id,
-      component: 'Column',
-      children: childIds,
-      gap: 'small',
-    } as A2uiComponent,
-    ...entries.map((entry, index) => ({
-      id: childIds[index],
-      component: 'Text',
-      text: formatFileLabel(entry.path),
-      variant: 'subtitle2',
-    }) as A2uiComponent),
-  ];
+  return [{
+    id: component.id,
+    component: 'Text',
+    text: formatFileWorkspaceSummary(entries),
+    variant: 'body2',
+  } as A2uiComponent];
 }
 
 function extractFileEntries(
@@ -442,7 +413,7 @@ function normalizeFileEntry(
 
   const record = entry as Record<string, unknown>;
   const artifactPath = coerceString(record.artifactPath);
-  const path = coerceString(record.filename) ?? artifactPath;
+  const path = coerceString(record.filename) ?? coerceString(record.path) ?? artifactPath;
   if (!path) {
     return null;
   }
@@ -468,12 +439,21 @@ function coerceString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-function formatFileLabel(path: string): string {
-  return `📄 ${path}`;
+function formatFileWorkspaceSummary(entries: Array<GeneratedChatFile & { artifactPath?: string }>): string {
+  if (entries.length === 0) {
+    return '📄 Generated files are available in the workspace.';
+  }
+
+  if (entries.length === 1) {
+    return `📄 ${entries[0].path} is available in the workspace.`;
+  }
+
+  return `📄 ${entries.length} generated files are available in the workspace.`;
 }
 
 function isFileEditorComponent(component: A2uiComponent): component is A2uiComponent & {
   filename?: string;
+  path?: string;
   content?: string;
   language?: string;
   artifactPath?: string;


### PR DESCRIPTION
Closes #333

## Summary
- remove the legacy App/Layout file editor + tree mount so the workspace file manager/viewer is the only file surface in chat mode
- collapse inline FileEditor chat output into compact workspace summaries while still routing generated files into the workspace/file manager
- preserve workspace-backed and multi-file FileEditor payloads through core schema validation, response processing, client rehydration, and API session hydration
- add regression coverage for app file-surface composition, chat A2UI compaction, response processing/schema handling, and session artifact rehydration

## Notes
- Working with Fry (Frontend Dev), Bender (Backend Dev), and Hermes (Tester)
- The branch was rebased onto `origin/main` and revalidated after conflict resolution
