### PR TITLE
feat: validate Playground fat components

### DIFF
--- a/packages/web/e2e/playground.spec.ts
+++ b/packages/web/e2e/playground.spec.ts
@@ -1,6 +1,16 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from './helpers';
 
 const PLAYGROUND_URL = '/?playground';
+
+async function openScenario(page: Page, label: string) {
+  const searchBox = page.getByPlaceholder('Filter scenarios...');
+  await searchBox.fill(label);
+  const card = page.getByRole('button', { name: label }).first();
+  await card.waitFor({ timeout: 10_000 });
+  await card.click();
+  await page.getByRole('dialog').waitFor({ timeout: 5_000 });
+}
 
 test.describe('Playground', () => {
   test.beforeEach(async ({ page }) => {
@@ -124,6 +134,42 @@ test.describe('Playground', () => {
       await expect(async () => {
         expect(await cards.count()).toBe(initialCount);
       }).toPass({ timeout: 3000 });
+    });
+  });
+
+  test.describe('Fat component slices', () => {
+    test('Azure AuthCard signs in with the playground stub flow', async ({ page }) => {
+      await openScenario(page, 'Azure AuthCard');
+
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Sign in to Azure' }).click();
+
+      await expect(dialog.getByText('Connected')).toBeVisible({ timeout: 3_000 });
+      await expect(dialog.getByRole('button', { name: 'Sign out' })).toBeVisible();
+    });
+
+    test('GitHub AuthCard signs in with the playground stub flow', async ({ page }) => {
+      await openScenario(page, 'GitHub AuthCard');
+
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Sign in to GitHub' }).click();
+
+      await expect(dialog.getByText('Connected')).toBeVisible({ timeout: 3_000 });
+      await expect(dialog.getByRole('button', { name: 'Sign out' })).toBeVisible();
+    });
+
+    test('fat slice scenario renders stub Azure and GitHub data', async ({ page }) => {
+      await openScenario(page, 'Fat slice: Azure + GitHub');
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByText('kickstart-aks')).toBeVisible({ timeout: 5_000 });
+      await expect(dialog.getByText('stub-user/my-web-app')).toBeVisible({ timeout: 5_000 });
+
+      await dialog.getByRole('button', { name: 'Sign in to Azure' }).click();
+      await expect(dialog.getByText('Kickstart Dev Subscription')).toBeVisible({ timeout: 5_000 });
+
+      await dialog.getByRole('button', { name: 'Sign in with GitHub' }).click();
+      await expect(dialog.getByText('Signed in via GitHub')).toBeVisible({ timeout: 5_000 });
     });
   });
 

--- a/packages/web/e2e/playground.spec.ts
+++ b/packages/web/e2e/playground.spec.ts
@@ -145,7 +145,7 @@ test.describe('Playground', () => {
       await dialog.getByRole('button', { name: 'Sign in to Azure' }).click();
 
       await expect(dialog.getByText('Connected')).toBeVisible({ timeout: 3_000 });
-      await expect(dialog.getByRole('button', { name: 'Sign out' })).toBeVisible();
+      await expect(dialog.getByRole('button', { name: 'Disconnect' })).toBeVisible();
     });
 
     test('GitHub AuthCard signs in with the playground stub flow', async ({ page }) => {
@@ -155,7 +155,7 @@ test.describe('Playground', () => {
       await dialog.getByRole('button', { name: 'Sign in to GitHub' }).click();
 
       await expect(dialog.getByText('Connected')).toBeVisible({ timeout: 3_000 });
-      await expect(dialog.getByRole('button', { name: 'Sign out' })).toBeVisible();
+      await expect(dialog.getByRole('button', { name: 'Disconnect' })).toBeVisible();
     });
 
     test('fat slice scenario renders stub Azure and GitHub data', async ({ page }) => {

--- a/packages/web/src/catalog/components/AuthCard.tsx
+++ b/packages/web/src/catalog/components/AuthCard.tsx
@@ -30,6 +30,11 @@ import {
   signOutAzure,
   type AzureAuthSessionState,
 } from "../../services/azure-auth";
+import {
+  createAzureStubSession,
+  createGitHubStubSession,
+  shouldUsePlaygroundAuthStub,
+} from "../../services/playground-auth-stub";
 
 const AuthCardApi = {
   name: "AuthCard",
@@ -97,6 +102,7 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
   const classes = useStyles();
   const connector = useAPIConnector(CONNECTOR_NAME[props.provider]);
   const azureConnector = props.provider === "azure" ? connector as AzureARMConnector | undefined : undefined;
+  const usePlaygroundStub = shouldUsePlaygroundAuthStub();
 
   const [loading, setLoading] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
@@ -110,6 +116,15 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
   const description = str(props.description) || DEFAULT_DESCRIPTION[props.provider];
 
   const refreshGitHubSession = useCallback(async () => {
+    if (usePlaygroundStub) {
+      const session = createGitHubStubSession(false);
+      setGitHubSession(session);
+      setAuthenticated(false);
+      setError(undefined);
+      setChecking(false);
+      return;
+    }
+
     setChecking(true);
     try {
       const session = await getGitHubSession();
@@ -123,9 +138,18 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
     } finally {
       setChecking(false);
     }
-  }, []);
+  }, [usePlaygroundStub]);
 
   const refreshAzureSession = useCallback(async () => {
+    if (usePlaygroundStub) {
+      const session = createAzureStubSession(false);
+      setAzureSession(session);
+      setAuthenticated(false);
+      setError(undefined);
+      setChecking(false);
+      return;
+    }
+
     setChecking(true);
     try {
       const session = await getAzureSession(azureConnector);
@@ -139,7 +163,7 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
     } finally {
       setChecking(false);
     }
-  }, [azureConnector]);
+  }, [azureConnector, usePlaygroundStub]);
 
   useEffect(() => {
     if (props.provider === "github") {
@@ -173,12 +197,16 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
 
     try {
       if (props.provider === "github") {
-        const session = await signInWithGitHubPopup();
+        const session = usePlaygroundStub
+          ? createGitHubStubSession(true)
+          : await signInWithGitHubPopup();
         setGitHubSession(session);
         setAuthenticated(session.authenticated);
         setError(session.error);
       } else {
-        const session = await signInToAzure(azureConnector);
+        const session = usePlaygroundStub
+          ? createAzureStubSession(true)
+          : await signInToAzure(azureConnector);
         setAzureSession(session);
         setAuthenticated(session.authenticated);
         setError(session.error);
@@ -190,7 +218,7 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
     } finally {
       setLoading(false);
     }
-  }, [azureConnector, handleAzureContinue, props.provider]);
+  }, [azureConnector, handleAzureContinue, props.provider, usePlaygroundStub]);
 
   useEffect(() => {
     if (props.provider !== "azure") return;
@@ -211,15 +239,23 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
 
     try {
       if (props.provider === "github") {
-        await signOutGitHub();
-        setGitHubSession((previous) => previous
-          ? { ...previous, authenticated: false, viewer: undefined, owners: [] }
-          : null);
+        if (usePlaygroundStub) {
+          setGitHubSession(createGitHubStubSession(false));
+        } else {
+          await signOutGitHub();
+          setGitHubSession((previous) => previous
+            ? { ...previous, authenticated: false, viewer: undefined, owners: [] }
+            : null);
+        }
       } else {
-        await signOutAzure();
-        setAzureSession((previous) => previous
-          ? { ...previous, authenticated: false, subscriptions: [], error: undefined }
-          : null);
+        if (usePlaygroundStub) {
+          setAzureSession(createAzureStubSession(false));
+        } else {
+          await signOutAzure();
+          setAzureSession((previous) => previous
+            ? { ...previous, authenticated: false, subscriptions: [], error: undefined }
+            : null);
+        }
       }
       setAuthenticated(false);
     } catch (err) {
@@ -227,7 +263,7 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
     } finally {
       setLoading(false);
     }
-  }, [azureConnector, props.provider]);
+  }, [props.provider, usePlaygroundStub]);
 
   const summary = useMemo(() => {
     if (props.provider === "azure") {
@@ -318,6 +354,16 @@ export const AuthCard = createReactComponent(AuthCardApi, ({ props, context }) =
           }}
         >
           Azure sign-in is unavailable until the backend auth configuration is ready.
+        </Caption1>
+      )}
+      {usePlaygroundStub && (
+        <Caption1
+          style={{
+            color: tokens.colorNeutralForeground3,
+            marginTop: tokens.spacingVerticalXS,
+          }}
+        >
+          Running in offline mode — sign-in will use stub data
         </Caption1>
       )}
     </Card>

--- a/packages/web/src/catalog/components/GitHubLoginCard.tsx
+++ b/packages/web/src/catalog/components/GitHubLoginCard.tsx
@@ -22,6 +22,10 @@ import {
   signOutGitHub,
   type GitHubSessionState,
 } from "../../services/github-handoff";
+import {
+  createGitHubStubSession,
+  shouldUsePlaygroundAuthStub,
+} from "../../services/playground-auth-stub";
 
 const GitHubLoginCardApi = {
   name: "GitHubLoginCard",
@@ -69,12 +73,20 @@ const useStyles = makeStyles({
 
 export const GitHubLoginCard = createReactComponent(GitHubLoginCardApi, ({ props }) => {
   const classes = useStyles();
+  const usePlaygroundStub = shouldUsePlaygroundAuthStub();
 
   const [session, setSession] = useState<GitHubSessionState | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | undefined>();
 
   const refreshSession = useCallback(async () => {
+    if (usePlaygroundStub) {
+      setSession(createGitHubStubSession(false));
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
     try {
       const nextSession = await getGitHubSession();
@@ -86,13 +98,23 @@ export const GitHubLoginCard = createReactComponent(GitHubLoginCardApi, ({ props
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [usePlaygroundStub]);
 
   useEffect(() => {
     void refreshSession();
   }, [refreshSession]);
 
   const handleSignIn = async () => {
+    if (usePlaygroundStub) {
+      setSession(createGitHubStubSession(true));
+      setError(undefined);
+      setLoading(false);
+      if (props.onSignIn) {
+        (props.onSignIn as () => void)();
+      }
+      return;
+    }
+
     setLoading(true);
     setError(undefined);
     try {
@@ -110,6 +132,16 @@ export const GitHubLoginCard = createReactComponent(GitHubLoginCardApi, ({ props
   };
 
   const handleSignOut = async () => {
+    if (usePlaygroundStub) {
+      setSession(createGitHubStubSession(false));
+      setError(undefined);
+      setLoading(false);
+      if (props.onSignOut) {
+        (props.onSignOut as () => void)();
+      }
+      return;
+    }
+
     setLoading(true);
     setError(undefined);
     try {
@@ -151,6 +183,7 @@ export const GitHubLoginCard = createReactComponent(GitHubLoginCardApi, ({ props
             <Body2 style={{ fontWeight: 600 }}>
               {session.viewer.name || session.viewer.login}
             </Body2>
+            <Caption1>Signed in via GitHub</Caption1>
             <Caption1>{session.viewer.login}</Caption1>
           </div>
         </div>
@@ -179,12 +212,17 @@ export const GitHubLoginCard = createReactComponent(GitHubLoginCardApi, ({ props
         <Button
           appearance="primary"
           onClick={() => void handleSignIn()}
-          disabled={loading || session?.configured === false}
+          disabled={loading || (!usePlaygroundStub && session?.configured === false)}
           icon={loading ? <Spinner size="tiny" /> : undefined}
         >
           {loading ? "Checking sign-in…" : "Sign in with GitHub"}
         </Button>
       </div>
+      {usePlaygroundStub && (
+        <Caption1 style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalXS }}>
+          Running in offline mode — sign-in will use stub data
+        </Caption1>
+      )}
     </Card>
   );
 });

--- a/packages/web/src/catalog/components/GitHubRepoPicker.tsx
+++ b/packages/web/src/catalog/components/GitHubRepoPicker.tsx
@@ -28,6 +28,13 @@ import {
   listGitHubRepos,
   type GitHubSessionState,
 } from "../../services/github-handoff";
+import {
+  createGitHubStubRepo,
+  createGitHubStubSession,
+  DEFAULT_GITHUB_STUB_OWNER,
+  listGitHubStubRepos,
+  shouldUsePlaygroundAuthStub,
+} from "../../services/playground-auth-stub";
 import { sanitizeActionContext } from "../../utils/sanitize-action-context";
 
 const GitHubRepoPickerApi = {
@@ -136,6 +143,7 @@ function repoParts(fullName: string): { owner: string; repo: string } {
 export const GitHubRepoPicker = createReactComponent(GitHubRepoPickerApi, ({ props, context }) => {
   const classes = useStyles();
   const allowCreate = props.allowCreate !== false;
+  const usePlaygroundStub = shouldUsePlaygroundAuthStub();
 
   const [session, setSession] = useState<GitHubSessionState | null>(null);
   const [authLoading, setAuthLoading] = useState(true);
@@ -158,6 +166,15 @@ export const GitHubRepoPicker = createReactComponent(GitHubRepoPickerApi, ({ pro
   const [createPrivate, setCreatePrivate] = useState(false);
 
   const refreshSession = useCallback(async () => {
+    if (usePlaygroundStub) {
+      const nextSession = createGitHubStubSession(true);
+      setSession(nextSession);
+      setError(undefined);
+      setSelectedOwner((current) => current || DEFAULT_GITHUB_STUB_OWNER);
+      setAuthLoading(false);
+      return;
+    }
+
     setAuthLoading(true);
     try {
       const nextSession = await getGitHubSession();
@@ -170,13 +187,24 @@ export const GitHubRepoPicker = createReactComponent(GitHubRepoPickerApi, ({ pro
     } finally {
       setAuthLoading(false);
     }
-  }, []);
+  }, [usePlaygroundStub]);
 
   useEffect(() => {
     void refreshSession();
   }, [refreshSession]);
 
   const fetchRepos = useCallback(async (owner: string, pageNumber: number) => {
+    if (usePlaygroundStub) {
+      const nextRepos = listGitHubStubRepos(owner);
+      const pageStart = (pageNumber - 1) * PER_PAGE;
+      const pageRepos = nextRepos.slice(pageStart, pageStart + PER_PAGE);
+      setRepos(pageRepos);
+      setHasMore(pageStart + PER_PAGE < nextRepos.length);
+      setError(undefined);
+      setLoadingRepos(false);
+      return;
+    }
+
     setLoadingRepos(true);
     try {
       const nextRepos = await listGitHubRepos(owner, pageNumber, PER_PAGE);
@@ -190,7 +218,7 @@ export const GitHubRepoPicker = createReactComponent(GitHubRepoPickerApi, ({ pro
     } finally {
       setLoadingRepos(false);
     }
-  }, []);
+  }, [usePlaygroundStub]);
 
   useEffect(() => {
     if (!session?.authenticated || !selectedOwner || mode !== "existing") {
@@ -263,12 +291,19 @@ export const GitHubRepoPicker = createReactComponent(GitHubRepoPickerApi, ({ pro
 
     setCreating(true);
     try {
-      const createdRepo = await createGitHubRepo({
-        owner: selectedOwner,
-        name: createName.trim(),
-        description: createDescription.trim() || undefined,
-        private: createPrivate,
-      });
+      const createdRepo = usePlaygroundStub
+        ? createGitHubStubRepo({
+            owner: selectedOwner || DEFAULT_GITHUB_STUB_OWNER,
+            name: createName.trim(),
+            description: createDescription.trim() || undefined,
+            private: createPrivate,
+          })
+        : await createGitHubRepo({
+            owner: selectedOwner,
+            name: createName.trim(),
+            description: createDescription.trim() || undefined,
+            private: createPrivate,
+          });
       setRepos((previous) => [createdRepo, ...previous.filter((repo) => repo.full_name !== createdRepo.full_name)]);
       setSelectedRepo(createdRepo.full_name);
       setMode("existing");

--- a/packages/web/src/contexts/APIConnectorContext.tsx
+++ b/packages/web/src/contexts/APIConnectorContext.tsx
@@ -15,6 +15,11 @@ interface APIConnectorContextValue {
 
 const APIConnectorContext = createContext<APIConnectorContextValue | null>(null);
 
+function shouldUsePlaygroundStubRegistry(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).has('playground');
+}
+
 interface APIConnectorProviderProps {
   children: ReactNode;
   /**
@@ -45,16 +50,20 @@ export function APIConnectorProvider({
     if (externalRegistry) return externalRegistry;
 
     const r = new APIConnectorRegistry();
-    r.register(new AzureARMConnector({
-      auth: { kind: 'none' },
-      corsProxy: {
-        proxyBaseUrl: '/api/arm-proxy',
-      },
-    }));
-    r.register(new GitHubConnector({
-      auth: { kind: 'oauth2', scopes: ['read:user'] },
-      serverBaseUrl: '/api/github',
-    }));
+    // Playground intentionally omits auth-gated connectors so fat components
+    // exercise their built-in offline/stub flows without live credentials.
+    if (!shouldUsePlaygroundStubRegistry()) {
+      r.register(new AzureARMConnector({
+        auth: { kind: 'none' },
+        corsProxy: {
+          proxyBaseUrl: '/api/arm-proxy',
+        },
+      }));
+      r.register(new GitHubConnector({
+        auth: { kind: 'oauth2', scopes: ['read:user'] },
+        serverBaseUrl: '/api/github',
+      }));
+    }
     r.register(new PricingConnector());
     return r;
   }, [externalRegistry]);

--- a/packages/web/src/pages/playground-scenarios.ts
+++ b/packages/web/src/pages/playground-scenarios.ts
@@ -1394,7 +1394,7 @@ const fatAzureGitHubSlice = (): A2uiMsg[] => {
       text: 'The picker loads stub subscriptions, resource groups, and resources so the cascading flow is easy to test inside Playground.',
       variant: 'caption',
     },
-    { id: 'azure-picker', component: 'AzureResourcePicker', label: 'Pick an Azure resource' },
+    { id: 'azure-picker', component: 'AzureResourcePicker', label: 'Pick an Azure cluster', resourceType: 'Microsoft.ContainerService/managedClusters' },
     { id: 'github-picker-card', component: 'Card', child: 'github-picker-col' },
     { id: 'github-picker-col', component: 'Column', children: ['github-picker-title', 'github-picker-copy', 'github-picker'], gap: 'small' },
     { id: 'github-picker-title', component: 'Text', text: 'GitHub repository selection', variant: 'subtitle1' },

--- a/packages/web/src/pages/playground-scenarios.ts
+++ b/packages/web/src/pages/playground-scenarios.ts
@@ -1307,7 +1307,7 @@ const kitAzureAuth = (): A2uiMsg[] => {
     {
       id: 'desc',
       component: 'Text',
-      text: 'The AuthCard component is registered by the Azure kit. It renders an MSAL sign-in card that integrates with the azure-arm connector. In offline mode the card uses stub data.',
+      text: 'The AuthCard component is registered by the Azure kit. In Playground it uses the offline stub flow so you can verify the UI without wiring real Azure credentials first.',
       variant: 'body2',
     },
     { id: 'auth-card', component: 'AuthCard', provider: 'azure' },
@@ -1328,7 +1328,7 @@ const kitGitHubAuth = (): A2uiMsg[] => {
     {
       id: 'desc',
       component: 'Text',
-      text: 'The GitHub kit registers an AuthCard with the github-oauth provider. It renders a server-owned OAuth sign-in card that keeps GitHub tokens off the browser surface.',
+      text: 'The GitHub kit registers an AuthCard with the github-oauth provider. In Playground it falls back to the local offline flow so the sign-in card stays testable without a live GitHub session.',
       variant: 'body2',
     },
     { id: 'auth-card', component: 'AuthCard', provider: 'github' },
@@ -1349,7 +1349,7 @@ const kitMultiProvider = (): A2uiMsg[] => {
     {
       id: 'desc',
       component: 'Text',
-      text: 'Both Azure and GitHub kits registered side-by-side. Each AuthCard connects to its own connector and auth provider independently.',
+      text: 'Both Azure and GitHub kits are registered side-by-side. In Playground each AuthCard runs its own offline stub flow so the multi-provider layout is easy to verify without live auth.',
       variant: 'body2',
     },
     { id: 'cards-row', component: 'Row', children: ['azure-card', 'github-card'], gap: 'medium' },
@@ -1362,6 +1362,54 @@ const kitMultiProvider = (): A2uiMsg[] => {
       component: 'Text',
       text: 'Sign in to both providers to enable the full Kickstart workflow — Azure for infrastructure, GitHub for source code.',
       variant: 'body2',
+    },
+  ] as A2uiComponent[]);
+};
+
+const fatAzureGitHubSlice = (): A2uiMsg[] => {
+  const sid = uid('fat-slice-azure-github');
+  return surface(sid, [
+    {
+      id: 'root',
+      component: 'Column',
+      children: ['heading', 'desc', 'auth-row', 'azure-picker-card', 'github-picker-card', 'note'],
+      gap: 'medium',
+    },
+    { id: 'heading', component: 'Text', text: 'Fat slice: Azure + GitHub', variant: 'h3' },
+    {
+      id: 'desc',
+      component: 'Text',
+      text: 'This is the first real Playground smoke slice for fat components. Sign-in is simulated in Playground mode and the pickers use built-in stub data so you can validate the UX without live credentials.',
+      variant: 'body2',
+    },
+    { id: 'auth-row', component: 'Row', children: ['azure-login', 'github-login'], gap: 'medium' },
+    { id: 'azure-login', component: 'AzureLoginCard' },
+    { id: 'github-login', component: 'GitHubLoginCard' },
+    { id: 'azure-picker-card', component: 'Card', child: 'azure-picker-col' },
+    { id: 'azure-picker-col', component: 'Column', children: ['azure-picker-title', 'azure-picker-copy', 'azure-picker'], gap: 'small' },
+    { id: 'azure-picker-title', component: 'Text', text: 'Azure resource selection', variant: 'subtitle1' },
+    {
+      id: 'azure-picker-copy',
+      component: 'Text',
+      text: 'The picker loads stub subscriptions, resource groups, and resources so the cascading flow is easy to test inside Playground.',
+      variant: 'caption',
+    },
+    { id: 'azure-picker', component: 'AzureResourcePicker', label: 'Pick an Azure resource' },
+    { id: 'github-picker-card', component: 'Card', child: 'github-picker-col' },
+    { id: 'github-picker-col', component: 'Column', children: ['github-picker-title', 'github-picker-copy', 'github-picker'], gap: 'small' },
+    { id: 'github-picker-title', component: 'Text', text: 'GitHub repository selection', variant: 'subtitle1' },
+    {
+      id: 'github-picker-copy',
+      component: 'Text',
+      text: 'The picker loads stub repositories so search and selection work even when no GitHub auth is configured.',
+      variant: 'caption',
+    },
+    { id: 'github-picker', component: 'GitHubRepoPicker', placeholder: 'Search repositories...' },
+    {
+      id: 'note',
+      component: 'Text',
+      text: 'Use the Playground at /?playground and open this card for the quickest end-to-end fat-component check.',
+      variant: 'caption',
     },
   ] as A2uiComponent[]);
 };
@@ -1539,7 +1587,7 @@ const domainGitHubLogin = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'gh-login'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'GitHubLoginCard', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'GitHub authentication card with a server-owned OAuth flow. Sign in to connect your repositories.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'GitHub authentication card with a server-owned OAuth flow. In Playground it falls back to a stub user so you can verify the states without live auth.', variant: 'body2' },
     { id: 'gh-login', component: 'GitHubLoginCard' },
   ] as A2uiComponent[]);
 };
@@ -1549,7 +1597,7 @@ const domainGitHubRepoPicker = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'gh-picker'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'GitHubRepoPicker', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Search and select a GitHub repository with pagination, language badges, and metadata. Requires GitHub authentication.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Search and select a GitHub repository with pagination, language badges, and metadata. Playground falls back to stub repositories when GitHub auth is unavailable.', variant: 'body2' },
     { id: 'gh-picker', component: 'GitHubRepoPicker', placeholder: 'Search repositories...' },
   ] as A2uiComponent[]);
 };
@@ -1559,7 +1607,7 @@ const domainGitHubAction = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'gh-action'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'GitHubAction', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Execute a GitHub API action with built-in safety: operation allowlist, branch protection, and destructive confirmation.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Execute a GitHub API action with built-in safety: operation allowlist, branch protection, and destructive confirmation. Playground simulates success when no GitHub connector is configured.', variant: 'body2' },
     { id: 'gh-action', component: 'GitHubAction', title: 'Create feature branch', description: 'Creates a new branch from main for the feature implementation.', method: 'POST', path: '/repos/demo-org/demo-repo/git/refs', operationType: 'git/refs/create', body: { ref: 'refs/heads/feature/new-api', sha: 'abc123' } },
   ] as A2uiComponent[]);
 };
@@ -1569,7 +1617,7 @@ const domainGitHubCommit = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'gh-commit'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'GitHubCommit', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Multi-step pull request creation wizard: select artifacts, configure branch name, title, and body.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Multi-step pull request creation wizard: select artifacts, configure branch name, title, and body. Playground simulates PR creation when no GitHub connector is configured.', variant: 'body2' },
     { id: 'gh-commit', component: 'GitHubCommit', suggestedBranchName: 'feature/add-api-endpoints', suggestedTitle: 'Add REST API endpoints', suggestedBody: 'Implements CRUD endpoints for the user service.' },
   ] as A2uiComponent[]);
 };
@@ -1583,7 +1631,7 @@ const domainAzureLogin = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'az-login'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'AzureLoginCard', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Azure MSAL authentication card. Sign in to manage your Azure subscriptions and resources.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Azure MSAL authentication card. In Playground it uses stub subscription data so you can verify the signed-in states without live Azure auth.', variant: 'body2' },
     { id: 'az-login', component: 'AzureLoginCard' },
   ] as A2uiComponent[]);
 };
@@ -1593,7 +1641,7 @@ const domainAzureResourcePicker = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'az-picker'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'AzureResourcePicker', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Cascading dropdowns: subscription → resource group → resource. Requires Azure authentication.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Cascading dropdowns: subscription → resource group → resource. Playground uses stub subscriptions, resource groups, and resources when Azure auth is unavailable.', variant: 'body2' },
     { id: 'az-picker', component: 'AzureResourcePicker', label: 'Select a resource' },
   ] as A2uiComponent[]);
 };
@@ -1603,7 +1651,7 @@ const domainAzureResourceForm = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'az-form'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'AzureResourceForm', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Dynamic resource creation form with type-specific fields (Kubernetes version, admin user, access tier, etc.). Requires Azure authentication.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Dynamic resource creation form with type-specific fields (Kubernetes version, admin user, access tier, etc.). Playground uses fallback data and simulated submission when Azure auth is unavailable.', variant: 'body2' },
     { id: 'az-form', component: 'AzureResourceForm', title: 'Create Kubernetes Cluster', resourceType: 'Microsoft.ContainerService/managedClusters' },
   ] as A2uiComponent[]);
 };
@@ -1613,7 +1661,7 @@ const domainAzureAction = (): A2uiMsg[] => {
   return surface(sid, [
     { id: 'root', component: 'Column', children: ['heading', 'desc', 'az-action'], gap: 'medium' },
     { id: 'heading', component: 'Text', text: 'AzureAction', variant: 'h3' },
-    { id: 'desc', component: 'Text', text: 'Execute an Azure ARM API action with resource type allowlist, path validation, and destructive confirmation.', variant: 'body2' },
+    { id: 'desc', component: 'Text', text: 'Execute an Azure ARM API action with resource type allowlist, path validation, and destructive confirmation. Playground simulates success when no Azure connector is configured.', variant: 'body2' },
     { id: 'az-action', component: 'AzureAction', title: 'Scale AKS cluster', description: 'Updates the node count for the default node pool.', method: 'PATCH', path: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ContainerService/managedClusters/my-cluster', body: { properties: { agentPoolProfiles: [{ name: 'default', count: 5 }] } } },
   ] as A2uiComponent[]);
 };
@@ -1679,6 +1727,7 @@ export const CONTROL_SCENARIOS: ScenarioDef[] = [
   { id: 'dyn-conditional', label: 'Conditional Content',  description: 'Feature flags with data binding',            group: 'Dynamic Patterns', generate: dynamicConditionalContent },
   { id: 'dyn-dashboard', label: 'Complex Dashboard',      description: 'Multi-tab dashboard with data binding',      group: 'Dynamic Patterns', generate: dynamicComplexDashboard },
   // Integration Kits
+  { id: 'fat-slice-azure-github', label: 'Fat slice: Azure + GitHub', description: 'Offline smoke test for login cards + pickers', group: 'Integration Kits', catalog: 'kickstart', generate: fatAzureGitHubSlice },
   { id: 'kit-azure-auth',    label: 'Azure AuthCard',         description: 'Azure MSAL sign-in via kit registration',  group: 'Integration Kits', catalog: 'kickstart', generate: kitAzureAuth },
   { id: 'kit-github-auth',   label: 'GitHub AuthCard',        description: 'GitHub OAuth sign-in via kit registration', group: 'Integration Kits', catalog: 'kickstart', generate: kitGitHubAuth },
   { id: 'kit-multi-provider', label: 'Multi-Provider Sign-In', description: 'Azure + GitHub AuthCards side by side',    group: 'Integration Kits', catalog: 'kickstart', generate: kitMultiProvider },

--- a/packages/web/src/services/playground-auth-stub.ts
+++ b/packages/web/src/services/playground-auth-stub.ts
@@ -82,7 +82,7 @@ export function createGitHubStubSession(authenticated: boolean): GitHubSessionSt
     authenticated,
     configured: true,
     viewer: authenticated ? GITHUB_STUB_VIEWER : undefined,
-    owners: GITHUB_STUB_OWNERS,
+    owners: authenticated ? GITHUB_STUB_OWNERS : [],
   };
 }
 

--- a/packages/web/src/services/playground-auth-stub.ts
+++ b/packages/web/src/services/playground-auth-stub.ts
@@ -1,0 +1,118 @@
+import type { AzureSubscription, GitHubRepo } from "@kickstart/core";
+import type { AzureAuthSessionState } from "./azure-auth";
+import type { GitHubSessionState, GitHubOwnerSummary, GitHubViewerSummary } from "./github-handoff";
+import { isPlaygroundMode } from "./mock-streaming";
+
+const AZURE_STUB_SUBSCRIPTIONS: AzureSubscription[] = [
+  {
+    subscriptionId: "00000000-0000-0000-0000-000000000001",
+    displayName: "Kickstart Dev Subscription",
+    state: "Enabled",
+    tenantId: "00000000-0000-0000-0000-000000000099",
+  },
+];
+
+const GITHUB_STUB_VIEWER: GitHubViewerSummary = {
+  login: "stub-user",
+  name: "Stub User",
+  avatarUrl: "https://avatars.githubusercontent.com/u/9919?v=4",
+  htmlUrl: "https://github.com/stub-user",
+};
+
+const GITHUB_STUB_OWNERS: GitHubOwnerSummary[] = [
+  {
+    login: GITHUB_STUB_VIEWER.login,
+    type: "User",
+    label: GITHUB_STUB_VIEWER.login,
+    avatarUrl: GITHUB_STUB_VIEWER.avatarUrl,
+    htmlUrl: GITHUB_STUB_VIEWER.htmlUrl,
+  },
+];
+
+const GITHUB_STUB_REPOS: GitHubRepo[] = [
+  {
+    id: 9001,
+    name: "my-web-app",
+    full_name: "stub-user/my-web-app",
+    private: false,
+    html_url: "https://github.com/stub-user/my-web-app",
+    description: "Demo repository surfaced by Playground stub mode.",
+    default_branch: "main",
+    language: "TypeScript",
+    stargazers_count: 42,
+    updated_at: "2026-04-15T00:00:00.000Z",
+  },
+  {
+    id: 9002,
+    name: "kickstart-portal",
+    full_name: "stub-user/kickstart-portal",
+    private: true,
+    html_url: "https://github.com/stub-user/kickstart-portal",
+    description: "Private portal prototype used for offline Playground validation.",
+    default_branch: "main",
+    language: "JavaScript",
+    stargazers_count: 7,
+    updated_at: "2026-04-14T00:00:00.000Z",
+  },
+];
+
+export const DEFAULT_GITHUB_STUB_OWNER = GITHUB_STUB_VIEWER.login;
+
+export function shouldUsePlaygroundAuthStub(): boolean {
+  return typeof window !== "undefined" && isPlaygroundMode();
+}
+
+export function createAzureStubSession(authenticated: boolean): AzureAuthSessionState {
+  return {
+    configured: true,
+    authenticated,
+    user: authenticated
+      ? {
+          name: "Azure User",
+          username: "azure.user@kickstart.local",
+          tenantId: AZURE_STUB_SUBSCRIPTIONS[0]?.tenantId,
+        }
+      : undefined,
+    subscriptions: authenticated ? AZURE_STUB_SUBSCRIPTIONS : [],
+  };
+}
+
+export function createGitHubStubSession(authenticated: boolean): GitHubSessionState {
+  return {
+    authenticated,
+    configured: true,
+    viewer: authenticated ? GITHUB_STUB_VIEWER : undefined,
+    owners: GITHUB_STUB_OWNERS,
+  };
+}
+
+export function listGitHubStubRepos(owner = DEFAULT_GITHUB_STUB_OWNER): GitHubRepo[] {
+  return GITHUB_STUB_REPOS.map((repo) => ({
+    ...repo,
+    full_name: `${owner}/${repo.name}`,
+    html_url: `https://github.com/${owner}/${repo.name}`,
+  }));
+}
+
+export function createGitHubStubRepo(input: {
+  owner?: string;
+  name: string;
+  description?: string;
+  private?: boolean;
+}): GitHubRepo {
+  const owner = input.owner ?? DEFAULT_GITHUB_STUB_OWNER;
+  const name = input.name.trim();
+
+  return {
+    id: Date.now(),
+    name,
+    full_name: `${owner}/${name}`,
+    private: Boolean(input.private),
+    html_url: `https://github.com/${owner}/${name}`,
+    description: input.description?.trim() || null,
+    default_branch: "main",
+    language: "TypeScript",
+    stargazers_count: 0,
+    updated_at: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
Closes #331

Working as Fry (Frontend Dev)

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Summary
- keep Azure and GitHub fat components in Playground on their offline/stub paths by omitting auth-gated connectors from the Playground registry
- clarify Playground scenario copy so fat-component demos explicitly say when stub data or simulated success is in use
- add focused Playwright smoke coverage for the Playground fat-component slice

## Testing
- npm run build
- npx playwright test packages/web/e2e/playground.spec.ts --grep "Fat component slices" *(blocked locally in this runner because Playwright Chromium is missing libnspr4; CI is the authoritative gate)*
