### PR TITLE
feat: implement codex-backed setup generation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,32 @@ export type {
   ResolvedCopilotSkills,
 } from "./engine/index.js";
 
+// Setup generation shared contract
+export {
+  SETUP_GENERATION_STEP_ORDER,
+  SETUP_GENERATION_STEP_LABELS,
+  SETUP_GENERATION_FILE_LANGUAGE_ALLOWLIST,
+  SETUP_GENERATION_QUOTAS,
+} from "./setup-generation.js";
+export type {
+  SetupGenerationStepId,
+  SetupGenerationFileLanguage,
+  SetupGenerationStepStatus,
+  SetupGenerationRunStatus,
+  SetupGenerationControlAction,
+  SetupGenerationErrorCode,
+  SetupGenerationStepState,
+  SetupGeneratedFileManifest,
+  SetupGenerationStepError,
+  SetupGenerationRunState,
+  SetupGenerationSnapshot,
+  SetupGenerationStepStartEvent,
+  SetupGenerationFileGeneratedEvent,
+  SetupGenerationStepCompleteEvent,
+  SetupGenerationStepErrorEvent,
+  SetupGenerationEvent,
+} from "./setup-generation.js";
+
 // Generators
 export {
   generateKubernetesManifests,

--- a/packages/core/src/setup-generation.ts
+++ b/packages/core/src/setup-generation.ts
@@ -1,0 +1,153 @@
+export const SETUP_GENERATION_STEP_ORDER = [
+  "app-scaffolding",
+  "dockerfile",
+  "deployment-config",
+  "ci-cd",
+  "service-connections",
+] as const;
+
+export type SetupGenerationStepId =
+  typeof SETUP_GENERATION_STEP_ORDER[number];
+
+export const SETUP_GENERATION_STEP_LABELS: Record<
+  SetupGenerationStepId,
+  string
+> = {
+  "app-scaffolding": "App scaffolding",
+  dockerfile: "Dockerfile",
+  "deployment-config": "Deployment config",
+  "ci-cd": "CI/CD",
+  "service-connections": "Service connections",
+};
+
+export const SETUP_GENERATION_FILE_LANGUAGE_ALLOWLIST = [
+  "typescript",
+  "javascript",
+  "python",
+  "yaml",
+  "json",
+  "dockerfile",
+  "bicep",
+  "go",
+  "shell",
+  "html",
+  "css",
+  "markdown",
+  "ignore",
+  "dotenv",
+  "toml",
+  "plaintext",
+] as const;
+
+export type SetupGenerationFileLanguage =
+  typeof SETUP_GENERATION_FILE_LANGUAGE_ALLOWLIST[number];
+
+export type SetupGenerationStepStatus =
+  | "pending"
+  | "running"
+  | "complete"
+  | "error"
+  | "skipped";
+
+export type SetupGenerationRunStatus =
+  | "idle"
+  | "running"
+  | "paused"
+  | "complete"
+  | "failed";
+
+export type SetupGenerationControlAction =
+  | "retry-current-step"
+  | "stop-generation";
+
+export type SetupGenerationErrorCode =
+  | "codex_timeout"
+  | "codex_error"
+  | "validation_failed"
+  | "quota_exceeded"
+  | "connection_interrupted";
+
+export const SETUP_GENERATION_QUOTAS = {
+  maxFilesPerStep: 4,
+  maxBytesPerFile: 64 * 1024,
+  maxBytesPerStep: 160 * 1024,
+  maxFilesPerSession: 20,
+  maxBytesPerSession: 512 * 1024,
+} as const;
+
+export interface SetupGenerationStepState {
+  id: SetupGenerationStepId;
+  label: string;
+  required: boolean;
+  status: SetupGenerationStepStatus;
+}
+
+export interface SetupGeneratedFileManifest {
+  stepId: SetupGenerationStepId;
+  path: string;
+  language: string;
+  byteLength: number;
+  sha256: string;
+}
+
+export interface SetupGenerationStepError {
+  stepId: SetupGenerationStepId;
+  code: SetupGenerationErrorCode;
+  message: string;
+  recoverable: boolean;
+  occurredAt: string;
+}
+
+export interface SetupGenerationRunState {
+  runId: string;
+  phase: "generate";
+  currentStepIndex: number;
+  steps: SetupGenerationStepState[];
+  status: SetupGenerationRunStatus;
+  generatedFiles: SetupGeneratedFileManifest[];
+  totalBytes: number;
+  updatedAt: string;
+  lastError?: SetupGenerationStepError;
+}
+
+export interface SetupGenerationSnapshot {
+  run: SetupGenerationRunState;
+}
+
+export interface SetupGenerationStepStartEvent {
+  type: "step_start";
+  stepId: SetupGenerationStepId;
+  label: string;
+  sequence: number;
+}
+
+export interface SetupGenerationFileGeneratedEvent {
+  type: "file_generated";
+  stepId: SetupGenerationStepId;
+  path: string;
+  language: string;
+  content: string;
+  byteLength: number;
+  sha256: string;
+}
+
+export interface SetupGenerationStepCompleteEvent {
+  type: "step_complete";
+  stepId: SetupGenerationStepId;
+  filesCount: number;
+  totalBytes: number;
+}
+
+export interface SetupGenerationStepErrorEvent {
+  type: "step_error";
+  stepId: SetupGenerationStepId;
+  code: SetupGenerationErrorCode;
+  message: string;
+  recoverable: boolean;
+}
+
+export type SetupGenerationEvent =
+  | SetupGenerationStepStartEvent
+  | SetupGenerationFileGeneratedEvent
+  | SetupGenerationStepCompleteEvent
+  | SetupGenerationStepErrorEvent;

--- a/packages/web/api/src/functions/converse.test.ts
+++ b/packages/web/api/src/functions/converse.test.ts
@@ -11,6 +11,12 @@ const chatCompletionWithTools = vi.fn();
 const chatCompletion = vi.fn();
 const chatCompletionWithAutoContinue = vi.fn(async () => ({ content: "" }));
 const isTruncated = vi.fn(() => false);
+const executeSetupGeneration = vi.fn();
+const serializeSetupGenerationEvent = vi.fn((event: unknown) => JSON.stringify(event));
+const shouldUseStepwiseGeneration = vi.fn(() => false);
+const isSetupGenerationControlAction = vi.fn((value: string | undefined) =>
+  value === "retry-current-step" || value === "stop-generation",
+);
 
 vi.mock("@azure/functions", () => ({
   app: {
@@ -24,6 +30,13 @@ vi.mock("../lib/openai-client.js", () => ({
   getChatDeploymentName: () => "gpt-5.4-mini",
   getGenerateDeploymentName: () => "gpt-5.4",
   getCodexDeploymentName: () => "gpt-5.4",
+}));
+
+vi.mock("../lib/setup-generation.js", () => ({
+  executeSetupGeneration,
+  serializeSetupGenerationEvent,
+  shouldUseStepwiseGeneration,
+  isSetupGenerationControlAction,
 }));
 
 vi.mock("../lib/content-safety.js", () => ({
@@ -64,6 +77,15 @@ beforeEach(() => {
   chatCompletionWithAutoContinue.mockResolvedValue({ content: "" });
   isTruncated.mockReset();
   isTruncated.mockReturnValue(false);
+  executeSetupGeneration.mockReset();
+  serializeSetupGenerationEvent.mockReset();
+  serializeSetupGenerationEvent.mockImplementation((event: unknown) => JSON.stringify(event));
+  shouldUseStepwiseGeneration.mockReset();
+  shouldUseStepwiseGeneration.mockReturnValue(false);
+  isSetupGenerationControlAction.mockReset();
+  isSetupGenerationControlAction.mockImplementation((value: string | undefined) =>
+    value === "retry-current-step" || value === "stop-generation",
+  );
 });
 
 function createRequest(
@@ -560,6 +582,112 @@ describe("converse model routing", () => {
       model: "gpt-5.4",
       phase: Phase.Generate,
     });
+  });
+
+  it("streams stepwise setup events and snapshots when the generate flow is feature-flagged", async () => {
+    const session = createSession();
+    setSessionPhase(session, Phase.Generate);
+    shouldUseStepwiseGeneration.mockReturnValueOnce(true);
+    executeSetupGeneration.mockImplementationOnce(async (_session, options) => {
+      await options.hooks?.emitEvent?.({
+        type: "step_start",
+        stepId: "dockerfile",
+        label: "Dockerfile",
+        sequence: 1,
+      });
+      await options.hooks?.emitEvent?.({
+        type: "file_generated",
+        stepId: "dockerfile",
+        path: "Dockerfile",
+        language: "dockerfile",
+        content: "FROM node:20-alpine",
+        byteLength: 20,
+        sha256: "sha-1",
+      });
+      await options.hooks?.emitEvent?.({
+        type: "step_complete",
+        stepId: "dockerfile",
+        filesCount: 1,
+        totalBytes: 20,
+      });
+
+      return {
+        message: "Setup files are ready in the workspace. Next up: review the plan and deployment defaults.",
+        currentPhase: Phase.Review,
+        usage: {
+          inputTokens: 120,
+          outputTokens: 45,
+          totalTokens: 165,
+        },
+        events: [],
+        a2uiMessages: [],
+        snapshot: {
+          run: {
+            runId: "run-1",
+            phase: "generate",
+            currentStepIndex: 1,
+            steps: [
+              { id: "dockerfile", label: "Dockerfile", required: true, status: "complete" },
+            ],
+            status: "complete",
+            generatedFiles: [
+              {
+                stepId: "dockerfile",
+                path: "Dockerfile",
+                language: "dockerfile",
+                byteLength: 20,
+                sha256: "sha-1",
+              },
+            ],
+            totalBytes: 20,
+            updatedAt: "2026-04-16T00:00:00.000Z",
+          },
+        },
+      };
+    });
+
+    const response = await converseHandler(
+      createRequest(
+        {
+          sessionId: session.state.sessionId,
+          message: "Generate the next batch",
+        },
+        { accept: "text/event-stream" },
+      ),
+      createContext(),
+    ) as { status: number; body: ReadableStream<Uint8Array> };
+
+    expect(response.status).toBe(200);
+    expect(chatCompletion).not.toHaveBeenCalled();
+
+    const events = parseSseEvents(await readStream(response.body));
+    const eventNames = events.map((event) => event.event);
+    expect(eventNames).toEqual(expect.arrayContaining([
+      "step_start",
+      "file_generated",
+      "step_complete",
+      "message",
+      "done",
+    ]));
+
+    const donePayload = JSON.parse(
+      events.find((event) => event.event === "done")?.data ?? "{}",
+    ) as {
+      model?: string;
+      phase?: string;
+      setupGeneration?: { run?: { runId?: string } };
+    };
+
+    expect(donePayload).toMatchObject({
+      model: "gpt-5.4",
+      phase: Phase.Review,
+      setupGeneration: {
+        run: {
+          runId: "run-1",
+        },
+      },
+    });
+    expect(getSession(session.state.sessionId)?.engineState.currentPhase).toBe(Phase.Review);
   });
 
   it("uses generate pricing for trusted gpt-5.4 turns", async () => {

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -28,14 +28,21 @@ import {
   defaultKitRegistry,
   InMemoryArtifactStore,
   handleImplicitFlags,
+  transition,
 } from "@kickstart/core";
-import type { PhaseItem, ToolContext, ConversationState } from "@kickstart/core";
+import type {
+  PhaseItem,
+  ToolContext,
+  ConversationState,
+  SetupGenerationControlAction,
+  SetupGenerationSnapshot,
+} from "@kickstart/core";
 import {
   getSession, createSession, getPrincipalId, hydrateSession, addMessage,
   adoptSessionPrincipal, isSessionOwnedBy, recordUsage,
   extractArtifactsFromA2UI, upsertArtifact,
 } from "../lib/session-store.js";
-import type { ClientMessage, GeneratedArtifact } from "../lib/session-store.js";
+import type { ApiSession, ClientMessage, GeneratedArtifact } from "../lib/session-store.js";
 import { chatCompletion, chatCompletionWithTools } from "../lib/openai-client.js";
 import { checkContentSafety } from "../lib/content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
@@ -51,6 +58,12 @@ import {
   resolveConverseModelRoute,
 } from "../lib/converse-model-router.js";
 import type { ConverseModelRoute } from "../lib/converse-model-router.js";
+import {
+  executeSetupGeneration,
+  isSetupGenerationControlAction,
+  serializeSetupGenerationEvent,
+  shouldUseStepwiseGeneration,
+} from "../lib/setup-generation.js";
 
 interface ConverseRequest {
   sessionId?: string;
@@ -65,6 +78,7 @@ interface ConverseResponse {
   message: string;
   model?: string;
   a2ui?: object[];
+  setupGeneration?: SetupGenerationSnapshot;
   usage?: UsageSummary;
   autoContinue?: boolean;
   autoContinuePrompt?: string;
@@ -78,6 +92,7 @@ interface StreamDonePayload {
   phase: string;
   phaseLabel: string;
   model?: string;
+  setupGeneration?: SetupGenerationSnapshot;
   usage?: UsageSummary;
   autoContinue?: boolean;
   autoContinuePrompt?: string;
@@ -89,6 +104,32 @@ function getSafeCurrentPhase(
   engineState: Pick<ConversationState, "currentPhase">,
 ): Phase {
   return normalizeConversePhase(engineState.currentPhase) ?? Phase.Discover;
+}
+
+function extractSetupControlAction(
+  message: string,
+): SetupGenerationControlAction | undefined {
+  const normalized = message.trim().toLowerCase();
+  if (isSetupGenerationControlAction(normalized)) {
+    return normalized;
+  }
+
+  if (/retry(?: the)? current step/.test(normalized)) {
+    return "retry-current-step";
+  }
+
+  if (/stop(?: generation)?/.test(normalized)) {
+    return "stop-generation";
+  }
+
+  return undefined;
+}
+
+function syncSessionPhase(session: ApiSession, nextPhase: Phase): void {
+  while (getSafeCurrentPhase(session.engineState) !== nextPhase && !session.engineState.isComplete) {
+    session.engineState = transition(session.engineState, { type: "ADVANCE" });
+  }
+  session.state.currentPhase = session.engineState.currentPhase;
 }
 
 app.http("converse", {
@@ -170,6 +211,32 @@ app.http("converse", {
       const modelRoute = resolveConverseModelRoute(currentPhase, {
         trustedPhase: session.routingPhaseTrusted,
       });
+      const wantsStream = request.headers
+        .get("accept")
+        ?.includes("text/event-stream");
+      const debugMode = isDebugMode(request);
+      const setupControlAction = extractSetupControlAction(body.message);
+
+      if (shouldUseStepwiseGeneration(session, currentPhase)) {
+        const stepwiseModelRoute = resolveConverseModelRoute(currentPhase, {
+          trustedPhase: true,
+        });
+        if (wantsStream) {
+          return handleSetupGenerationStreaming(
+            session,
+            stepwiseModelRoute,
+            context,
+            debugMode,
+            setupControlAction,
+          );
+        }
+        return handleSetupGenerationResponse(
+          session,
+          stepwiseModelRoute,
+          debugMode,
+          setupControlAction,
+        );
+      }
 
 
       // Build artifact summary from files generated in previous turns
@@ -188,14 +255,6 @@ app.http("converse", {
         role: m.role as "system" | "user" | "assistant",
         content: idx === 0 && m.role === "system" ? freshSystemPrompt : m.content,
       }));
-
-      // Check if client wants SSE streaming
-      const wantsStream = request.headers
-        .get("accept")
-        ?.includes("text/event-stream");
-
-      // Check if debug metadata is requested
-      const debugMode = isDebugMode(request);
 
       // Create a session-scoped ToolContext for artifact isolation
       const toolContext: ToolContext = {
@@ -328,6 +387,139 @@ function buildPhaseIndicator(engineState: ConversationState): object[] {
       currentPhase,
     },
   ];
+}
+
+async function handleSetupGenerationResponse(
+  session: ApiSession,
+  modelRoute: ConverseModelRoute,
+  debugMode: boolean,
+  controlAction?: SetupGenerationControlAction,
+): Promise<HttpResponseInit> {
+  const result = await executeSetupGeneration(session, {
+    controlAction,
+    surfaceId: "generate-progress",
+  });
+
+  syncSessionPhase(session, result.currentPhase);
+  addMessage(session.state.sessionId, "assistant", result.message);
+
+  const usageSummary = finalizeUsage(
+    session.state.sessionId,
+    modelRoute,
+    result.usage,
+  );
+
+  const responseBody: ConverseResponse = {
+    sessionId: session.state.sessionId,
+    phase: result.currentPhase,
+    message: result.message,
+    model: modelRoute.model,
+    a2ui: [...buildPhaseIndicator(session.engineState), ...result.a2uiMessages],
+    ...(usageSummary ? { usage: usageSummary } : {}),
+    setupGeneration: result.snapshot,
+  };
+
+  if (debugMode) {
+    const debugMeta = buildConverseDebugMeta(
+      modelRoute.model,
+      result.message,
+      result.a2uiMessages.length,
+      result.a2uiMessages.length > 0,
+      session.engineState.currentPhase,
+    );
+    responseBody.debug = debugMeta;
+    responseBody.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
+  }
+
+  return { status: 200, jsonBody: responseBody };
+}
+
+function handleSetupGenerationStreaming(
+  session: ApiSession,
+  modelRoute: ConverseModelRoute,
+  context: InvocationContext,
+  debugMode: boolean,
+  controlAction?: SetupGenerationControlAction,
+): HttpResponseInit {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        const result = await executeSetupGeneration(session, {
+          controlAction,
+          surfaceId: "generate-progress",
+          hooks: {
+            emitEvent: (event) => {
+              controller.enqueue(
+                encoder.encode(
+                  `event: ${event.type}\ndata: ${serializeSetupGenerationEvent(event)}\n\n`,
+                ),
+              );
+            },
+          },
+        });
+
+        syncSessionPhase(session, result.currentPhase);
+        addMessage(session.state.sessionId, "assistant", result.message);
+
+        const usageSummary = finalizeUsage(
+          session.state.sessionId,
+          modelRoute,
+          result.usage,
+        );
+
+        controller.enqueue(
+          encoder.encode(
+            `event: message\ndata: ${JSON.stringify({ content: result.message })}\n\n`,
+          ),
+        );
+
+        const phaseDef = getPhaseDefinition(result.currentPhase);
+        const donePayload: StreamDonePayload = {
+          sessionId: session.state.sessionId,
+          phase: result.currentPhase,
+          phaseLabel: phaseDef.label,
+          model: modelRoute.model,
+          ...(usageSummary ? { usage: usageSummary } : {}),
+          setupGeneration: result.snapshot,
+        };
+
+        if (debugMode) {
+          const debugMeta = buildConverseDebugMeta(
+            modelRoute.model,
+            result.message,
+            result.a2uiMessages.length,
+            result.a2uiMessages.length > 0,
+            session.engineState.currentPhase,
+          );
+          donePayload.debug = debugMeta;
+          donePayload.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
+        }
+
+        controller.enqueue(
+          encoder.encode(`event: done\ndata: ${JSON.stringify(donePayload)}\n\n`),
+        );
+      } catch (err) {
+        const safeMsg = safeStreamError(err, context, "Stream error");
+        controller.enqueue(
+          encoder.encode(`event: error\ndata: ${JSON.stringify({ error: safeMsg })}\n\n`),
+        );
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    },
+    body: stream,
+  };
 }
 
 /** Handle SSE streaming response with typed events. */

--- a/packages/web/api/src/lib/openai-client.ts
+++ b/packages/web/api/src/lib/openai-client.ts
@@ -47,12 +47,14 @@ export interface CodexCompletionOptions {
   instructions?: string;
   temperature?: number;
   maxOutputTokens?: number;
+  deployment?: string;
 }
 
 export interface CodexCompletionResult {
   content: string;
   responseId: string;
   status: string;
+  usage?: ChatUsage;
 }
 
 // ---------------------------------------------------------------------------
@@ -341,11 +343,12 @@ export async function codexCompletion(
   options: CodexCompletionOptions = {},
 ): Promise<CodexCompletionResult> {
   const { endpoint, codexDeployment, apiKey } = getConfig();
-  if (!codexDeployment) {
+  const deployment = options.deployment || codexDeployment;
+  if (!deployment) {
     throw new Error("No codex deployment configured. Set AZURE_OPENAI_CODEX_DEPLOYMENT or AZURE_OPENAI_DEPLOYMENT.");
   }
 
-  const url = `${endpoint}/openai/deployments/${codexDeployment}/responses?api-version=${RESPONSES_API_VERSION}`;
+  const url = `${endpoint}/openai/deployments/${deployment}/responses?api-version=${RESPONSES_API_VERSION}`;
 
   const body: Record<string, unknown> = {
     input: input.filter((m) => m.role !== "system"),
@@ -381,6 +384,13 @@ export async function codexCompletion(
       type: string;
       content?: Array<{ type: string; text: string }>;
     }>;
+    usage?: {
+      prompt_tokens?: number;
+      completion_tokens?: number;
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+    };
   };
 
   const textParts = data.output
@@ -391,6 +401,7 @@ export async function codexCompletion(
     content: textParts.join(""),
     responseId: data.id,
     status: data.status,
+    usage: normalizeChatUsage(data.usage),
   };
 }
 
@@ -403,11 +414,12 @@ export async function* codexCompletionStream(
   options: CodexCompletionOptions = {},
 ): AsyncGenerator<string> {
   const { endpoint, codexDeployment, apiKey } = getConfig();
-  if (!codexDeployment) {
+  const deployment = options.deployment || codexDeployment;
+  if (!deployment) {
     throw new Error("No codex deployment configured. Set AZURE_OPENAI_CODEX_DEPLOYMENT or AZURE_OPENAI_DEPLOYMENT.");
   }
 
-  const url = `${endpoint}/openai/deployments/${codexDeployment}/responses?api-version=${RESPONSES_API_VERSION}`;
+  const url = `${endpoint}/openai/deployments/${deployment}/responses?api-version=${RESPONSES_API_VERSION}`;
 
   const body: Record<string, unknown> = {
     input: input.filter((m) => m.role !== "system"),

--- a/packages/web/api/src/lib/session-store.test.ts
+++ b/packages/web/api/src/lib/session-store.test.ts
@@ -92,6 +92,71 @@ describe("session-store phase hydration", () => {
       },
     ]);
   });
+
+  it("rehydrates trusted setup generation snapshots from client history", () => {
+    const session = hydrateSession([
+      {
+        role: "assistant",
+        content: "Setup generation paused on Dockerfile.",
+        phase: Phase.Generate,
+        setupGeneration: {
+          run: {
+            runId: "run-1",
+            phase: "generate",
+            currentStepIndex: 1,
+            steps: [
+              { id: "app-scaffolding", label: "App scaffolding", required: false, status: "skipped" },
+              { id: "dockerfile", label: "Dockerfile", required: true, status: "error" },
+              { id: "deployment-config", label: "Deployment config", required: true, status: "pending" },
+              { id: "ci-cd", label: "CI/CD", required: true, status: "pending" },
+              { id: "service-connections", label: "Service connections", required: false, status: "skipped" },
+            ],
+            status: "paused",
+            generatedFiles: [
+              {
+                stepId: "dockerfile",
+                path: "Dockerfile",
+                language: "dockerfile",
+                byteLength: 42,
+                sha256: "abc123",
+              },
+            ],
+            totalBytes: 42,
+            updatedAt: "2026-04-16T00:00:00.000Z",
+            lastError: {
+              stepId: "dockerfile",
+              code: "codex_error",
+              message: "Retry the current step.",
+              recoverable: true,
+              occurredAt: "2026-04-16T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    ], "principal-123");
+
+    expect(session.setupGenerationTrusted).toBe(true);
+    expect(session.setupGenerationRun).toMatchObject({
+      runId: "run-1",
+      currentStepIndex: 1,
+      status: "paused",
+      totalBytes: 42,
+      generatedFiles: [
+        expect.objectContaining({
+          path: "Dockerfile",
+          language: "dockerfile",
+        }),
+      ],
+    });
+    expect(session.generatedArtifacts).toEqual([
+      {
+        filename: "Dockerfile",
+        language: "dockerfile",
+        bicepResources: [],
+        k8sResources: [],
+      },
+    ]);
+  });
 });
 
 describe("extractArtifactsFromA2UI", () => {

--- a/packages/web/api/src/lib/session-store.test.ts
+++ b/packages/web/api/src/lib/session-store.test.ts
@@ -157,6 +157,34 @@ describe("session-store phase hydration", () => {
       },
     ]);
   });
+
+  it("rejects invalid setup generation snapshots from client history", () => {
+    const session = hydrateSession([
+      {
+        role: "assistant",
+        content: "Setup generation paused on Dockerfile.",
+        phase: Phase.Generate,
+        setupGeneration: {
+          run: {
+            runId: "run-1",
+            phase: "generate",
+            currentStepIndex: 1,
+            steps: [
+              { id: "dockerfile", label: "Dockerfile", required: true, status: "error" },
+            ],
+            status: "totally-invalid",
+            generatedFiles: [],
+            totalBytes: 0,
+            updatedAt: "2026-04-16T00:00:00.000Z",
+          },
+        },
+      },
+    ], "principal-123");
+
+    expect(session.setupGenerationTrusted).toBe(false);
+    expect(session.setupGenerationRun).toBeUndefined();
+    expect(session.generatedArtifacts).toEqual([]);
+  });
 });
 
 describe("extractArtifactsFromA2UI", () => {

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from "node:crypto";
 import {
   Phase,
+  SETUP_GENERATION_STEP_ORDER,
   createInitialState,
   buildSystemPrompt,
   transition,
@@ -17,6 +18,8 @@ import type {
   ConversationState,
   ConversationMessage,
   CostEstimateProps,
+  SetupGenerationRunState,
+  SetupGenerationSnapshot,
 } from "@kickstart/core";
 import { buildUsageSummary } from "./usage-tracking.js";
 import type { TurnUsage, UsageSummary } from "./usage-tracking.js";
@@ -78,6 +81,10 @@ export interface ApiSession {
   principalId?: string;
   /** Only server-owned phase state may escalate routing to codex. */
   routingPhaseTrusted: boolean;
+  /** Server-validated setup generation state for stepwise file generation. */
+  setupGenerationRun?: SetupGenerationRunState;
+  /** Client-supplied setup generation snapshots are trusted only after validation. */
+  setupGenerationTrusted: boolean;
   /** Thin deployment state for the real Azure happy path. */
   deployState: DeployState;
   /** Per-session CostEstimate pricing cache keyed by normalized pricing request. */
@@ -153,6 +160,7 @@ export function createSession(principalId?: string): ApiSession {
     usageHistory: [],
     principalId,
     routingPhaseTrusted: true,
+    setupGenerationTrusted: false,
     deployState: {
       stage: "idle",
       updatedAt: now,
@@ -173,6 +181,7 @@ export interface ClientMessage {
   content: string;
   phase?: string;
   usage?: TurnUsage;
+  setupGeneration?: SetupGenerationSnapshot;
   /** Optional compact artifact-bearing A2UI payloads for cold-start rehydration. */
   a2uiMessages?: unknown[];
 }
@@ -208,6 +217,7 @@ export function hydrateSession(clientMessages: ClientMessage[], principalId?: st
   const session = createSession(principalId);
   const now = new Date().toISOString();
   session.routingPhaseTrusted = false;
+  let latestSetupGeneration: SetupGenerationRunState | undefined;
 
   for (const msg of clientMessages) {
     // Only allow user/assistant — never trust client-sent system prompts
@@ -234,12 +244,29 @@ export function hydrateSession(clientMessages: ClientMessage[], principalId?: st
       if (isTurnUsage(msg.usage)) {
         session.usageHistory.push(msg.usage);
       }
+      if (isSetupGenerationSnapshot(msg.setupGeneration)) {
+        latestSetupGeneration = cloneSetupGenerationRun(msg.setupGeneration.run);
+        for (const generatedFile of latestSetupGeneration.generatedFiles) {
+          upsertArtifact(
+            session.generatedArtifacts,
+            extractArtifactMetadata(
+              generatedFile.path,
+              generatedFile.language,
+              "",
+            ),
+          );
+        }
+      }
     }
   }
 
   session.engineState = restoreEngineStateFromHistory(clientMessages);
   session.state.currentPhase = session.engineState.currentPhase;
   session.state.updatedAt = now;
+  if (latestSetupGeneration) {
+    session.setupGenerationRun = latestSetupGeneration;
+    session.setupGenerationTrusted = true;
+  }
   return session;
 }
 
@@ -435,4 +462,69 @@ function isTurnUsage(value: unknown): value is TurnUsage {
     && typeof usage.outputTokens === "number"
     && typeof usage.totalTokens === "number"
     && (usage.costStatus === "estimated" || usage.costStatus === "unavailable");
+}
+
+function isSetupGenerationSnapshot(
+  value: unknown,
+): value is SetupGenerationSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const snapshot = value as { run?: unknown };
+  if (!snapshot.run || typeof snapshot.run !== "object" || Array.isArray(snapshot.run)) {
+    return false;
+  }
+
+  const run = snapshot.run as Partial<SetupGenerationRunState>;
+  if (run.phase !== "generate") return false;
+  if (typeof run.runId !== "string" || run.runId.length === 0) return false;
+  if (typeof run.currentStepIndex !== "number" || !Number.isInteger(run.currentStepIndex) || run.currentStepIndex < 0) {
+    return false;
+  }
+  if (typeof run.status !== "string" || typeof run.updatedAt !== "string") {
+    return false;
+  }
+  if (!Array.isArray(run.steps) || !Array.isArray(run.generatedFiles)) {
+    return false;
+  }
+  if (typeof run.totalBytes !== "number" || !Number.isFinite(run.totalBytes) || run.totalBytes < 0) {
+    return false;
+  }
+
+  return run.steps.every((step) => {
+    if (!step || typeof step !== "object" || Array.isArray(step)) return false;
+    const candidate = step as Record<string, unknown>;
+    return typeof candidate.id === "string"
+      && SETUP_GENERATION_STEP_ORDER.includes(candidate.id as SetupGenerationRunState["steps"][number]["id"])
+      && typeof candidate.label === "string"
+      && typeof candidate.required === "boolean"
+      && (candidate.status === "pending"
+        || candidate.status === "running"
+        || candidate.status === "complete"
+        || candidate.status === "error"
+        || candidate.status === "skipped");
+  }) && run.generatedFiles.every((file) => {
+    if (!file || typeof file !== "object" || Array.isArray(file)) return false;
+    const candidate = file as Record<string, unknown>;
+    return typeof candidate.stepId === "string"
+      && SETUP_GENERATION_STEP_ORDER.includes(candidate.stepId as SetupGenerationRunState["generatedFiles"][number]["stepId"])
+      && typeof candidate.path === "string"
+      && typeof candidate.language === "string"
+      && typeof candidate.byteLength === "number"
+      && Number.isFinite(candidate.byteLength)
+      && candidate.byteLength >= 0
+      && typeof candidate.sha256 === "string";
+  });
+}
+
+function cloneSetupGenerationRun(
+  run: SetupGenerationRunState,
+): SetupGenerationRunState {
+  return {
+    ...run,
+    steps: run.steps.map((step) => ({ ...step })),
+    generatedFiles: run.generatedFiles.map((file) => ({ ...file })),
+    ...(run.lastError ? { lastError: { ...run.lastError } } : {}),
+  };
 }

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -21,6 +21,10 @@ import type {
   SetupGenerationRunState,
   SetupGenerationSnapshot,
 } from "@kickstart/core";
+import {
+  cloneSetupGenerationRun,
+  isValidSetupGenerationSnapshot,
+} from "./setup-generation-state.js";
 import { buildUsageSummary } from "./usage-tracking.js";
 import type { TurnUsage, UsageSummary } from "./usage-tracking.js";
 
@@ -244,7 +248,7 @@ export function hydrateSession(clientMessages: ClientMessage[], principalId?: st
       if (isTurnUsage(msg.usage)) {
         session.usageHistory.push(msg.usage);
       }
-      if (isSetupGenerationSnapshot(msg.setupGeneration)) {
+      if (isValidSetupGenerationSnapshot(msg.setupGeneration)) {
         latestSetupGeneration = cloneSetupGenerationRun(msg.setupGeneration.run);
         for (const generatedFile of latestSetupGeneration.generatedFiles) {
           upsertArtifact(
@@ -462,69 +466,4 @@ function isTurnUsage(value: unknown): value is TurnUsage {
     && typeof usage.outputTokens === "number"
     && typeof usage.totalTokens === "number"
     && (usage.costStatus === "estimated" || usage.costStatus === "unavailable");
-}
-
-function isSetupGenerationSnapshot(
-  value: unknown,
-): value is SetupGenerationSnapshot {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-
-  const snapshot = value as { run?: unknown };
-  if (!snapshot.run || typeof snapshot.run !== "object" || Array.isArray(snapshot.run)) {
-    return false;
-  }
-
-  const run = snapshot.run as Partial<SetupGenerationRunState>;
-  if (run.phase !== "generate") return false;
-  if (typeof run.runId !== "string" || run.runId.length === 0) return false;
-  if (typeof run.currentStepIndex !== "number" || !Number.isInteger(run.currentStepIndex) || run.currentStepIndex < 0) {
-    return false;
-  }
-  if (typeof run.status !== "string" || typeof run.updatedAt !== "string") {
-    return false;
-  }
-  if (!Array.isArray(run.steps) || !Array.isArray(run.generatedFiles)) {
-    return false;
-  }
-  if (typeof run.totalBytes !== "number" || !Number.isFinite(run.totalBytes) || run.totalBytes < 0) {
-    return false;
-  }
-
-  return run.steps.every((step) => {
-    if (!step || typeof step !== "object" || Array.isArray(step)) return false;
-    const candidate = step as Record<string, unknown>;
-    return typeof candidate.id === "string"
-      && SETUP_GENERATION_STEP_ORDER.includes(candidate.id as SetupGenerationRunState["steps"][number]["id"])
-      && typeof candidate.label === "string"
-      && typeof candidate.required === "boolean"
-      && (candidate.status === "pending"
-        || candidate.status === "running"
-        || candidate.status === "complete"
-        || candidate.status === "error"
-        || candidate.status === "skipped");
-  }) && run.generatedFiles.every((file) => {
-    if (!file || typeof file !== "object" || Array.isArray(file)) return false;
-    const candidate = file as Record<string, unknown>;
-    return typeof candidate.stepId === "string"
-      && SETUP_GENERATION_STEP_ORDER.includes(candidate.stepId as SetupGenerationRunState["generatedFiles"][number]["stepId"])
-      && typeof candidate.path === "string"
-      && typeof candidate.language === "string"
-      && typeof candidate.byteLength === "number"
-      && Number.isFinite(candidate.byteLength)
-      && candidate.byteLength >= 0
-      && typeof candidate.sha256 === "string";
-  });
-}
-
-function cloneSetupGenerationRun(
-  run: SetupGenerationRunState,
-): SetupGenerationRunState {
-  return {
-    ...run,
-    steps: run.steps.map((step) => ({ ...step })),
-    generatedFiles: run.generatedFiles.map((file) => ({ ...file })),
-    ...(run.lastError ? { lastError: { ...run.lastError } } : {}),
-  };
 }

--- a/packages/web/api/src/lib/setup-generation-state.ts
+++ b/packages/web/api/src/lib/setup-generation-state.ts
@@ -1,0 +1,106 @@
+import { SETUP_GENERATION_STEP_ORDER } from "@kickstart/core";
+import type {
+  SetupGenerationRunState,
+  SetupGenerationSnapshot,
+  SetupGenerationStepId,
+  SetupGenerationStepState,
+} from "@kickstart/core";
+
+export function isValidSetupGenerationSnapshot(
+  value: unknown,
+): value is SetupGenerationSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const snapshot = value as { run?: unknown };
+  if (!snapshot.run || typeof snapshot.run !== "object" || Array.isArray(snapshot.run)) {
+    return false;
+  }
+
+  const run = snapshot.run as Partial<SetupGenerationRunState>;
+  if (run.phase !== "generate") return false;
+  if (typeof run.runId !== "string" || run.runId.length === 0) return false;
+  if (
+    typeof run.currentStepIndex !== "number"
+    || !Number.isInteger(run.currentStepIndex)
+    || run.currentStepIndex < 0
+  ) {
+    return false;
+  }
+  if (!Array.isArray(run.steps) || !Array.isArray(run.generatedFiles)) return false;
+  if (typeof run.totalBytes !== "number" || !Number.isFinite(run.totalBytes) || run.totalBytes < 0) {
+    return false;
+  }
+  if (typeof run.updatedAt !== "string" || run.updatedAt.length === 0) return false;
+  if (!isRunStatus(run.status)) return false;
+
+  return run.steps.every((step) => isValidSetupGenerationStepState(step))
+    && run.generatedFiles.every((file) => isValidGeneratedFileManifest(file));
+}
+
+export function restoreSetupGenerationRunState(
+  snapshot: SetupGenerationSnapshot,
+): SetupGenerationRunState {
+  return cloneSetupGenerationRun(snapshot.run);
+}
+
+export function cloneSetupGenerationRun(
+  run: SetupGenerationRunState,
+): SetupGenerationRunState {
+  return {
+    ...run,
+    steps: run.steps.map((step) => ({ ...step })),
+    generatedFiles: run.generatedFiles.map((file) => ({ ...file })),
+    ...(run.lastError ? { lastError: { ...run.lastError } } : {}),
+  };
+}
+
+function isRunStatus(value: unknown): value is SetupGenerationRunState["status"] {
+  return value === "idle"
+    || value === "running"
+    || value === "paused"
+    || value === "complete"
+    || value === "failed";
+}
+
+function isStepStatus(value: unknown): value is SetupGenerationStepState["status"] {
+  return value === "pending"
+    || value === "running"
+    || value === "complete"
+    || value === "error"
+    || value === "skipped";
+}
+
+function isValidSetupGenerationStepState(
+  value: unknown,
+): value is SetupGenerationStepState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const step = value as Partial<SetupGenerationStepState>;
+  return typeof step.id === "string"
+    && typeof step.label === "string"
+    && typeof step.required === "boolean"
+    && isStepStatus(step.status)
+    && SETUP_GENERATION_STEP_ORDER.includes(step.id as SetupGenerationStepId);
+}
+
+function isValidGeneratedFileManifest(
+  value: unknown,
+): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const file = value as Record<string, unknown>;
+  return typeof file.stepId === "string"
+    && SETUP_GENERATION_STEP_ORDER.includes(file.stepId as SetupGenerationStepId)
+    && typeof file.path === "string"
+    && typeof file.language === "string"
+    && typeof file.byteLength === "number"
+    && Number.isFinite(file.byteLength)
+    && file.byteLength >= 0
+    && typeof file.sha256 === "string";
+}

--- a/packages/web/api/src/lib/setup-generation.ts
+++ b/packages/web/api/src/lib/setup-generation.ts
@@ -22,6 +22,11 @@ import { sumChatUsage } from "./usage-tracking.js";
 import type { ChatUsage } from "./usage-tracking.js";
 import { codexCompletion } from "./openai-client.js";
 import {
+  cloneSetupGenerationRun,
+  isValidSetupGenerationSnapshot,
+  restoreSetupGenerationRunState,
+} from "./setup-generation-state.js";
+import {
   extractArtifactMetadata,
   upsertArtifact,
 } from "./session-store.js";
@@ -224,39 +229,6 @@ export function getSetupGenerationSnapshot(
   return {
     run: cloneSetupGenerationRun(session.setupGenerationRun),
   };
-}
-
-export function isValidSetupGenerationSnapshot(
-  value: unknown,
-): value is SetupGenerationSnapshot {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-
-  const snapshot = value as { run?: unknown };
-  if (!snapshot.run || typeof snapshot.run !== "object" || Array.isArray(snapshot.run)) {
-    return false;
-  }
-
-  const run = snapshot.run as Partial<SetupGenerationRunState>;
-  if (run.phase !== "generate") return false;
-  if (typeof run.runId !== "string" || run.runId.length === 0) return false;
-  if (typeof run.currentStepIndex !== "number" || !Number.isInteger(run.currentStepIndex) || run.currentStepIndex < 0) {
-    return false;
-  }
-  if (!Array.isArray(run.steps) || !Array.isArray(run.generatedFiles)) return false;
-  if (typeof run.totalBytes !== "number" || !Number.isFinite(run.totalBytes) || run.totalBytes < 0) return false;
-  if (typeof run.updatedAt !== "string" || run.updatedAt.length === 0) return false;
-  if (!isRunStatus(run.status)) return false;
-
-  return run.steps.every((step) => isValidSetupGenerationStepState(step))
-    && run.generatedFiles.every((file) => isValidGeneratedFileManifest(file));
-}
-
-export function restoreSetupGenerationRunState(
-  snapshot: SetupGenerationSnapshot,
-): SetupGenerationRunState {
-  return cloneSetupGenerationRun(snapshot.run);
 }
 
 export function buildSetupGenerationProgressA2UI(
@@ -1015,62 +987,4 @@ function normalizeSetupGenerationFailure(error: unknown): SetupGenerationFailure
 function shouldRetryCodexError(error: unknown): boolean {
   const detail = error instanceof Error ? error.message : String(error);
   return /timeout|timed out|network|502|503|504/i.test(detail);
-}
-
-function isRunStatus(value: unknown): value is SetupGenerationRunState["status"] {
-  return value === "idle"
-    || value === "running"
-    || value === "paused"
-    || value === "complete"
-    || value === "failed";
-}
-
-function isStepStatus(value: unknown): value is SetupGenerationStepState["status"] {
-  return value === "pending"
-    || value === "running"
-    || value === "complete"
-    || value === "error"
-    || value === "skipped";
-}
-
-function isValidSetupGenerationStepState(
-  value: unknown,
-): value is SetupGenerationStepState {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  const step = value as Partial<SetupGenerationStepState>;
-  return typeof step.id === "string"
-    && typeof step.label === "string"
-    && typeof step.required === "boolean"
-    && isStepStatus(step.status)
-    && SETUP_GENERATION_STEP_ORDER.includes(step.id as SetupGenerationStepId);
-}
-
-function isValidGeneratedFileManifest(
-  value: unknown,
-): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  const file = value as Record<string, unknown>;
-  return typeof file.stepId === "string"
-    && SETUP_GENERATION_STEP_ORDER.includes(file.stepId as SetupGenerationStepId)
-    && typeof file.path === "string"
-    && typeof file.language === "string"
-    && typeof file.byteLength === "number"
-    && Number.isFinite(file.byteLength)
-    && file.byteLength >= 0
-    && typeof file.sha256 === "string";
-}
-
-function cloneSetupGenerationRun(
-  run: SetupGenerationRunState,
-): SetupGenerationRunState {
-  return {
-    ...run,
-    steps: run.steps.map((step) => ({ ...step })),
-    generatedFiles: run.generatedFiles.map((file) => ({ ...file })),
-    ...(run.lastError ? { lastError: { ...run.lastError } } : {}),
-  };
 }

--- a/packages/web/api/src/lib/setup-generation.ts
+++ b/packages/web/api/src/lib/setup-generation.ts
@@ -1,0 +1,1076 @@
+import { createHash, randomUUID } from "node:crypto";
+import { posix as pathPosix } from "node:path";
+import type { A2UIMessage, ChatMessage } from "@kickstart/core";
+import {
+  Phase,
+  SETUP_GENERATION_FILE_LANGUAGE_ALLOWLIST,
+  SETUP_GENERATION_QUOTAS,
+  SETUP_GENERATION_STEP_LABELS,
+  SETUP_GENERATION_STEP_ORDER,
+} from "@kickstart/core";
+import type {
+  SetupGenerationControlAction,
+  SetupGenerationErrorCode,
+  SetupGenerationEvent,
+  SetupGenerationFileLanguage,
+  SetupGenerationRunState,
+  SetupGenerationSnapshot,
+  SetupGenerationStepId,
+  SetupGenerationStepState,
+} from "@kickstart/core";
+import { sumChatUsage } from "./usage-tracking.js";
+import type { ChatUsage } from "./usage-tracking.js";
+import { codexCompletion } from "./openai-client.js";
+import {
+  extractArtifactMetadata,
+  upsertArtifact,
+} from "./session-store.js";
+import type { ApiSession } from "./session-store.js";
+
+const STEPWISE_GENERATION_FLAG = "STEPWISE_GENERATION_V1";
+const PATH_ALLOWLIST_RE = /^[A-Za-z0-9._/-]+$/;
+const DRIVE_LETTER_RE = /^[A-Za-z]:/;
+const MAX_TRANSCRIPT_CHARS = 6_000;
+const MAX_ARTIFACT_SUMMARY_CHARS = 2_000;
+const MAX_CODEX_RESPONSE_CHARS = 32_000;
+const FILE_CONTENT_FENCE_RE = /^```[\s\S]*```$/;
+const MULTI_FILE_WRAPPER_PATTERNS = [
+  /^#+\s*file:\s+/im,
+  /^---\s*file:\s+/im,
+  /^\s*\/\/\s*file:\s+/im,
+  /^\s*filename:\s+/im,
+];
+const SECRET_LEAK_PATTERNS = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/i,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}/i,
+  /DefaultEndpointsProtocol=.*;AccountName=.*;AccountKey=.*;/i,
+  /SharedAccessSignature=/i,
+  /x-ms-client-principal/i,
+  /AZURE_OPENAI_API_KEY\s*=/i,
+  /GITHUB_TOKEN\s*=/i,
+  /CONNECTION_STRING\s*=/i,
+  /Traceback \(most recent call last\):/i,
+  /BEGIN SYSTEM PROMPT|END SYSTEM PROMPT|<tool_output>|<\|im_start\|>/i,
+];
+
+const STEP_SPECIFIC_PROMPTS: Record<SetupGenerationStepId, string> = {
+  "app-scaffolding": [
+    "Generate the application starter files only.",
+    "Create a working project skeleton that matches the runtime inferred from the transcript.",
+    "Include the dependency manifest, a main entry point, a health endpoint, and a concise README when space allows.",
+    "Do not generate Docker, infrastructure, or CI files in this step.",
+  ].join("\n"),
+  dockerfile: [
+    "Generate only the containerization files for this project.",
+    "Prefer Dockerfile and .dockerignore when useful.",
+    "Use multi-stage builds, non-root execution, and pinned base images.",
+    "Do not generate application source files, infrastructure, or CI files in this step.",
+  ].join("\n"),
+  "deployment-config": [
+    "Generate only deployment and infrastructure configuration files.",
+    "Prefer production-ready AKS Automatic defaults, managed identity/workload identity, and least-privilege service wiring.",
+    "Stay within 2-4 files total and keep cross-file names consistent.",
+    "Do not generate CI or application source files in this step.",
+  ].join("\n"),
+  "ci-cd": [
+    "Generate only CI/CD automation files for build, test, image publish, and deploy.",
+    "Prefer GitHub Actions with workload identity / OIDC placeholders instead of static secrets.",
+    "Do not generate application, Docker, or infrastructure files in this step.",
+  ].join("\n"),
+  "service-connections": [
+    "Generate only the files needed to wire backing services into the app runtime.",
+    "Prefer env templates, typed config modules, or concise connection docs over ad-hoc notes.",
+    "Do not emit secrets, real tokens, stack traces, or diagnostic dumps.",
+  ].join("\n"),
+};
+
+const LANGUAGE_BY_EXTENSION: Record<string, SetupGenerationFileLanguage> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  py: "python",
+  yaml: "yaml",
+  yml: "yaml",
+  json: "json",
+  dockerfile: "dockerfile",
+  bicep: "bicep",
+  go: "go",
+  sh: "shell",
+  bash: "shell",
+  html: "html",
+  css: "css",
+  md: "markdown",
+  dockerignore: "ignore",
+  gitignore: "ignore",
+  env: "dotenv",
+  toml: "toml",
+};
+
+export interface SetupGenerationExecutionResult {
+  message: string;
+  currentPhase: Phase;
+  usage?: ChatUsage;
+  events: SetupGenerationEvent[];
+  a2uiMessages: Array<A2UIMessage | object>;
+  snapshot: SetupGenerationSnapshot;
+}
+
+export function isSetupGenerationFailure(
+  value: unknown,
+): value is SetupGenerationFailure {
+  return value instanceof SetupGenerationFailure;
+}
+
+interface StepGenerationCandidate {
+  path: string;
+  language?: string;
+  content: string;
+}
+
+interface ValidatedGeneratedFile {
+  path: string;
+  language: string;
+  content: string;
+  byteLength: number;
+  sha256: string;
+}
+
+interface StepGenerationResult {
+  files: ValidatedGeneratedFile[];
+  usage?: ChatUsage;
+}
+
+interface SetupGenerationExecutionHooks {
+  emitA2ui?: (messages: Array<A2UIMessage | object>) => Promise<void> | void;
+  emitEvent?: (event: SetupGenerationEvent) => Promise<void> | void;
+}
+
+interface StepwisePlan {
+  includeAppScaffolding: boolean;
+  includeServiceConnections: boolean;
+}
+
+export class SetupGenerationFailure extends Error {
+  code: SetupGenerationErrorCode;
+  recoverable: boolean;
+
+  constructor(
+    code: SetupGenerationErrorCode,
+    message: string,
+    options: { recoverable: boolean },
+  ) {
+    super(message);
+    this.name = "SetupGenerationFailure";
+    this.code = code;
+    this.recoverable = options.recoverable;
+  }
+}
+
+export function isStepwiseGenerationEnabled(): boolean {
+  return process.env[STEPWISE_GENERATION_FLAG] === "true";
+}
+
+export function isSetupGenerationControlAction(
+  value: string | undefined,
+): value is SetupGenerationControlAction {
+  return value === "retry-current-step" || value === "stop-generation";
+}
+
+export function shouldUseStepwiseGeneration(
+  session: Pick<ApiSession, "routingPhaseTrusted" | "setupGenerationTrusted">,
+  phase: Phase,
+): boolean {
+  if (!isStepwiseGenerationEnabled()) return false;
+  if (phase !== Phase.Generate) return false;
+  return session.routingPhaseTrusted || session.setupGenerationTrusted;
+}
+
+export function createSetupGenerationRunState(
+  session: Pick<ApiSession, "state">,
+): SetupGenerationRunState {
+  const plan = inferStepwisePlan(session.state.messages);
+  const steps: SetupGenerationStepState[] = SETUP_GENERATION_STEP_ORDER.map((id) => {
+    const required = id === "app-scaffolding"
+      ? plan.includeAppScaffolding
+      : id === "service-connections"
+        ? plan.includeServiceConnections
+        : true;
+
+    return {
+      id,
+      label: SETUP_GENERATION_STEP_LABELS[id],
+      required,
+      status: required ? "pending" : "skipped",
+    };
+  });
+
+  return {
+    runId: randomUUID(),
+    phase: "generate",
+    currentStepIndex: findNextRunnableStepIndex(steps),
+    steps,
+    status: "idle",
+    generatedFiles: [],
+    totalBytes: 0,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function getSetupGenerationSnapshot(
+  session: Pick<ApiSession, "setupGenerationRun">,
+): SetupGenerationSnapshot | undefined {
+  if (!session.setupGenerationRun) return undefined;
+  return {
+    run: cloneSetupGenerationRun(session.setupGenerationRun),
+  };
+}
+
+export function isValidSetupGenerationSnapshot(
+  value: unknown,
+): value is SetupGenerationSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const snapshot = value as { run?: unknown };
+  if (!snapshot.run || typeof snapshot.run !== "object" || Array.isArray(snapshot.run)) {
+    return false;
+  }
+
+  const run = snapshot.run as Partial<SetupGenerationRunState>;
+  if (run.phase !== "generate") return false;
+  if (typeof run.runId !== "string" || run.runId.length === 0) return false;
+  if (typeof run.currentStepIndex !== "number" || !Number.isInteger(run.currentStepIndex) || run.currentStepIndex < 0) {
+    return false;
+  }
+  if (!Array.isArray(run.steps) || !Array.isArray(run.generatedFiles)) return false;
+  if (typeof run.totalBytes !== "number" || !Number.isFinite(run.totalBytes) || run.totalBytes < 0) return false;
+  if (typeof run.updatedAt !== "string" || run.updatedAt.length === 0) return false;
+  if (!isRunStatus(run.status)) return false;
+
+  return run.steps.every((step) => isValidSetupGenerationStepState(step))
+    && run.generatedFiles.every((file) => isValidGeneratedFileManifest(file));
+}
+
+export function restoreSetupGenerationRunState(
+  snapshot: SetupGenerationSnapshot,
+): SetupGenerationRunState {
+  return cloneSetupGenerationRun(snapshot.run);
+}
+
+export function buildSetupGenerationProgressA2UI(
+  run: SetupGenerationRunState,
+  options: {
+    surfaceId: string;
+    includeCreateSurface?: boolean;
+    statusMessage: string;
+    errorCode?: string;
+    errorMessage?: string;
+  },
+): A2UIMessage[] {
+  const steps = run.steps.map((step) => ({
+    id: step.id,
+    label: step.label,
+    status: step.status,
+  }));
+
+  const progressComponent = {
+    id: "setup-progress",
+    component: "DeploymentProgress",
+    title: "Project Setup",
+    runId: run.runId,
+    overallStatus: mapRunStatusToOverallStatus(run.status),
+    statusMessage: options.statusMessage,
+    ...(options.errorCode ? { errorCode: options.errorCode } : {}),
+    ...(options.errorMessage ? { errorMessage: options.errorMessage } : {}),
+    lastUpdated: run.updatedAt,
+    steps,
+  };
+
+  const messages: A2UIMessage[] = [];
+  if (options.includeCreateSurface) {
+    messages.push({
+      version: "v0.9",
+      createSurface: {
+        surfaceId: options.surfaceId,
+        catalogId: "kickstart",
+      },
+    });
+  }
+  messages.push({
+    version: "v0.9",
+    updateComponents: {
+      surfaceId: options.surfaceId,
+      components: [progressComponent],
+    },
+  });
+  return messages;
+}
+
+export async function executeSetupGeneration(
+  session: ApiSession,
+  options: {
+    controlAction?: SetupGenerationControlAction;
+    surfaceId: string;
+    hooks?: SetupGenerationExecutionHooks;
+  },
+): Promise<SetupGenerationExecutionResult> {
+  const hooks = options.hooks ?? {};
+  const a2uiMessages: Array<A2UIMessage | object> = [];
+  const events: SetupGenerationEvent[] = [];
+  let accumulatedUsage: ChatUsage | undefined;
+
+  const emitA2ui = async (messages: Array<A2UIMessage | object>) => {
+    if (messages.length === 0) return;
+    a2uiMessages.push(...messages);
+    await hooks.emitA2ui?.(messages);
+  };
+
+  const emitEvent = async (event: SetupGenerationEvent) => {
+    events.push(event);
+    await hooks.emitEvent?.(event);
+  };
+
+  const strictCodexDeployment = getStrictCodexDeploymentName();
+  if (!strictCodexDeployment) {
+    throw new SetupGenerationFailure(
+      "codex_error",
+      "Setup generation is unavailable until AZURE_OPENAI_CODEX_DEPLOYMENT is configured.",
+      { recoverable: false },
+    );
+  }
+
+  if (!session.setupGenerationRun) {
+    session.setupGenerationRun = createSetupGenerationRunState(session);
+    session.setupGenerationTrusted = true;
+  }
+
+  const run = session.setupGenerationRun;
+  run.updatedAt = new Date().toISOString();
+
+  if (options.controlAction === "stop-generation") {
+    run.status = "paused";
+    run.updatedAt = new Date().toISOString();
+    const stopMessage = "Setup generation stopped. Files from completed steps remain in the workspace.";
+    const stopA2ui = buildSetupGenerationProgressA2UI(run, {
+      surfaceId: options.surfaceId,
+      includeCreateSurface: true,
+      statusMessage: stopMessage,
+    });
+    await emitA2ui(stopA2ui);
+    return {
+      message: stopMessage,
+      currentPhase: Phase.Generate,
+      events,
+      a2uiMessages,
+      snapshot: { run: cloneSetupGenerationRun(run) },
+    };
+  }
+
+  if (run.status === "paused" && run.lastError && options.controlAction !== "retry-current-step") {
+    throw new SetupGenerationFailure(
+      run.lastError.code,
+      "Setup generation is paused. Retry the current step or stop generation.",
+      { recoverable: run.lastError.recoverable },
+    );
+  }
+
+  if (options.controlAction === "retry-current-step") {
+    const currentStep = run.steps[run.currentStepIndex];
+    if (!currentStep || currentStep.status !== "error") {
+      throw new SetupGenerationFailure(
+        "validation_failed",
+        "There is no failed setup step to retry.",
+        { recoverable: false },
+      );
+    }
+    currentStep.status = "pending";
+    delete run.lastError;
+    run.status = "idle";
+    run.updatedAt = new Date().toISOString();
+  }
+
+  await emitA2ui([
+    ...buildSetupGenerationProgressA2UI(run, {
+      surfaceId: options.surfaceId,
+      includeCreateSurface: true,
+      statusMessage: "Preparing setup generation.",
+    }),
+  ]);
+
+  while (true) {
+    const nextIndex = findNextExecutableStepIndex(run);
+    run.updatedAt = new Date().toISOString();
+
+    if (nextIndex < 0) {
+      run.status = "complete";
+      run.currentStepIndex = Math.max(run.steps.length - 1, 0);
+      run.updatedAt = new Date().toISOString();
+      const completeMessage = "Setup files are ready in the workspace. Next up: review the plan and deployment defaults.";
+      await emitA2ui(buildSetupGenerationProgressA2UI(run, {
+        surfaceId: options.surfaceId,
+        statusMessage: completeMessage,
+      }));
+      return {
+        message: completeMessage,
+        currentPhase: Phase.Review,
+        usage: accumulatedUsage,
+        events,
+        a2uiMessages,
+        snapshot: { run: cloneSetupGenerationRun(run) },
+      };
+    }
+
+    run.currentStepIndex = nextIndex;
+
+    const step = run.steps[nextIndex]!;
+    step.status = "running";
+    run.status = "running";
+    run.updatedAt = new Date().toISOString();
+
+    const startEvent = createStepStartEvent(run, step, nextIndex);
+    await emitEvent(startEvent);
+    await emitA2ui(buildSetupGenerationProgressA2UI(run, {
+      surfaceId: options.surfaceId,
+      statusMessage: `Running ${step.label.toLowerCase()}...`,
+    }));
+
+    try {
+      const stepResult = await generateStepFiles(
+        session,
+        run,
+        step.id,
+        strictCodexDeployment,
+      );
+      accumulatedUsage = sumChatUsage(accumulatedUsage, stepResult.usage);
+
+      for (const file of stepResult.files) {
+        const fileEvent = createFileGeneratedEvent(step.id, file);
+        await emitEvent(fileEvent);
+        const artifact = extractArtifactMetadata(file.path, file.language, file.content);
+        upsertArtifact(session.generatedArtifacts, artifact);
+        run.generatedFiles.push({
+          stepId: step.id,
+          path: file.path,
+          language: file.language,
+          byteLength: file.byteLength,
+          sha256: file.sha256,
+        });
+        run.totalBytes += file.byteLength;
+      }
+
+      step.status = "complete";
+      delete run.lastError;
+      run.updatedAt = new Date().toISOString();
+
+      await emitEvent({
+        type: "step_complete",
+        stepId: step.id,
+        filesCount: stepResult.files.length,
+        totalBytes: stepResult.files.reduce((sum, file) => sum + file.byteLength, 0),
+      });
+      await emitA2ui(buildSetupGenerationProgressA2UI(run, {
+        surfaceId: options.surfaceId,
+        statusMessage: `${step.label} complete.`,
+      }));
+    } catch (error) {
+      const failure = normalizeSetupGenerationFailure(error);
+      step.status = "error";
+      run.status = "paused";
+      run.lastError = {
+        stepId: step.id,
+        code: failure.code,
+        message: failure.message,
+        recoverable: failure.recoverable,
+        occurredAt: new Date().toISOString(),
+      };
+      run.updatedAt = run.lastError.occurredAt;
+
+      await emitEvent({
+        type: "step_error",
+        stepId: step.id,
+        code: failure.code,
+        message: failure.message,
+        recoverable: failure.recoverable,
+      });
+      await emitA2ui(buildSetupGenerationProgressA2UI(run, {
+        surfaceId: options.surfaceId,
+        statusMessage: `${step.label} failed. Retry the current step or stop generation.`,
+        errorCode: failure.code,
+        errorMessage: failure.message,
+      }));
+
+      return {
+        message: `${step.label} failed. Retry the current step or stop generation.`,
+        currentPhase: Phase.Generate,
+        usage: accumulatedUsage,
+        events,
+        a2uiMessages,
+        snapshot: { run: cloneSetupGenerationRun(run) },
+      };
+    }
+  }
+}
+
+export function serializeSetupGenerationEvent(
+  event: SetupGenerationEvent,
+): string {
+  switch (event.type) {
+    case "step_start":
+      return JSON.stringify({
+        stepId: event.stepId,
+        label: event.label,
+        sequence: event.sequence,
+      });
+    case "file_generated":
+      return JSON.stringify({
+        stepId: event.stepId,
+        path: event.path,
+        language: event.language,
+        content: event.content,
+        byteLength: event.byteLength,
+        sha256: event.sha256,
+      });
+    case "step_complete":
+      return JSON.stringify({
+        stepId: event.stepId,
+        filesCount: event.filesCount,
+        totalBytes: event.totalBytes,
+      });
+    case "step_error":
+      return JSON.stringify({
+        stepId: event.stepId,
+        code: event.code,
+        message: event.message,
+        recoverable: event.recoverable,
+      });
+  }
+}
+
+function createStepStartEvent(
+  run: SetupGenerationRunState,
+  step: SetupGenerationStepState,
+  index: number,
+): SetupGenerationEvent {
+  return {
+    type: "step_start",
+    stepId: step.id,
+    label: step.label,
+    sequence: computeStepSequence(run, index),
+  };
+}
+
+function createFileGeneratedEvent(
+  stepId: SetupGenerationStepId,
+  file: ValidatedGeneratedFile,
+): SetupGenerationEvent {
+  return {
+    type: "file_generated",
+    stepId,
+    path: file.path,
+    language: file.language,
+    content: file.content,
+    byteLength: file.byteLength,
+    sha256: file.sha256,
+  };
+}
+
+async function generateStepFiles(
+  session: ApiSession,
+  run: SetupGenerationRunState,
+  stepId: SetupGenerationStepId,
+  strictCodexDeployment: string,
+): Promise<StepGenerationResult> {
+  const prompt = buildStepPrompt(session, run, stepId);
+  const firstAttempt = await callCodexCompletionWithRetry(
+    [{ role: "user", content: prompt.userContent } satisfies ChatMessage],
+    {
+      instructions: prompt.instructions,
+      maxOutputTokens: 12_000,
+      deployment: strictCodexDeployment,
+    },
+  );
+
+  let usage = firstAttempt.usage;
+  let parsed = parseStepGenerationResponse(firstAttempt.content);
+
+  if (!parsed) {
+    const repaired = await callCodexCompletionWithRetry(
+      [{ role: "user", content: buildRepairPrompt(firstAttempt.content) } satisfies ChatMessage],
+      {
+        instructions: [
+          "Repair the previous setup-generation output into valid JSON only.",
+          'Return exactly {"files":[{"path":"...","language":"...","content":"..."}]} with no markdown fences or commentary.',
+          "Preserve file contents exactly when possible.",
+        ].join("\n"),
+        maxOutputTokens: 12_000,
+        deployment: strictCodexDeployment,
+      },
+    );
+    usage = sumChatUsage(usage, repaired.usage);
+    parsed = parseStepGenerationResponse(repaired.content);
+  }
+
+  if (!parsed) {
+    throw new SetupGenerationFailure(
+      "codex_error",
+      "The generation model returned an invalid file batch. Retry the current step.",
+      { recoverable: true },
+    );
+  }
+
+  return {
+    files: validateGeneratedFiles(parsed.files, run, stepId),
+    usage,
+  };
+}
+
+function buildStepPrompt(
+  session: ApiSession,
+  run: SetupGenerationRunState,
+  stepId: SetupGenerationStepId,
+): { instructions: string; userContent: string } {
+  const transcript = buildTranscriptSummary(session.state.messages);
+  const artifacts = buildArtifactSummary(session.generatedArtifacts);
+  const step = run.steps.find((candidate) => candidate.id === stepId);
+  const knownAppDefinition = Object.keys(session.state.appDefinition).length > 0
+    ? JSON.stringify(session.state.appDefinition, null, 2)
+    : "{}";
+
+  return {
+    instructions: [
+      "You are Kickstart's setup generation backend.",
+      "The server already chose the current step. Never invent, rename, skip, or reorder setup steps.",
+      'Return ONLY valid JSON in this exact shape: {"files":[{"path":"relative/path","language":"typescript","content":"file body"}]}.',
+      `Current step: ${step?.label ?? SETUP_GENERATION_STEP_LABELS[stepId]} (${stepId}).`,
+      `Emit between 1 and ${SETUP_GENERATION_QUOTAS.maxFilesPerStep} files for this step only.`,
+      "All paths must be relative repo paths. No leading slash. No parent traversal.",
+      "Do not include markdown fences, commentary, tool outputs, prompts, diagnostics, secrets, or stack traces.",
+      "Keep names consistent with previously generated files.",
+      STEP_SPECIFIC_PROMPTS[stepId],
+    ].join("\n"),
+    userContent: [
+      "Project context (latest transcript excerpt):",
+      transcript || "No transcript available.",
+      "",
+      "Known app definition JSON:",
+      knownAppDefinition,
+      "",
+      "Generated artifacts so far:",
+      artifacts || "None yet.",
+    ].join("\n"),
+  };
+}
+
+function buildRepairPrompt(rawContent: string): string {
+  const trimmed = rawContent.slice(0, MAX_CODEX_RESPONSE_CHARS);
+  return [
+    "The previous setup-generation output was invalid JSON.",
+    "Repair it into valid JSON only.",
+    'Required shape: {"files":[{"path":"relative/path","language":"typescript","content":"file body"}]}',
+    "Do not wrap the JSON in markdown fences.",
+    "Previous output:",
+    trimmed,
+  ].join("\n");
+}
+
+function parseStepGenerationResponse(
+  rawContent: string,
+): { files: StepGenerationCandidate[] } | undefined {
+  const trimmed = rawContent.trim();
+  if (!trimmed) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const record = parsed as { files?: unknown };
+  if (!Array.isArray(record.files)) {
+    return undefined;
+  }
+
+  const files = record.files
+    .map((file): StepGenerationCandidate | null => {
+      if (!file || typeof file !== "object" || Array.isArray(file)) {
+        return null;
+      }
+      const candidate = file as Record<string, unknown>;
+      return {
+        path: typeof candidate.path === "string" ? candidate.path : "",
+        language: typeof candidate.language === "string" ? candidate.language : undefined,
+        content: typeof candidate.content === "string" ? candidate.content : "",
+      };
+    })
+    .filter((file): file is StepGenerationCandidate => file !== null);
+
+  return files.length > 0 ? { files } : undefined;
+}
+
+function validateGeneratedFiles(
+  files: StepGenerationCandidate[],
+  run: SetupGenerationRunState,
+  stepId: SetupGenerationStepId,
+): ValidatedGeneratedFile[] {
+  if (files.length > SETUP_GENERATION_QUOTAS.maxFilesPerStep) {
+    throw new SetupGenerationFailure(
+      "quota_exceeded",
+      `This setup step exceeded the maximum of ${SETUP_GENERATION_QUOTAS.maxFilesPerStep} files.`,
+      { recoverable: false },
+    );
+  }
+
+  if (run.generatedFiles.length + files.length > SETUP_GENERATION_QUOTAS.maxFilesPerSession) {
+    throw new SetupGenerationFailure(
+      "quota_exceeded",
+      `This session exceeded the maximum of ${SETUP_GENERATION_QUOTAS.maxFilesPerSession} generated files.`,
+      { recoverable: false },
+    );
+  }
+
+  const existingPaths = new Set(run.generatedFiles.map((file) => file.path));
+  const seenPaths = new Set<string>();
+  const validated: ValidatedGeneratedFile[] = [];
+  let stepBytes = 0;
+
+  for (const file of files) {
+    if (!file.path || !file.content) {
+      throw new SetupGenerationFailure(
+        "validation_failed",
+        `The ${SETUP_GENERATION_STEP_LABELS[stepId]} step returned an incomplete file entry.`,
+        { recoverable: false },
+      );
+    }
+
+    const path = normalizeGeneratedPath(file.path);
+    if (seenPaths.has(path) || existingPaths.has(path)) {
+      throw new SetupGenerationFailure(
+        "validation_failed",
+        `The ${SETUP_GENERATION_STEP_LABELS[stepId]} step returned a duplicate file path.`,
+        { recoverable: false },
+      );
+    }
+    seenPaths.add(path);
+
+    validateFileContent(file.content, stepId);
+
+    const byteLength = new TextEncoder().encode(file.content).length;
+    if (byteLength > SETUP_GENERATION_QUOTAS.maxBytesPerFile) {
+      throw new SetupGenerationFailure(
+        "quota_exceeded",
+        `Generated file ${path} exceeded the ${SETUP_GENERATION_QUOTAS.maxBytesPerFile} byte limit.`,
+        { recoverable: false },
+      );
+    }
+
+    stepBytes += byteLength;
+    if (stepBytes > SETUP_GENERATION_QUOTAS.maxBytesPerStep) {
+      throw new SetupGenerationFailure(
+        "quota_exceeded",
+        `The ${SETUP_GENERATION_STEP_LABELS[stepId]} step exceeded the total byte limit.`,
+        { recoverable: false },
+      );
+    }
+    if (run.totalBytes + stepBytes > SETUP_GENERATION_QUOTAS.maxBytesPerSession) {
+      throw new SetupGenerationFailure(
+        "quota_exceeded",
+        `This session exceeded the ${SETUP_GENERATION_QUOTAS.maxBytesPerSession} byte limit for generated files.`,
+        { recoverable: false },
+      );
+    }
+
+    validated.push({
+      path,
+      language: normalizeGeneratedLanguage(file.language, path),
+      content: file.content,
+      byteLength,
+      sha256: createHash("sha256").update(file.content, "utf8").digest("hex"),
+    });
+  }
+
+  return validated;
+}
+
+function normalizeGeneratedPath(rawPath: string): string {
+  const trimmed = rawPath.trim();
+  if (!trimmed || trimmed.includes("\0") || DRIVE_LETTER_RE.test(trimmed)) {
+    throw new SetupGenerationFailure(
+      "validation_failed",
+      "Generated files must use safe relative paths.",
+      { recoverable: false },
+    );
+  }
+
+  const normalized = pathPosix.normalize(trimmed);
+  if (
+    normalized === "."
+    || normalized.startsWith("../")
+    || normalized.includes("/../")
+    || normalized.startsWith("/")
+    || normalized.length > 180
+    || normalized.split("/").length > 8
+    || !PATH_ALLOWLIST_RE.test(normalized)
+  ) {
+    throw new SetupGenerationFailure(
+      "validation_failed",
+      "Generated files must use safe relative paths.",
+      { recoverable: false },
+    );
+  }
+
+  return normalized;
+}
+
+function validateFileContent(
+  content: string,
+  stepId: SetupGenerationStepId,
+): void {
+  if (content.includes("\0") || FILE_CONTENT_FENCE_RE.test(content.trim())) {
+    throw new SetupGenerationFailure(
+      "validation_failed",
+      `The ${SETUP_GENERATION_STEP_LABELS[stepId]} step returned unsupported file content.`,
+      { recoverable: false },
+    );
+  }
+
+  if (MULTI_FILE_WRAPPER_PATTERNS.some((pattern) => pattern.test(content))) {
+    throw new SetupGenerationFailure(
+      "validation_failed",
+      `The ${SETUP_GENERATION_STEP_LABELS[stepId]} step returned a multi-file wrapper instead of a single file body.`,
+      { recoverable: false },
+    );
+  }
+
+  if (SECRET_LEAK_PATTERNS.some((pattern) => pattern.test(content))) {
+    throw new SetupGenerationFailure(
+      "validation_failed",
+      `The ${SETUP_GENERATION_STEP_LABELS[stepId]} step returned sensitive or diagnostic output.`,
+      { recoverable: false },
+    );
+  }
+}
+
+function normalizeGeneratedLanguage(
+  rawLanguage: string | undefined,
+  path: string,
+): string {
+  if (
+    rawLanguage
+    && SETUP_GENERATION_FILE_LANGUAGE_ALLOWLIST.includes(
+      rawLanguage as SetupGenerationFileLanguage,
+    )
+  ) {
+    return rawLanguage;
+  }
+
+  const filename = path.split("/").pop() ?? path;
+  if (filename === "Dockerfile") return "dockerfile";
+  if (filename === ".dockerignore" || filename === ".gitignore") return "ignore";
+  if (filename === ".env" || filename === ".env.template") return "dotenv";
+
+  const ext = filename.includes(".")
+    ? filename.split(".").pop()?.toLowerCase() ?? ""
+    : filename.toLowerCase();
+  return LANGUAGE_BY_EXTENSION[ext] ?? "plaintext";
+}
+
+function inferStepwisePlan(
+  messages: readonly { role?: string; content: string }[],
+): StepwisePlan {
+  const transcript = messages
+    .filter((message) => message.role !== "system")
+    .map((message) => message.content.toLowerCase())
+    .join("\n");
+
+  const includeAppScaffolding = /starting fresh|from scratch|no existing code/.test(transcript);
+  const includeServiceConnections = /\b(postgres|mysql|mongodb|cosmos|redis|database|cache|queue|service bus|search|vector|key vault|openai)\b/.test(transcript);
+
+  return {
+    includeAppScaffolding,
+    includeServiceConnections,
+  };
+}
+
+function buildTranscriptSummary(
+  messages: readonly { role?: string; content: string }[],
+): string {
+  const transcript = messages
+    .filter((message) => message.role !== "system")
+    .slice(-12)
+    .map((message) => `${message.role ?? "user"}: ${message.content.trim()}`)
+    .join("\n\n");
+  return transcript.slice(-MAX_TRANSCRIPT_CHARS);
+}
+
+function buildArtifactSummary(
+  artifacts: readonly { filename: string; bicepResources: string[]; k8sResources: string[] }[],
+): string {
+  if (artifacts.length === 0) return "";
+
+  const lines = [
+    `Files generated so far: ${artifacts.map((artifact) => artifact.filename).join(", ")}`,
+  ];
+  const bicepResources = artifacts.flatMap((artifact) => artifact.bicepResources);
+  if (bicepResources.length > 0) {
+    lines.push(`Azure resources declared: ${bicepResources.join(", ")}`);
+  }
+  const k8sResources = artifacts.flatMap((artifact) => artifact.k8sResources);
+  if (k8sResources.length > 0) {
+    lines.push(`Kubernetes resources declared: ${k8sResources.join(", ")}`);
+  }
+  return lines.join("\n").slice(0, MAX_ARTIFACT_SUMMARY_CHARS);
+}
+
+async function callCodexCompletionWithRetry(
+  input: ChatMessage[],
+  options: Parameters<typeof codexCompletion>[1],
+) {
+  try {
+    return await codexCompletion(input, options);
+  } catch (firstError) {
+    if (!shouldRetryCodexError(firstError)) {
+      throw firstError;
+    }
+    return codexCompletion(input, options);
+  }
+}
+
+function getStrictCodexDeploymentName(): string | undefined {
+  const deployment = process.env.AZURE_OPENAI_CODEX_DEPLOYMENT?.trim();
+  return deployment ? deployment : undefined;
+}
+
+function findNextRunnableStepIndex(
+  steps: readonly SetupGenerationStepState[],
+): number {
+  return steps.findIndex((step) => step.status === "pending" || step.status === "error");
+}
+
+function findNextExecutableStepIndex(
+  run: SetupGenerationRunState,
+): number {
+  for (let index = 0; index < run.steps.length; index += 1) {
+    const step = run.steps[index];
+    if (step?.status === "pending" || step?.status === "error") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function computeStepSequence(
+  run: SetupGenerationRunState,
+  currentIndex: number,
+): number {
+  const activeSteps = run.steps.filter((step) => step.required);
+  const currentId = run.steps[currentIndex]?.id;
+  const activeIndex = activeSteps.findIndex((step) => step.id === currentId);
+  return activeIndex >= 0 ? activeIndex + 1 : currentIndex + 1;
+}
+
+function mapRunStatusToOverallStatus(
+  status: SetupGenerationRunState["status"],
+): "idle" | "running" | "complete" | "error" {
+  switch (status) {
+    case "complete":
+      return "complete";
+    case "running":
+      return "running";
+    case "paused":
+    case "failed":
+      return "error";
+    default:
+      return "idle";
+  }
+}
+
+function normalizeSetupGenerationFailure(error: unknown): SetupGenerationFailure {
+  if (error instanceof SetupGenerationFailure) {
+    return error;
+  }
+
+  const detail = error instanceof Error ? error.message : String(error);
+  if (/timeout/i.test(detail)) {
+    return new SetupGenerationFailure(
+      "codex_timeout",
+      "The generation model timed out. Retry the current step.",
+      { recoverable: true },
+    );
+  }
+
+  return new SetupGenerationFailure(
+    "codex_error",
+    "The generation model failed before it could finish this step. Retry the current step.",
+    { recoverable: true },
+  );
+}
+
+function shouldRetryCodexError(error: unknown): boolean {
+  const detail = error instanceof Error ? error.message : String(error);
+  return /timeout|timed out|network|502|503|504/i.test(detail);
+}
+
+function isRunStatus(value: unknown): value is SetupGenerationRunState["status"] {
+  return value === "idle"
+    || value === "running"
+    || value === "paused"
+    || value === "complete"
+    || value === "failed";
+}
+
+function isStepStatus(value: unknown): value is SetupGenerationStepState["status"] {
+  return value === "pending"
+    || value === "running"
+    || value === "complete"
+    || value === "error"
+    || value === "skipped";
+}
+
+function isValidSetupGenerationStepState(
+  value: unknown,
+): value is SetupGenerationStepState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const step = value as Partial<SetupGenerationStepState>;
+  return typeof step.id === "string"
+    && typeof step.label === "string"
+    && typeof step.required === "boolean"
+    && isStepStatus(step.status)
+    && SETUP_GENERATION_STEP_ORDER.includes(step.id as SetupGenerationStepId);
+}
+
+function isValidGeneratedFileManifest(
+  value: unknown,
+): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const file = value as Record<string, unknown>;
+  return typeof file.stepId === "string"
+    && SETUP_GENERATION_STEP_ORDER.includes(file.stepId as SetupGenerationStepId)
+    && typeof file.path === "string"
+    && typeof file.language === "string"
+    && typeof file.byteLength === "number"
+    && Number.isFinite(file.byteLength)
+    && file.byteLength >= 0
+    && typeof file.sha256 === "string";
+}
+
+function cloneSetupGenerationRun(
+  run: SetupGenerationRunState,
+): SetupGenerationRunState {
+  return {
+    ...run,
+    steps: run.steps.map((step) => ({ ...step })),
+    generatedFiles: run.generatedFiles.map((file) => ({ ...file })),
+    ...(run.lastError ? { lastError: { ...run.lastError } } : {}),
+  };
+}


### PR DESCRIPTION
Closes #327

## Summary
- add a shared setup-generation contract and server-side executor for codex-backed step sequencing
- stream stepwise setup progress, files, and snapshots through `/api/converse` while keeping session resume state trusted and deterministic
- add focused backend regressions for stepwise SSE delivery, model routing, usage accounting, and snapshot hydration

## Changes
- add the shared setup-generation types/constants plus the API executor and validation logic
- wire `/api/converse`, session storage, and OpenAI routing to support feature-flagged stepwise generation
- cover the backend contract with converse and session-store tests

## Testing
- `npm run build -w @kickstart/core`
- `npm run build -w @kickstart/api`
- `npx vitest run packages/web/api/src/functions/converse.test.ts packages/web/api/src/lib/session-store.test.ts`
- `npm run test`

## Notes
- Working as Bender (Backend Dev)
- ⚠️ This task was flagged as "needs review" — please have a squad member review before merging.
- Frontend dependency PR: #336