### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 This project uses [@changesets/cli](https://github.com/changesets/changesets) for versioning.
 
+## [0.7.0] - 2026-04-15
+
+### Added
+
+- **Stepwise setup generation** — Codex-backed setup execution now streams progress in chat while delivering generated files directly into the workspace/file manager. (#336, #337)
+- **Real Azure deployment lane** — Kickstart now includes the real Azure deployment path with deploy UI, auth boundary coverage, and deployment health-check hardening. (#301)
+- **Real GitHub handoff flow** — Project handoff now supports the real GitHub ship/repo flow instead of placeholder behavior. (#274)
+- **Live pricing + token usage tracking** — Chat sessions now surface Azure pricing data and per-session token usage/cost tracking. (#272, #277)
+- **Workspace and diagram upgrades** — Generated-file routing, file manager UX, and ArchitectureDiagram rendering depth all improved significantly. (#252, #265, #314)
+
+### Changed
+
+- **Generate routing and progressive flow** — Generate-phase routing now prefers codex-backed execution and the progressive conversation/setup flow is more resilient end-to-end. (#266, #275, #278)
+- **Prompt and diagram narrative alignment** — System prompts and diagram rendering are more closely aligned with the Try-AKS narrative and richer architecture output. (#278, #300, #314)
+
+### Fixed
+
+- **File/workspace artifact stability** — Fixed the setup/file rendering regressions, file-surface duplication, and chat/file ownership issues around generated artifacts. (#334, #336, #337)
+- **Runtime and deployment hardening** — Fixed CostEstimate compatibility, hotspot robustness, SWA/API startup hygiene, false heartbeat failures, and Azure/GitHub deployment-path error handling. (#312, #317, #320, #324)
+- **Security and debug hardening** — Strengthened action-context sanitization, ArchitectureDiagram safety, and raw/debug output handling. (#250, #263, #300)
+- **UI and session polish** — Fixed assorted issues across session rehydration, streaming, buttons, tabs, code blocks, topbar polish, and general chat rendering behavior. (#239, #243, #244, #248, #291, #294)
+
 ## [0.6.0] - 2026-04-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kickstart",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kickstart",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -5009,7 +5009,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5019,7 +5018,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -15127,7 +15125,7 @@
     },
     "packages/core": {
       "name": "@kickstart/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "zod": "^3.25.76"
       },
@@ -15146,7 +15144,7 @@
     },
     "packages/mcp-server": {
       "name": "@kickstart/mcp-server",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@kickstart/core": "*",
         "@modelcontextprotocol/sdk": "^1.12.1"
@@ -15160,7 +15158,7 @@
     },
     "packages/web": {
       "name": "@kickstart/web",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-components": "^9.73.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kickstart",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "AI-guided onboarding for deploying apps to AKS",
   "license": "MIT",
   "workspaces": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @kickstart/core
 
+## 0.7.0
+
+### Minor Changes
+
+- Release the merged v0.7.0 feature set: codex-backed stepwise setup generation,
+  workspace-first file delivery, real Azure and GitHub deployment lanes, live pricing
+  and token usage tracking, file manager improvements, and architecture diagram upgrades.
+
 ## 0.5.7
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Kickstart conversation engine, A2UI catalog, and code generators",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @kickstart/mcp-server
 
+## 0.7.0
+
+### Minor Changes
+
+- Release the merged v0.7.0 feature set: codex-backed stepwise setup generation,
+  workspace-first file delivery, real Azure and GitHub deployment lanes, live pricing
+  and token usage tracking, file manager improvements, and architecture diagram upgrades.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @kickstart/core@0.7.0
+
 ## 0.5.7
 
 ### Patch Changes

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/mcp-server",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "MCP server for AKS Kickstart — exposes conversation tools and A2UI responses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @kickstart/web
 
+## 0.7.0
+
+### Minor Changes
+
+- Release the merged v0.7.0 feature set: codex-backed stepwise setup generation,
+  workspace-first file delivery, real Azure and GitHub deployment lanes, live pricing
+  and token usage tracking, file manager improvements, and architecture diagram upgrades.
+
 ## 0.5.7
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstart/web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "Kickstart web frontend — Azure Portal-style UX for AI-guided AKS deployment",


### PR DESCRIPTION
## Summary
- bump Kickstart to v0.7.0 across the root app and linked packages
- roll package changelogs via Changesets and add the top-level v0.7.0 changelog entry
- validate the release branch locally before handing it to CI

## Testing
- npm run build
- npm run test

## Notes
- Tag v0.7.0 will be created and pushed immediately after this PR merges because main is protected by PR-only rules.
