### PR TITLE
sec: add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint-build:
     name: Lint, Build & Unit Tests


### PR DESCRIPTION
## Summary
Adds a workflow-level `permissions: contents: read` block to `.github/workflows/ci.yml` to satisfy CodeQL code scanning alerts #1 and #2 (`actions/missing-workflow-permissions`).

## Changes
- Added `permissions: contents: read` at workflow level in `ci.yml`

## Why
Without explicit permissions, GitHub Actions grants the default token permissions which may include write access. This violates the principle of least privilege. The CI jobs only require read access to checkout and test the repository.

Working as Bender (Backend Dev / Security)

Closes #364