### PR TITLE
feat: keep setup progress in chat and files in workspace

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -24,13 +24,18 @@ import { healthCheck } from './services/api-client';
 import { isMockMode, isPlaygroundMode } from './services/mock-streaming';
 import { VirtualFileSystem } from './services/virtual-fs';
 import {
+  applyGenerateStreamEvent,
+  buildGenerateProgressMessages,
+  finalizeGenerateProgressState,
   getLatestConversationPhase,
+  interruptGenerateProgressState,
   normalizeConversationPhase,
   prepareChatA2ui,
   rebuildChatSessionState,
 } from './utils/chat-a2ui';
+import type { GenerateProgressState } from './utils/chat-a2ui';
 import { summarizeTokenUsage } from './utils/chat-usage';
-import type { AppMode, ChatMessage, A2uiPayloadItem, ConversationPhaseId } from './types';
+import type { AppMode, ChatMessage, A2uiPayloadItem, ConversationPhaseId, GenerateStreamEvent } from './types';
 // A2uiClientAction type no longer needed — actions route through useActionDispatch only
 
 const mockEnabled = isMockMode();
@@ -52,7 +57,10 @@ export function App() {
   const [filePanelOpen, setFilePanelOpen] = useState(true);
   const [fileSidebarOpen, setFileSidebarOpen] = useState(true);
   const [viewerFile, setViewerFile] = useState<string | undefined>();
+  const [workspaceAnnouncement, setWorkspaceAnnouncement] = useState('');
   const viewerFileRef = useRef<string | undefined>(undefined);
+  const generateProgressStateRef = useRef<GenerateProgressState | null>(null);
+  const streamedFileKeysRef = useRef<Set<string>>(new Set());
 
   const connectorRegistry = useAPIConnectorRegistry();
   const { getArtifact } = useArtifacts();
@@ -164,6 +172,9 @@ export function App() {
     a2ui.reset();
     fs.clear();
     lastPersistedRef.current = new Map();
+    generateProgressStateRef.current = null;
+    streamedFileKeysRef.current = new Set();
+    setWorkspaceAnnouncement('');
     clearActionLog();
     viewerFileRef.current = undefined;
     setViewerFile(undefined);
@@ -204,6 +215,28 @@ export function App() {
       progressiveQueue.enqueue(newIds);
     }
   }, [resolveArtifactContent, fs, openGeneratedFile, a2ui, progressiveQueue, setConversationPhase]);
+
+  const handleIncomingGenerateEvent = useCallback((event: GenerateStreamEvent, turnId: string) => {
+    if (event.type === 'file_generated') {
+      const fileKey = `${event.stepId}::${event.path}::${event.sha256}`;
+      if (streamedFileKeysRef.current.has(fileKey)) {
+        return;
+      }
+      streamedFileKeysRef.current.add(fileKey);
+    }
+
+    setConversationPhase('generate');
+
+    const prepared = applyGenerateStreamEvent(generateProgressStateRef.current, event, {
+      includeCreateSurface: !generateProgressStateRef.current,
+    });
+    generateProgressStateRef.current = prepared.state;
+    processIncomingA2UI(prepared.messages, turnId);
+
+    if (event.type === 'file_generated') {
+      setWorkspaceAnnouncement(`${event.path} added to workspace`);
+    }
+  }, [processIncomingA2UI, setConversationPhase]);
 
   const handleSendMessage = useCallback(async (text: string, isAutoContinue = false, explicitSessionId?: string) => {
     // Manual messages reset the consecutive auto-continue counter
@@ -249,9 +282,56 @@ export function App() {
     streamingSurfaceIdsRef.current = [];
     streamingA2UIMessagesRef.current = [];
     progressiveQueue.reset();
+    generateProgressStateRef.current = null;
+    streamedFileKeysRef.current = new Set();
+    setWorkspaceAnnouncement('');
 
     const handleIncomingA2UI = (payload: A2uiPayloadItem[]) => {
       processIncomingA2UI(payload, assistantMessageId);
+    };
+
+    const finalizeGenerateProgressForCompletion = () => {
+      const currentState = generateProgressStateRef.current;
+      if (!currentState) {
+        return;
+      }
+
+      const finalizedState = finalizeGenerateProgressState(currentState);
+      if (finalizedState === currentState) {
+        return;
+      }
+
+      generateProgressStateRef.current = finalizedState;
+      processIncomingA2UI(buildGenerateProgressMessages(finalizedState, false), assistantMessageId);
+    };
+
+    const finalizeGenerateProgressForError = (error: string) => {
+      const currentState = generateProgressStateRef.current;
+      if (!currentState) {
+        return;
+      }
+
+      setConversationPhase('generate');
+      const interruptedState = interruptGenerateProgressState(currentState, error);
+      generateProgressStateRef.current = interruptedState;
+      processIncomingA2UI(buildGenerateProgressMessages(interruptedState, false), assistantMessageId);
+    };
+
+    const collectAssistantTurnArtifacts = () => {
+      progressiveQueue.flush();
+      const collectedIds = streamingSurfaceIdsRef.current;
+      const surfaceIds = collectedIds.length > 0 ? collectedIds : undefined;
+      const a2uiMessages = streamingA2UIMessagesRef.current.length > 0
+        ? [...streamingA2UIMessagesRef.current]
+        : undefined;
+
+      streamingSurfaceIdsRef.current = [];
+      streamingA2UIMessagesRef.current = [];
+      progressiveQueue.reset();
+      generateProgressStateRef.current = null;
+      streamedFileKeysRef.current = new Set();
+
+      return { surfaceIds, a2uiMessages };
     };
 
     // Use mock streaming when ?mock is active, real streaming otherwise
@@ -259,16 +339,12 @@ export function App() {
       mockStreaming.send(text, sessionId, {
         onDelta: () => {},
         onA2UI: handleIncomingA2UI,
+        onGenerateEvent: (event) => handleIncomingGenerateEvent(event, assistantMessageId),
         onPhase: (phase) => setConversationPhase(phase),
         onComplete: (fullText, model) => {
+          finalizeGenerateProgressForCompletion();
           const phase = currentPhaseRef.current || undefined;
-          progressiveQueue.flush();
-          const collectedIds = streamingSurfaceIdsRef.current;
-          const surfaceIds = collectedIds.length > 0 ? collectedIds : undefined;
-          const a2uiMessages = streamingA2UIMessagesRef.current.length > 0 ? [...streamingA2UIMessagesRef.current] : undefined;
-          streamingSurfaceIdsRef.current = [];
-          streamingA2UIMessagesRef.current = [];
-          progressiveQueue.reset();
+          const { surfaceIds, a2uiMessages } = collectAssistantTurnArtifacts();
           const assistantMsg: ChatMessage = {
             id: assistantMessageId,
             role: 'assistant',
@@ -283,14 +359,17 @@ export function App() {
           sessions.addMessage(sessionId!, assistantMsg);
         },
         onError: (error) => {
-          streamingSurfaceIdsRef.current = [];
-          streamingA2UIMessagesRef.current = [];
-          progressiveQueue.reset();
+          finalizeGenerateProgressForError(error);
+          const phase = currentPhaseRef.current || undefined;
+          const { surfaceIds, a2uiMessages } = collectAssistantTurnArtifacts();
           const errorMsg: ChatMessage = {
             id: msgId('error'),
             role: 'assistant',
             text: `⚠️ ${error}`,
+            surfaceIds,
+            phase,
             timestamp: Date.now(),
+            a2uiMessages,
           };
           setMessages(prev => [...prev, errorMsg]);
           sessions.addMessage(sessionId!, errorMsg);
@@ -304,20 +383,16 @@ export function App() {
       streaming.send(text, backendSessionId, {
         onDelta: () => {},
         onA2UI: handleIncomingA2UI,
+        onGenerateEvent: (event) => handleIncomingGenerateEvent(event, assistantMessageId),
         onPhase: (phase) => setConversationPhase(phase),
         onComplete: (fullText, model, receivedSessionId, debugInfo, usage) => {
+          finalizeGenerateProgressForCompletion();
           const phase = currentPhaseRef.current || undefined;
           // Store the backend session ID on first response
           if (receivedSessionId && !activeSession?.backendSessionId) {
             sessions.updateSession(sessionId!, { backendSessionId: receivedSessionId });
           }
-          progressiveQueue.flush();
-          const collectedIds = streamingSurfaceIdsRef.current;
-          const surfaceIds = collectedIds.length > 0 ? collectedIds : undefined;
-          const a2uiMessages = streamingA2UIMessagesRef.current.length > 0 ? [...streamingA2UIMessagesRef.current] : undefined;
-          streamingSurfaceIdsRef.current = [];
-          streamingA2UIMessagesRef.current = [];
-          progressiveQueue.reset();
+          const { surfaceIds, a2uiMessages } = collectAssistantTurnArtifacts();
           const assistantMsg: ChatMessage = {
             id: assistantMessageId,
             role: 'assistant',
@@ -334,21 +409,24 @@ export function App() {
           sessions.addMessage(sessionId!, assistantMsg);
         },
         onError: (error) => {
-          streamingSurfaceIdsRef.current = [];
-          streamingA2UIMessagesRef.current = [];
-          progressiveQueue.reset();
+          finalizeGenerateProgressForError(error);
+          const phase = currentPhaseRef.current || undefined;
+          const { surfaceIds, a2uiMessages } = collectAssistantTurnArtifacts();
           const errorMsg: ChatMessage = {
             id: msgId('error'),
             role: 'assistant',
             text: `⚠️ ${error}`,
+            surfaceIds,
+            phase,
             timestamp: Date.now(),
+            a2uiMessages,
           };
           setMessages(prev => [...prev, errorMsg]);
           sessions.addMessage(sessionId!, errorMsg);
         },
       }, debugEnabled, activeSession?.messages ?? []);
     }
-  }, [sessions, streaming, mockStreaming, isApiAvailable, resetConsecutiveCount, progressiveQueue, debugEnabled, clearActionLog, setConversationPhase, processIncomingA2UI]);
+  }, [sessions, streaming, mockStreaming, isApiAvailable, resetConsecutiveCount, progressiveQueue, debugEnabled, clearActionLog, setConversationPhase, processIncomingA2UI, handleIncomingGenerateEvent]);
 
   const handleStartChat = useCallback(async (prompt: string) => {
     await clearWorkspace();
@@ -428,7 +506,6 @@ export function App() {
         nav.replaceCurrent({ view: 'landing' });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const isStreaming = mockEnabled ? mockStreaming.isStreaming : streaming.isStreaming;
@@ -577,6 +654,7 @@ export function App() {
             <FileManagerSidebar
               streamingFiles={fsFiles}
               persistedFiles={vfsFileRecords}
+              workspaceAnnouncement={workspaceAnnouncement}
               selectedPath={viewerFile}
               onSelectFile={handleSelectViewerFile}
               onDownloadZip={handleDownloadZip}

--- a/packages/web/src/__tests__/chat-ui.test.ts
+++ b/packages/web/src/__tests__/chat-ui.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ChatMessage as ChatMessageView } from '../components/Chat/ChatMessage';
 import { ChatShell } from '../components/Chat/ChatShell';
 import { DebugPanel } from '../components/Chat/DebugPanel';
+import { FileManagerSidebar } from '../components/FileManager';
 import type { ChatMessage, TokenUsageSummary } from '../types';
 import { GENERATE_PROGRESS_TITLE, getLatestConversationPhase, rebuildChatSessionState } from '../utils/chat-a2ui';
 import { summarizeTokenUsage } from '../utils/chat-usage';
@@ -335,10 +336,12 @@ describe('chat file workspace rehydration', () => {
     ]);
     expect(firstSession.renderableMessages[0].createSurface?.surfaceId).toBe('assistant-turn-8::msg-1');
     expect(firstSession.renderableMessages[1].updateComponents?.surfaceId).toBe('assistant-turn-8::msg-1');
-    expect(firstSession.renderableMessages[1].updateComponents?.components[0]).toMatchObject({
-      id: 'progress',
-      title: GENERATE_PROGRESS_TITLE,
-    });
+    expect(firstSession.renderableMessages[1].updateComponents?.components).toEqual([
+      expect.objectContaining({
+        id: 'progress',
+        title: GENERATE_PROGRESS_TITLE,
+      }),
+    ]);
 
     const secondSession = rebuildChatSessionState([
       {
@@ -376,5 +379,21 @@ describe('chat file workspace rehydration', () => {
     ]);
     expect(secondSession.renderableMessages[0].createSurface?.surfaceId).toBe('assistant-turn-9::msg-2');
     expect(secondSession.renderableMessages[1].updateComponents?.surfaceId).toBe('assistant-turn-9::msg-2');
+  });
+
+  it('exposes a polite live region for streamed workspace announcements', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(FileManagerSidebar, {
+        streamingFiles: [],
+        persistedFiles: [],
+        workspaceAnnouncement: 'Dockerfile added to workspace',
+        onSelectFile: () => undefined,
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain('Dockerfile added to workspace');
   });
 });

--- a/packages/web/src/components/FileManager/FileManagerSidebar.tsx
+++ b/packages/web/src/components/FileManager/FileManagerSidebar.tsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
+    position: 'relative',
     width: '260px',
     minWidth: '200px',
     maxWidth: '360px',
@@ -117,6 +118,17 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     paddingTop: tokens.spacingVerticalXXL,
     color: tokens.colorNeutralForeground3,
+  },
+  screenReaderOnly: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    margin: '-1px',
+    overflow: 'hidden',
+    border: '0',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
   },
 });
 
@@ -263,6 +275,8 @@ export interface FileManagerSidebarProps {
   streamingFiles: VirtualFile[];
   /** IndexedDB-backed persisted files. */
   persistedFiles: VFSFile[];
+  /** Latest screen-reader announcement for streamed workspace updates. */
+  workspaceAnnouncement?: string;
   /** Currently selected file path in the viewer. */
   selectedPath?: string;
   /** Called when user clicks a file node. */
@@ -276,6 +290,7 @@ export interface FileManagerSidebarProps {
 export function FileManagerSidebar({
   streamingFiles,
   persistedFiles,
+  workspaceAnnouncement,
   selectedPath,
   onSelectFile,
   onDownloadZip,
@@ -330,6 +345,14 @@ export function FileManagerSidebar({
 
   return (
     <div className={styles.root} data-testid="file-manager-sidebar">
+      <div
+        className={styles.screenReaderOnly}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {workspaceAnnouncement ?? ''}
+      </div>
       <div className={styles.header}>
         <Text className={styles.headerTitle} size={300}>
           Files{fileCount > 0 ? ` (${fileCount})` : ''}

--- a/packages/web/src/hooks/useMockStreaming.ts
+++ b/packages/web/src/hooks/useMockStreaming.ts
@@ -7,11 +7,12 @@
 
 import { useState, useCallback, useRef } from 'react';
 import { sendMock, resetMockState } from '../services/mock-streaming';
-import type { A2uiPayloadItem } from '../types';
+import type { A2uiPayloadItem, GenerateStreamEvent } from '../types';
 
 interface MockStreamCallbacks {
   onDelta: (text: string) => void;
   onA2UI: (messages: A2uiPayloadItem[]) => void;
+  onGenerateEvent?: (event: GenerateStreamEvent) => void;
   onPhase: (phase: string) => void;
   onComplete: (fullText: string, model?: string, sessionId?: string) => void;
   onError: (error: string) => void;

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -4,6 +4,7 @@ import type {
   A2uiPayloadItem,
   DebugMetadata,
   ChatMessage,
+  GenerateStreamEvent,
   TokenUsageSummary,
 } from '../types';
 import { apiFetch, SessionExpiredError } from '../services/api-client';
@@ -11,6 +12,7 @@ import { apiFetch, SessionExpiredError } from '../services/api-client';
 interface StreamCallbacks {
   onDelta: (text: string) => void;
   onA2UI: (messages: A2uiPayloadItem[]) => void;
+  onGenerateEvent: (event: GenerateStreamEvent) => void;
   onPhase: (phase: string) => void;
   onComplete: (
     fullText: string,
@@ -219,6 +221,58 @@ export function useStreaming() {
                 displayText = parsed.content;
                 updateRevealTarget(displayText);
               }
+              currentEventType = '';
+              continue;
+            }
+
+            if (currentEventType === 'step_start') {
+              const parsed = JSON.parse(data);
+              callbacks.onGenerateEvent({
+                type: 'step_start',
+                stepId: parsed.stepId,
+                label: parsed.label,
+                sequence: parsed.sequence,
+              });
+              currentEventType = '';
+              continue;
+            }
+
+            if (currentEventType === 'file_generated') {
+              const parsed = JSON.parse(data);
+              callbacks.onGenerateEvent({
+                type: 'file_generated',
+                stepId: parsed.stepId,
+                path: parsed.path,
+                language: parsed.language,
+                content: parsed.content,
+                byteLength: parsed.byteLength,
+                sha256: parsed.sha256,
+              });
+              currentEventType = '';
+              continue;
+            }
+
+            if (currentEventType === 'step_complete') {
+              const parsed = JSON.parse(data);
+              callbacks.onGenerateEvent({
+                type: 'step_complete',
+                stepId: parsed.stepId,
+                filesCount: parsed.filesCount,
+                totalBytes: parsed.totalBytes,
+              });
+              currentEventType = '';
+              continue;
+            }
+
+            if (currentEventType === 'step_error') {
+              const parsed = JSON.parse(data);
+              callbacks.onGenerateEvent({
+                type: 'step_error',
+                stepId: parsed.stepId,
+                code: parsed.code,
+                message: parsed.message,
+                recoverable: parsed.recoverable,
+              });
               currentEventType = '';
               continue;
             }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -57,6 +57,51 @@ export interface TokenUsageSummary {
   session: SessionUsageTotals;
 }
 
+export type GenerationStepErrorCode =
+  | 'codex_timeout'
+  | 'codex_error'
+  | 'validation_failed'
+  | 'quota_exceeded'
+  | 'connection_interrupted';
+
+export interface StepStartEvent {
+  type: 'step_start';
+  stepId: string;
+  label: string;
+  sequence: number;
+}
+
+export interface FileGeneratedEvent {
+  type: 'file_generated';
+  stepId: string;
+  path: string;
+  language: string;
+  content: string;
+  byteLength: number;
+  sha256: string;
+}
+
+export interface StepCompleteEvent {
+  type: 'step_complete';
+  stepId: string;
+  filesCount: number;
+  totalBytes: number;
+}
+
+export interface StepErrorEvent {
+  type: 'step_error';
+  stepId: string;
+  code: GenerationStepErrorCode;
+  message: string;
+  recoverable: boolean;
+}
+
+export type GenerateStreamEvent =
+  | StepStartEvent
+  | FileGeneratedEvent
+  | StepCompleteEvent
+  | StepErrorEvent;
+
 export type ConversationPhaseId =
   | 'discover'
   | 'design'

--- a/packages/web/src/utils/chat-a2ui.test.ts
+++ b/packages/web/src/utils/chat-a2ui.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatMessage, A2uiPayloadItem } from '../types';
 import {
+  applyGenerateStreamEvent,
+  buildGenerateProgressMessages,
   GENERATE_PROGRESS_TITLE,
+  GENERATE_PROGRESS_SURFACE_ID,
+  finalizeGenerateProgressState,
   getLatestConversationPhase,
+  interruptGenerateProgressState,
   prepareChatA2ui,
   prepareChatA2uiPayload,
   rebuildChatSessionState,
@@ -89,7 +94,7 @@ describe('prepareChatA2uiPayload', () => {
 });
 
 describe('prepareChatA2ui', () => {
-  it('replaces inline FileEditor components with workspace summaries and extracts files', () => {
+  it('suppresses inline FileEditor components during generate while still extracting workspace files', () => {
     const payload: A2uiPayloadItem[] = [
       {
         type: 'ConversationPhase',
@@ -146,12 +151,6 @@ describe('prepareChatA2ui', () => {
           component: 'DeploymentProgress',
           steps: [{ id: 'dockerfile', label: 'Dockerfile', status: 'complete' }],
           title: GENERATE_PROGRESS_TITLE,
-        },
-        {
-          id: 'file',
-          component: 'Text',
-          text: '📄 Dockerfile is available in the workspace.',
-          variant: 'body2',
         },
       ],
     });
@@ -269,6 +268,135 @@ describe('prepareChatA2ui', () => {
       artifactPath: 'artifacts/infra/main.bicep',
       content: 'param location string = resourceGroup().location',
       language: 'bicep',
+    });
+  });
+
+  it('turns stepwise generate events into progress-only chat surfaces while writing files to the workspace', () => {
+    const started = applyGenerateStreamEvent(null, {
+      type: 'step_start',
+      stepId: 'dockerfile',
+      label: 'Dockerfile',
+      sequence: 1,
+    }, { includeCreateSurface: true });
+    const withFile = applyGenerateStreamEvent(started.state, {
+      type: 'file_generated',
+      stepId: 'dockerfile',
+      path: 'Dockerfile',
+      language: 'dockerfile',
+      content: 'FROM node:20-alpine',
+      byteLength: 19,
+      sha256: 'sha-1',
+    });
+    const completed = applyGenerateStreamEvent(withFile.state, {
+      type: 'step_complete',
+      stepId: 'dockerfile',
+      filesCount: 1,
+      totalBytes: 19,
+    });
+    const finalized = finalizeGenerateProgressState(completed.state);
+
+    const prepared = prepareChatA2ui(
+      [
+        ...started.messages,
+        ...withFile.messages,
+        ...completed.messages,
+        ...buildGenerateProgressMessages(finalized, false),
+      ],
+      'assistant-turn-stepwise',
+      { currentPhase: 'generate' },
+    );
+
+    expect(prepared.files).toEqual([
+      {
+        path: 'Dockerfile',
+        content: 'FROM node:20-alpine',
+        language: 'dockerfile',
+      },
+    ]);
+    expect(prepared.renderableMessages[0].createSurface?.surfaceId).toBe(
+      `assistant-turn-stepwise::${GENERATE_PROGRESS_SURFACE_ID}`,
+    );
+    expect(prepared.renderableMessages.slice(1)).toEqual([
+      expect.objectContaining({
+        updateComponents: expect.objectContaining({
+          surfaceId: `assistant-turn-stepwise::${GENERATE_PROGRESS_SURFACE_ID}`,
+          components: [
+            expect.objectContaining({
+              component: 'DeploymentProgress',
+              title: GENERATE_PROGRESS_TITLE,
+              overallStatus: 'running',
+              statusMessage: 'Generating Dockerfile…',
+            }),
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        updateComponents: expect.objectContaining({
+          surfaceId: `assistant-turn-stepwise::${GENERATE_PROGRESS_SURFACE_ID}`,
+          components: [
+            expect.objectContaining({
+              component: 'DeploymentProgress',
+              statusMessage: 'Dockerfile added to workspace.',
+            }),
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        updateComponents: expect.objectContaining({
+          surfaceId: `assistant-turn-stepwise::${GENERATE_PROGRESS_SURFACE_ID}`,
+          components: [
+            expect.objectContaining({
+              component: 'DeploymentProgress',
+              overallStatus: 'running',
+              statusMessage: 'Dockerfile complete.',
+            }),
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        updateComponents: expect.objectContaining({
+          surfaceId: `assistant-turn-stepwise::${GENERATE_PROGRESS_SURFACE_ID}`,
+          components: [
+            expect.objectContaining({
+              component: 'DeploymentProgress',
+              overallStatus: 'complete',
+              statusMessage: 'Setup files are ready in the workspace.',
+            }),
+          ],
+        }),
+      }),
+    ]);
+    expect(
+      prepared.renderableMessages.flatMap((message) => message.updateComponents?.components ?? []),
+    ).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ component: 'FileEditor' }),
+      expect.objectContaining({ component: 'Text', text: expect.stringContaining('workspace') }),
+    ]));
+  });
+
+  it('marks interrupted stepwise progress as an error state without changing prior files', () => {
+    const started = applyGenerateStreamEvent(null, {
+      type: 'step_start',
+      stepId: 'deployment-config',
+      label: 'Deployment config',
+      sequence: 2,
+    });
+
+    const interrupted = interruptGenerateProgressState(started.state, 'Connection interrupted.');
+
+    expect(interrupted).toMatchObject({
+      overallStatus: 'error',
+      errorCode: 'connection_interrupted',
+      errorMessage: 'Connection interrupted.',
+      statusMessage: 'Connection interrupted.',
+      steps: [
+        {
+          id: 'deployment-config',
+          label: 'Deployment config',
+          status: 'error',
+          detail: 'Connection interrupted.',
+        },
+      ],
     });
   });
 });

--- a/packages/web/src/utils/chat-a2ui.ts
+++ b/packages/web/src/utils/chat-a2ui.ts
@@ -1,4 +1,13 @@
-import type { A2uiComponent, A2uiMsg, A2uiPayloadItem, ChatMessage, ConversationPhaseId } from '../types';
+import type {
+  A2uiComponent,
+  A2uiMsg,
+  A2uiPayloadItem,
+  ChatMessage,
+  ConversationPhaseId,
+  FileGeneratedEvent,
+  GenerateStreamEvent,
+  GenerationStepErrorCode,
+} from '../types';
 
 const PHASE_COMPONENT_NAME = 'ConversationPhase';
 const PHASE_SURFACE_ID = 'phase-indicator';
@@ -44,6 +53,17 @@ const FILE_NAME_LANGUAGES: Record<string, string> = {
 };
 
 export const GENERATE_PROGRESS_TITLE = 'Project Setup';
+export const GENERATE_PROGRESS_SURFACE_ID = 'generate-progress';
+
+const GENERATE_PROGRESS_COMPONENT_ID = 'generate-progress-card';
+
+const GENERATE_STEP_LABELS: Record<string, string> = {
+  'app-scaffolding': 'App scaffolding',
+  dockerfile: 'Dockerfile',
+  'deployment-config': 'Deployment config',
+  'ci-cd': 'CI/CD',
+  'service-connections': 'Service connections',
+};
 
 export const CONVERSATION_PHASE_ORDER = [
   'discover',
@@ -79,6 +99,289 @@ export interface PreparedChatA2ui {
   renderableMessages: A2uiMsg[];
   files: GeneratedChatFile[];
   phase: ConversationPhaseId | null;
+}
+
+export interface GenerateProgressStep {
+  id: string;
+  label: string;
+  sequence: number;
+  status: 'pending' | 'running' | 'complete' | 'error' | 'skipped';
+  detail?: string;
+}
+
+export interface GenerateProgressState {
+  steps: GenerateProgressStep[];
+  overallStatus: 'running' | 'complete' | 'error';
+  statusMessage?: string;
+  errorCode?: GenerationStepErrorCode;
+  errorMessage?: string;
+}
+
+export function applyGenerateStreamEvent(
+  state: GenerateProgressState | null,
+  event: GenerateStreamEvent,
+  options: { includeCreateSurface?: boolean } = {},
+): { state: GenerateProgressState; messages: A2uiPayloadItem[] } {
+  const nextState = reduceGenerateStreamEvent(state, event);
+  return {
+    state: nextState,
+    messages: buildGenerateProgressMessages(nextState, options.includeCreateSurface ?? false, event),
+  };
+}
+
+export function finalizeGenerateProgressState(state: GenerateProgressState): GenerateProgressState {
+  if (state.overallStatus !== 'running') {
+    return state;
+  }
+
+  return {
+    ...state,
+    overallStatus: 'complete',
+    statusMessage: 'Setup files are ready in the workspace.',
+    errorCode: undefined,
+    errorMessage: undefined,
+  };
+}
+
+export function interruptGenerateProgressState(
+  state: GenerateProgressState,
+  message: string,
+): GenerateProgressState {
+  const targetStep = [...state.steps]
+    .sort(compareGenerateSteps)
+    .find((step) => step.status === 'running')
+    ?? [...state.steps].sort(compareGenerateSteps).at(-1);
+
+  const nextSteps = targetStep
+    ? upsertGenerateStep(state.steps, {
+        ...targetStep,
+        status: 'error',
+        detail: message,
+      })
+    : state.steps;
+
+  return {
+    ...state,
+    steps: nextSteps,
+    overallStatus: 'error',
+    statusMessage: message,
+    errorCode: 'connection_interrupted',
+    errorMessage: message,
+  };
+}
+
+function reduceGenerateStreamEvent(
+  state: GenerateProgressState | null,
+  event: GenerateStreamEvent,
+): GenerateProgressState {
+  const current = state ?? {
+    steps: [],
+    overallStatus: 'running' as const,
+  };
+
+  switch (event.type) {
+    case 'step_start': {
+      const nextStep = {
+        id: event.stepId,
+        label: normalizeGenerateStepLabel(event.stepId, event.label),
+        sequence: event.sequence,
+        status: 'running' as const,
+        detail: undefined,
+      };
+
+      return {
+        steps: upsertGenerateStep(current.steps, nextStep),
+        overallStatus: 'running',
+        statusMessage: `Generating ${nextStep.label}…`,
+        errorCode: undefined,
+        errorMessage: undefined,
+      };
+    }
+
+    case 'file_generated': {
+      const step = findGenerateStep(current.steps, event.stepId);
+      const detail = `${event.path} added to workspace.`;
+
+      return {
+        ...current,
+        steps: upsertGenerateStep(current.steps, {
+          id: event.stepId,
+          label: step?.label ?? normalizeGenerateStepLabel(event.stepId),
+          sequence: step?.sequence ?? current.steps.length,
+          status: 'running',
+          detail,
+        }),
+        overallStatus: 'running',
+        statusMessage: detail,
+      };
+    }
+
+    case 'step_complete': {
+      const step = findGenerateStep(current.steps, event.stepId);
+
+      return {
+        ...current,
+        steps: upsertGenerateStep(current.steps, {
+          id: event.stepId,
+          label: step?.label ?? normalizeGenerateStepLabel(event.stepId),
+          sequence: step?.sequence ?? current.steps.length,
+          status: 'complete',
+          detail: formatStepCompleteDetail(event.filesCount, event.totalBytes),
+        }),
+        overallStatus: 'running',
+        statusMessage: `${step?.label ?? normalizeGenerateStepLabel(event.stepId)} complete.`,
+      };
+    }
+
+    case 'step_error': {
+      const step = findGenerateStep(current.steps, event.stepId);
+      const recoveryHint = event.recoverable ? ' Retry this step or stop generation.' : '';
+
+      return {
+        ...current,
+        steps: upsertGenerateStep(current.steps, {
+          id: event.stepId,
+          label: step?.label ?? normalizeGenerateStepLabel(event.stepId),
+          sequence: step?.sequence ?? current.steps.length,
+          status: 'error',
+          detail: event.message,
+        }),
+        overallStatus: 'error',
+        statusMessage: `${event.message}${recoveryHint}`,
+        errorCode: event.code,
+        errorMessage: event.message,
+      };
+    }
+  }
+}
+
+export function buildGenerateProgressMessages(
+  state: GenerateProgressState,
+  includeCreateSurface: boolean,
+  event?: GenerateStreamEvent,
+): A2uiPayloadItem[] {
+  const messages: A2uiPayloadItem[] = [];
+
+  if (includeCreateSurface) {
+    messages.push({
+      version: 'v0.9',
+      createSurface: {
+        surfaceId: GENERATE_PROGRESS_SURFACE_ID,
+        catalogId: 'kickstart',
+      },
+    });
+  }
+
+  const components: A2uiComponent[] = [buildGenerateProgressComponent(state)];
+  if (event?.type === 'file_generated') {
+    components.push(buildGeneratedFileComponent(event));
+  }
+
+  messages.push({
+    version: 'v0.9',
+    updateComponents: {
+      surfaceId: GENERATE_PROGRESS_SURFACE_ID,
+      components,
+    },
+  });
+
+  return messages;
+}
+
+function buildGenerateProgressComponent(state: GenerateProgressState): A2uiComponent {
+  return {
+    id: GENERATE_PROGRESS_COMPONENT_ID,
+    component: 'DeploymentProgress',
+    title: GENERATE_PROGRESS_TITLE,
+    overallStatus: state.overallStatus,
+    statusMessage: state.statusMessage,
+    errorCode: state.errorCode,
+    errorMessage: state.errorMessage,
+    steps: [...state.steps]
+      .sort(compareGenerateSteps)
+      .map(({ id, label, status, detail }) => ({
+        id,
+        label,
+        status,
+        ...(detail ? { detail } : {}),
+      })),
+  };
+}
+
+function buildGeneratedFileComponent(event: FileGeneratedEvent): A2uiComponent {
+  return {
+    id: `generated-file-${sanitizeGenerateComponentId(`${event.stepId}-${event.path}`)}`,
+    component: 'FileEditor',
+    filename: event.path,
+    path: event.path,
+    language: event.language,
+    content: event.content,
+  };
+}
+
+function sanitizeGenerateComponentId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, '-');
+}
+
+function findGenerateStep(
+  steps: readonly GenerateProgressStep[],
+  stepId: string,
+): GenerateProgressStep | undefined {
+  return steps.find((step) => step.id === stepId);
+}
+
+function upsertGenerateStep(
+  steps: readonly GenerateProgressStep[],
+  nextStep: GenerateProgressStep,
+): GenerateProgressStep[] {
+  const nextSteps = [...steps];
+  const existingIndex = nextSteps.findIndex((step) => step.id === nextStep.id);
+
+  if (existingIndex === -1) {
+    nextSteps.push(nextStep);
+  } else {
+    nextSteps[existingIndex] = {
+      ...nextSteps[existingIndex],
+      ...nextStep,
+    };
+  }
+
+  return nextSteps.sort(compareGenerateSteps);
+}
+
+function compareGenerateSteps(a: GenerateProgressStep, b: GenerateProgressStep): number {
+  return a.sequence - b.sequence || a.label.localeCompare(b.label);
+}
+
+function normalizeGenerateStepLabel(stepId: string, label?: string): string {
+  return label?.trim() || GENERATE_STEP_LABELS[stepId] || humanizeGenerateStepId(stepId);
+}
+
+function humanizeGenerateStepId(stepId: string): string {
+  return stepId
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function formatStepCompleteDetail(filesCount: number, totalBytes: number): string {
+  const fileLabel = filesCount === 1 ? '1 file' : `${filesCount} files`;
+  return `${fileLabel} validated • ${formatByteSize(totalBytes)}`;
+}
+
+function formatByteSize(totalBytes: number): string {
+  if (totalBytes < 1024) {
+    return `${totalBytes} bytes`;
+  }
+
+  const kib = totalBytes / 1024;
+  if (kib < 1024) {
+    return `${kib.toFixed(1).replace(/\.0$/, '')} KiB`;
+  }
+
+  const mib = kib / 1024;
+  return `${mib.toFixed(1).replace(/\.0$/, '')} MiB`;
 }
 
 export function normalizeConversationPhase(phase: string | null | undefined): ConversationPhaseId | null {
@@ -368,7 +671,7 @@ function renderComponentsForChat(
     }
 
     if (isFileEditorComponent(component)) {
-      return buildGeneratedFileSummary(component);
+      return phase === 'generate' ? [] : buildGeneratedFileSummary(component);
     }
 
     if (phase === 'generate' && isDeploymentProgressComponent(component)) {


### PR DESCRIPTION
Closes #328

Working as Fry (Frontend Dev)
⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

Summary
- consume approved stepwise generate events on the frontend
- keep Generate chat progress/status only while routing validated files into the workspace/FileManager
- add workspace live announcements plus focused regressions for progress-only chat rendering and session rehydration

Testing
- vitest: targeted frontend files
- eslint: changed frontend files
- tsc packages/web: blocked by pre-existing vendor/Zod typing issues unrelated to this slice