### PR TITLE
chore: enable stepwise-generation feature flag — set STEPWISE_GENERATION_V1 env var and document

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,12 +62,31 @@ The API needs Azure OpenAI credentials to power the conversation engine. Edit `p
     "AZURE_OPENAI_CODEX_DEPLOYMENT": "gpt-5.4",
     "AZURE_CLIENT_ID": "e71a23c6-aeb4-459a-88fc-07ff96fc9b92",
     "AZURE_TENANT_ID": "d91aa5af-8c1e-442c-b77c-0b92988b387b",
-    "AZURE_CLIENT_SECRET": "<your-client-secret>"
+    "AZURE_CLIENT_SECRET": "<your-client-secret>",
+    "STEPWISE_GENERATION_V1": "true"
   }
 }
 ```
 
 > **Note:** `local.settings.json` is gitignored — it will never be committed. Each developer needs their own copy.
+
+### Stepwise Generation Feature Flag
+
+The `STEPWISE_GENERATION_V1` environment variable enables **codex-backed stepwise setup generation** — a feature that streams multi-step file generation during the Generate phase using Azure OpenAI's Responses API.
+
+**Default behavior:**
+- **Production (SWA):** `true` (enabled by default via Bicep parameter `enableStepwiseGeneration`)
+- **Local dev:** Set to `"true"` in `local.settings.json` to enable
+- **Feature activation:** Only activates on the Generate phase when:
+  - Session is server-owned (`routingPhaseTrusted = true`), OR
+  - Client-supplied setup-generation snapshot is validated (`setupGenerationTrusted = true`)
+
+**When enabled:**
+- `/api/converse` detects the Generate phase and activates stepwise SSE streaming
+- Generated files are streamed in real-time, workspace snapshots are created per turn
+- Users see progress as files are generated, not just the final result
+
+**To disable locally:** Set `"STEPWISE_GENERATION_V1": "false"` in `local.settings.json` to fall back to standard chat completions.
 
 ## Running Just the Frontend
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,6 +49,9 @@ param openAiApiKey string = ''
 @description('Entra ID client secret. When provided, stored in Key Vault and referenced by SWA.')
 param entraClientSecret string = ''
 
+@description('Enable stepwise-generation feature flag for codex-backed setup generation (STEPWISE_GENERATION_V1). Default: true (enabled in production).')
+param enableStepwiseGeneration bool = true
+
 // ── Key Vault ───────────────────────────────────────────────────
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
@@ -133,6 +136,7 @@ var baseAppSettings = {
   AZURE_OPENAI_CHAT_DEPLOYMENT: openAiChatDeployment
   AZURE_OPENAI_CODEX_DEPLOYMENT: openAiCodexDeployment
   AZURE_OPENAI_INSPIRE_DEPLOYMENT: openAiInspireDeployment
+  STEPWISE_GENERATION_V1: enableStepwiseGeneration ? 'true' : 'false'
 }
 
 var clientSecretSetting = !empty(entraClientSecret)


### PR DESCRIPTION
Closes #353

## Summary
Enable the completed stepwise-generation feature by setting `STEPWISE_GENERATION_V1` environment variable in infrastructure and documentation.

## Changes
- Add `enableStepwiseGeneration` Bicep parameter (defaults to `true`) in `infra/main.bicep`
- Add `STEPWISE_GENERATION_V1` to `baseAppSettings` so SWA populates the env var for Azure Functions
- Document the feature flag in DEVELOPMENT.md with activation conditions and local dev setup
- Include `STEPWISE_GENERATION_V1` in local.settings.json template

## Testing
- Build passes: `npm run build -w @kickstart/core -w @kickstart/api` ✅
- Bicep syntax valid (no linting errors)
- No new dependencies, no code logic changes (config/docs only)

## Notes
- Feature is already fully implemented (#327/#328) and tested (1204/1204 tests pass)
- Only env var wiring and documentation was missing
- DP approved by Leela (architecture) and Zapp (security) before implementation

Working as **Bender** (Backend Dev).