### PR TITLE
feat: align ArchitectureDiagram styling with Fluent 2

### DIFF
--- a/packages/web/src/catalog/components/ArchitectureDiagram.tsx
+++ b/packages/web/src/catalog/components/ArchitectureDiagram.tsx
@@ -4,14 +4,19 @@ import { z } from 'zod';
 import { DynamicStringSchema } from '../../vendor/a2ui/web_core/schema/common-types';
 import {
   Body2,
+  Button,
   Caption1,
   Card,
   makeStyles,
+  mergeClasses,
+  shorthands,
+  Subtitle2,
   tokens,
 } from '@fluentui/react-components';
 import {
   DiagramEdge,
   DiagramNode,
+  FLUENT_DIAGRAM_PALETTE,
   nodesToMermaid,
   renderArchitectureDiagramSvg,
 } from './architectureDiagramUtils';
@@ -21,22 +26,12 @@ import {
   getArchitectureDiagramIconRegistry,
 } from './architectureDiagramIconRegistry';
 
-const AZURE = {
-  themePrimary: '#0078d4',
-  neutralPrimary: '#292827',
-  neutralSecondary: '#646464',
-  neutralTertiaryAlt: '#a19f9d',
-  neutralLight: '#e1dfdd',
-  neutralLighter: '#f3f2f1',
-  neutralLighterAlt: '#faf9f8',
-  white: '#ffffff',
-  fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
-} as const;
-
 const VIEWPORT_MIN_HEIGHT = 320;
 const VIEWPORT_MAX_HEIGHT = 800;
 const MIN_SCALE = 0.2;
 const MAX_SCALE = 5;
+const FLUENT_DIAGRAM_ICON_FILTER =
+  'brightness(0) saturate(100%) invert(30%) sepia(91%) saturate(1523%) hue-rotate(191deg) brightness(92%) contrast(88%)';
 
 const NodeSchema = z.object({
   id: z.string(),
@@ -67,26 +62,25 @@ const useStyles = makeStyles({
     marginBottom: tokens.spacingVerticalS,
     width: '100%',
     overflow: 'hidden',
-    padding: '0',
-    backgroundColor: '#ffffff',
+    padding: 0,
+    backgroundColor: tokens.colorNeutralBackground1,
   },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
+    flexWrap: 'wrap',
     gap: tokens.spacingHorizontalM,
-    padding: '14px 20px',
-    borderBottomWidth: tokens.strokeWidthThin,
-    borderBottomStyle: 'solid',
-    borderBottomColor: '#e1dfdd',
-    backgroundColor: '#faf9f8',
-    letterSpacing: '0.01em',
+    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalL),
+    ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+    backgroundColor: tokens.colorNeutralBackground2,
   },
   titleGroup: {
     display: 'flex',
     flexDirection: 'column',
     gap: tokens.spacingVerticalXXS,
     minWidth: '0',
+    flex: '1 1 auto',
   },
   titleRow: {
     display: 'flex',
@@ -98,64 +92,45 @@ const useStyles = makeStyles({
     width: '16px',
     height: '16px',
     flexShrink: 0,
-    filter: 'brightness(0) saturate(100%) invert(28%) sepia(98%) saturate(1624%) hue-rotate(196deg) brightness(96%) contrast(101%)',
+    filter: FLUENT_DIAGRAM_ICON_FILTER,
   },
   title: {
-    fontSize: '16px',
-    fontWeight: 600,
-    lineHeight: '22px',
-    color: '#292827',
+    color: tokens.colorNeutralForeground1,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
   description: {
-    color: '#646464',
-    marginLeft: '24px',
+    color: tokens.colorNeutralForeground2,
+    paddingLeft: `calc(16px + ${tokens.spacingHorizontalXS})`,
   },
   controls: {
     display: 'flex',
+    flexWrap: 'wrap',
     alignItems: 'center',
-    gap: '4px',
+    justifyContent: 'flex-end',
+    gap: tokens.spacingHorizontalXXS,
     flexShrink: 0,
   },
   controlButton: {
-    width: '28px',
-    height: '28px',
-    border: '1px solid #e1dfdd',
-    borderRadius: '2px',
-    backgroundColor: '#ffffff',
-    color: '#646464',
-    cursor: 'pointer',
+    minWidth: '28px',
+    fontSize: tokens.fontSizeBase300,
+  },
+  actionButton: {
+    minWidth: 'fit-content',
+  },
+  percentage: {
+    minWidth: '40px',
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    fontSize: '14px',
-    lineHeight: 1,
-    padding: 0,
-    ':disabled': {
-      cursor: 'not-allowed',
-      opacity: 0.6,
-    },
-  },
-  actionButton: {
-    minWidth: '0',
-    width: 'auto',
-    paddingLeft: '8px',
-    paddingRight: '8px',
-    fontSize: '12px',
-  },
-  percentage: {
-    minWidth: '36px',
     textAlign: 'center',
-    fontSize: '11px',
-    lineHeight: '16px',
-    color: '#646464',
+    color: tokens.colorNeutralForeground3,
     fontFamily: tokens.fontFamilyMonospace,
   },
   diagramArea: {
-    padding: '24px',
-    backgroundColor: '#ffffff',
+    padding: tokens.spacingHorizontalXXL,
+    backgroundColor: tokens.colorNeutralBackground1,
   },
   viewport: {
     width: '100%',
@@ -163,9 +138,10 @@ const useStyles = makeStyles({
     position: 'relative',
     cursor: 'grab',
     userSelect: 'none',
-    border: '1px solid #e1dfdd',
-    backgroundColor: '#ffffff',
-    boxShadow: '0 1.6px 3.6px rgba(0,0,0,0.132), 0 0.3px 0.9px rgba(0,0,0,0.108)',
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground1,
+    boxShadow: tokens.shadow4,
   },
   viewportGrabbing: {
     cursor: 'grabbing',
@@ -177,22 +153,22 @@ const useStyles = makeStyles({
     transformOrigin: '0 0',
   },
   fallback: {
-    padding: '16px 20px',
-    backgroundColor: '#fdd8db',
-    border: '1px solid #a4262c',
-    borderRadius: '2px',
-    color: '#a4262c',
+    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalL),
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorPaletteRedBorder1),
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorPaletteRedBackground1,
+    color: tokens.colorPaletteRedForeground1,
     lineHeight: 1.5,
   },
   fallbackTitle: {
     display: 'block',
     marginBottom: tokens.spacingVerticalXS,
-    color: '#a4262c',
+    color: tokens.colorPaletteRedForeground1,
   },
   rawCode: {
     fontFamily: tokens.fontFamilyMonospace,
-    fontSize: '12px',
-    lineHeight: '18px',
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase300,
     whiteSpace: 'pre-wrap',
     margin: 0,
     overflowX: 'auto',
@@ -204,14 +180,18 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     gap: tokens.spacingVerticalXS,
     minHeight: '220px',
-    color: '#646464',
+    ...shorthands.padding(tokens.spacingHorizontalXXL),
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground2,
+    color: tokens.colorNeutralForeground3,
     textAlign: 'center',
   },
   emptyStateIcon: {
     width: '32px',
     height: '32px',
-    opacity: 0.5,
-    filter: 'brightness(0) saturate(100%) invert(28%) sepia(98%) saturate(1624%) hue-rotate(196deg) brightness(96%) contrast(101%)',
+    opacity: 0.72,
+    filter: FLUENT_DIAGRAM_ICON_FILTER,
   },
 });
 
@@ -237,24 +217,24 @@ function loadMermaid(): Promise<MermaidApi> {
           startOnLoad: false,
           theme: 'base',
           securityLevel: 'antiscript',
-          fontFamily: AZURE.fontFamily,
+          fontFamily: FLUENT_DIAGRAM_PALETTE.fontFamily,
           themeVariables: {
-            primaryColor: AZURE.white,
-            primaryBorderColor: AZURE.themePrimary,
-            primaryTextColor: AZURE.neutralPrimary,
-            lineColor: AZURE.neutralTertiaryAlt,
-            secondaryColor: AZURE.neutralLighter,
-            secondaryBorderColor: AZURE.neutralLight,
-            tertiaryColor: AZURE.neutralLighterAlt,
-            fontSize: '13px',
-            fontFamily: AZURE.fontFamily,
-            background: AZURE.white,
-            mainBkg: AZURE.white,
-            nodeBorder: AZURE.themePrimary,
-            clusterBkg: AZURE.neutralLighter,
-            clusterBorder: AZURE.neutralLight,
-            titleColor: AZURE.neutralPrimary,
-            edgeLabelBackground: AZURE.white,
+            primaryColor: FLUENT_DIAGRAM_PALETTE.neutralBackground1,
+            primaryBorderColor: FLUENT_DIAGRAM_PALETTE.brandForeground1,
+            primaryTextColor: FLUENT_DIAGRAM_PALETTE.neutralForeground1,
+            lineColor: FLUENT_DIAGRAM_PALETTE.neutralStroke1,
+            secondaryColor: FLUENT_DIAGRAM_PALETTE.neutralBackground3,
+            secondaryBorderColor: FLUENT_DIAGRAM_PALETTE.neutralStroke2,
+            tertiaryColor: FLUENT_DIAGRAM_PALETTE.neutralBackground4,
+            fontSize: FLUENT_DIAGRAM_PALETTE.fontSizeBody1,
+            fontFamily: FLUENT_DIAGRAM_PALETTE.fontFamily,
+            background: FLUENT_DIAGRAM_PALETTE.neutralBackground1,
+            mainBkg: FLUENT_DIAGRAM_PALETTE.neutralBackground1,
+            nodeBorder: FLUENT_DIAGRAM_PALETTE.brandForeground1,
+            clusterBkg: FLUENT_DIAGRAM_PALETTE.neutralBackground3,
+            clusterBorder: FLUENT_DIAGRAM_PALETTE.neutralStroke2,
+            titleColor: FLUENT_DIAGRAM_PALETTE.neutralForeground1,
+            edgeLabelBackground: FLUENT_DIAGRAM_PALETTE.neutralBackground1,
           },
           flowchart: {
             htmlLabels: true,
@@ -477,36 +457,62 @@ export const ArchitectureDiagram = createReactComponent(ArchitectureDiagramApi, 
   const regenerateDiagram = () => setRenderVersion((currentVersion) => currentVersion + 1);
 
   return (
-    <Card className={classes.root}>
+    <Card appearance="outline" className={classes.root}>
       <div className={classes.header}>
         <div className={classes.titleGroup}>
           <div className={classes.titleRow}>
             <img src={ARCHITECTURE_DIAGRAM_HEADER_ICON_URL} alt="" className={classes.headerIcon} />
-            <div className={classes.title}>{headerTitle}</div>
+            <Subtitle2 className={classes.title}>{headerTitle}</Subtitle2>
           </div>
           {props.description && <Body2 className={classes.description}>{props.description}</Body2>}
         </div>
-        <div className={classes.controls}>
-          <button type="button" className={classes.controlButton} onClick={zoomOut} aria-label="Zoom out" title="Zoom out">
-            −
-          </button>
-          <div className={classes.percentage}>{Math.round(scale * 100)}%</div>
-          <button type="button" className={classes.controlButton} onClick={zoomIn} aria-label="Zoom in" title="Zoom in">
-            +
-          </button>
-          <button type="button" className={`${classes.controlButton} ${classes.actionButton}`} onClick={resetView} aria-label="Reset view" title="Reset view">
-            Reset
-          </button>
-          <button
+        <div className={classes.controls} role="group" aria-label="Architecture diagram controls">
+          <Button
             type="button"
-            className={`${classes.controlButton} ${classes.actionButton}`}
+            size="small"
+            appearance="subtle"
+            className={classes.controlButton}
+            onClick={zoomOut}
+            aria-label="Zoom out"
+            title="Zoom out"
+          >
+            −
+          </Button>
+          <Caption1 className={classes.percentage}>{Math.round(scale * 100)}%</Caption1>
+          <Button
+            type="button"
+            size="small"
+            appearance="subtle"
+            className={classes.controlButton}
+            onClick={zoomIn}
+            aria-label="Zoom in"
+            title="Zoom in"
+          >
+            +
+          </Button>
+          <Button
+            type="button"
+            size="small"
+            appearance="transparent"
+            className={mergeClasses(classes.controlButton, classes.actionButton)}
+            onClick={resetView}
+            aria-label="Reset view"
+            title="Reset view"
+          >
+            Reset
+          </Button>
+          <Button
+            type="button"
+            size="small"
+            appearance="transparent"
+            className={mergeClasses(classes.controlButton, classes.actionButton)}
             onClick={regenerateDiagram}
             aria-label="Regenerate layout"
             title="Regenerate layout"
             disabled={isRendering || !hasDiagram}
           >
             {isRendering ? 'Rendering' : 'Regenerate'}
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -519,7 +525,7 @@ export const ArchitectureDiagram = createReactComponent(ArchitectureDiagramApi, 
         ) : hasDiagram ? (
           <div
             ref={viewportRef}
-            className={`${classes.viewport} ${isDragging ? classes.viewportGrabbing : ''}`}
+            className={mergeClasses(classes.viewport, isDragging && classes.viewportGrabbing)}
             style={{ height: `${viewportHeight}px` }}
             onWheel={handleWheel}
             onMouseDown={handleMouseDown}

--- a/packages/web/src/catalog/components/architectureDiagramUtils.test.ts
+++ b/packages/web/src/catalog/components/architectureDiagramUtils.test.ts
@@ -406,10 +406,9 @@ describe('architectureDiagramUtils', () => {
   // ---------------------------------------------------------------
   // Fluent 2 injected diagram CSS — structural contract (#347)
   // These tests lock the Fluent 2 restyle expectations.
-  // TDD-red: skip until #347 implementation lands.
   // ---------------------------------------------------------------
 
-  describe.skip('Fluent 2 diagram CSS contract', () => {
+  describe('Fluent 2 diagram CSS contract', () => {
     async function getInjectedStyle(): Promise<string> {
       const renderSvg = vi.fn(async () => ({
         svg: '<svg xmlns="http://www.w3.org/2000/svg"><g></g></svg>',

--- a/packages/web/src/catalog/components/architectureDiagramUtils.ts
+++ b/packages/web/src/catalog/components/architectureDiagramUtils.ts
@@ -1,3 +1,5 @@
+import { webLightTheme } from '@fluentui/react-components';
+
 export interface DiagramNode {
   id: string;
   label: string;
@@ -66,13 +68,31 @@ const ALLOWED_ICON_KEY_SET = new Set<string>(ALLOWED_ICON_KEYS);
 const ICON_KEY_PATTERN = /^[a-z0-9]+\/[a-z0-9-]+$/;
 const ICON_PLACEHOLDER_PATTERN = /%%icon:([^%]+)%%/gi;
 
-const TRY_AKS_SVG_CSS = `
+export const FLUENT_DIAGRAM_PALETTE = {
+  brandForeground1: webLightTheme.colorBrandForeground1,
+  neutralForeground1: webLightTheme.colorNeutralForeground1,
+  neutralForeground2: webLightTheme.colorNeutralForeground2,
+  neutralForeground3: webLightTheme.colorNeutralForeground3,
+  neutralStroke1: webLightTheme.colorNeutralStroke1,
+  neutralStroke2: webLightTheme.colorNeutralStroke2,
+  neutralBackground1: webLightTheme.colorNeutralBackground1,
+  neutralBackground2: webLightTheme.colorNeutralBackground2,
+  neutralBackground3: webLightTheme.colorNeutralBackground3,
+  neutralBackground4: webLightTheme.colorNeutralBackground4,
+  borderRadiusMedium: webLightTheme.borderRadiusMedium,
+  fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
+  fontSizeCaption1: '12px',
+  fontSizeBody1: '14px',
+  nodeShadow: 'drop-shadow(0 2px 4px rgba(0,0,0,0.04))',
+} as const;
+
+export const FLUENT_DIAGRAM_SVG_CSS = `
   .cluster rect {
-    rx: 0 !important;
-    ry: 0 !important;
+    rx: ${FLUENT_DIAGRAM_PALETTE.borderRadiusMedium} !important;
+    ry: ${FLUENT_DIAGRAM_PALETTE.borderRadiusMedium} !important;
     stroke-dasharray: none !important;
-    fill: #f3f2f1 !important;
-    stroke: #e1dfdd !important;
+    fill: ${FLUENT_DIAGRAM_PALETTE.neutralBackground3} !important;
+    stroke: ${FLUENT_DIAGRAM_PALETTE.neutralStroke2} !important;
     stroke-width: 1 !important;
   }
   .cluster-label,
@@ -91,37 +111,45 @@ const TRY_AKS_SVG_CSS = `
     white-space: nowrap !important;
     width: auto !important;
     padding-top: 13px !important;
-    font-family: 'Segoe UI', system-ui, sans-serif !important;
+    font-family: ${FLUENT_DIAGRAM_PALETTE.fontFamily} !important;
     font-weight: 600 !important;
-    font-size: 15px !important;
-    color: #646464 !important;
+    font-size: ${FLUENT_DIAGRAM_PALETTE.fontSizeBody1} !important;
+    color: ${FLUENT_DIAGRAM_PALETTE.neutralForeground2} !important;
   }
-  .edgePath .path,
+  .edgePath .path {
+    stroke-width: 1 !important;
+    stroke: ${FLUENT_DIAGRAM_PALETTE.neutralStroke1} !important;
+  }
   .flowchart-link {
-    stroke-width: 1.5;
-    stroke: #a19f9d;
+    stroke-width: 1 !important;
+    stroke: ${FLUENT_DIAGRAM_PALETTE.neutralStroke1} !important;
   }
   .edgePath marker path {
-    fill: #a19f9d;
+    fill: ${FLUENT_DIAGRAM_PALETTE.neutralStroke1} !important;
   }
   .edgeLabel {
-    font-family: 'Segoe UI Light', 'Segoe UI', system-ui, sans-serif;
-    font-size: 13px;
-    background-color: #ffffff;
+    font-family: ${FLUENT_DIAGRAM_PALETTE.fontFamily};
+    font-size: ${FLUENT_DIAGRAM_PALETTE.fontSizeCaption1};
+    background-color: ${FLUENT_DIAGRAM_PALETTE.neutralBackground1};
     padding: 2px 6px;
-    border-radius: 2px;
-    color: #646464;
+    border-radius: ${FLUENT_DIAGRAM_PALETTE.borderRadiusMedium};
+    color: ${FLUENT_DIAGRAM_PALETTE.neutralForeground3};
   }
   .node rect,
   .node circle,
   .node polygon {
-    filter: drop-shadow(0 1px 2px rgba(0,0,0,0.06));
-    stroke-width: 1.5;
+    filter: ${FLUENT_DIAGRAM_PALETTE.nodeShadow};
+    stroke-width: 1 !important;
+  }
+  .node rect {
+    rx: ${FLUENT_DIAGRAM_PALETTE.borderRadiusMedium};
+    ry: ${FLUENT_DIAGRAM_PALETTE.borderRadiusMedium};
   }
   .nodeLabel,
   .node .label {
-    font-family: 'Segoe UI', system-ui, sans-serif;
-    font-weight: 500;
+    font-family: ${FLUENT_DIAGRAM_PALETTE.fontFamily};
+    font-size: ${FLUENT_DIAGRAM_PALETTE.fontSizeBody1};
+    font-weight: 600;
     text-align: center;
     line-height: normal !important;
   }
@@ -242,8 +270,8 @@ export function expandIconPlaceholders(svg: string, resolveIconUrl: IconUrlResol
   });
 }
 
-export function injectTryAksDiagramStyles(svg: string): string {
-  return svg.replace(/<svg([^>]*)>/, `<svg$1><style>${TRY_AKS_SVG_CSS}</style>`);
+export function injectDiagramStyles(svg: string): string {
+  return svg.replace(/<svg([^>]*)>/, `<svg$1><style>${FLUENT_DIAGRAM_SVG_CSS}</style>`);
 }
 
 export async function renderArchitectureDiagramSvg(
@@ -253,5 +281,5 @@ export async function renderArchitectureDiagramSvg(
   resolveIconUrl: IconUrlResolver,
 ): Promise<string> {
   const { svg } = await renderSvg(id, prepareArchitectureDiagramSource(diagram));
-  return injectTryAksDiagramStyles(expandIconPlaceholders(svg, resolveIconUrl));
+  return injectDiagramStyles(expandIconPlaceholders(svg, resolveIconUrl));
 }


### PR DESCRIPTION
Closes #347

Working as Fry (Frontend Dev)

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Summary
Restyle ArchitectureDiagram to Fluent 2 while preserving Mermaid rendering, icon placeholders, zoom/pan, regenerate, and the existing Mermaid/XSS safety posture.

## Changes
- move ArchitectureDiagram chrome to Fluent 2 tokens and Fluent Button controls
- introduce a shared Fluent diagram palette for Mermaid theme values and injected SVG CSS
- enable and satisfy the Fluent 2 CSS contract tests in architectureDiagramUtils.test.ts

## Testing
- npm run lint
- npx vitest run packages/web/src/catalog/components/architectureDiagramUtils.test.ts packages/web/src/catalog/components/architectureDiagramIconRegistry.test.ts
- npm run build -w @kickstart/web

## Notes
- Branch is based on current main to avoid carrying over already-shipped #345/#346 history.
- Hermes approved the final #347 restyle; remaining gates are CI and required reviews.