### PR TITLE
fix: resolve next-card missing component (#352)

### DIFF
--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -267,7 +267,7 @@ Do NOT pre-select any option in ChoicePicker, CheckBox, or DateTimeInput compone
 
 The catalog above is the **complete set** of components available to you. It is assembled from two pools that you may draw from freely and simultaneously in any single response:
 
-1. **Built-in catalog components** — core kickstart components present in every integration (e.g. \`Text\`, \`Badge\`, \`Button\`, \`Card\`, \`ChoicePicker\`, \`DeploymentProgress\`, \`GenerationProgress\`).
+1. **Built-in catalog components** — core kickstart components present in every integration (e.g. \`Text\`, \`Badge\`, \`Button\`, \`Card\`, \`ChoicePicker\`, \`GenerationProgress\`).
 2. **Custom components** — additional components registered by the active integration kit specifically for this deployment scenario.
 
 You are NOT restricted to one source. A single \`updateComponents\` array MAY freely mix built-in and custom components. Combining both pools in one response is explicitly encouraged when doing so produces the richest experience. Example: pair a built-in \`Card\` + \`Text\` summary block with a custom \`AzureResourcePicker\` from the integration kit — all in the same surface.


### PR DESCRIPTION
Closes #352
Working as Fry (Frontend Dev)

## Investigation

Full codebase search returned **zero matches** for `next-card`, `NextCard`, or `nextCard` across all TypeScript, catalog, schema, and demo files.

Checked:
- `packages/core/src/prompts/system-prompt.ts`
- `packages/core/src/prompts/component-catalog.ts`
- `packages/core/src/services/a2ui-schema.ts`
- `packages/web/src/catalog/kickstart-catalog.ts`
- All demo/playground scenario files

## Decision: Option B — Phantom reference

`next-card` is an abandoned/phantom component name, never emitted by any prompt, schema, or demo in production.

**Why not implement NextCard:** The built-in `Card` component covers all "what's next" card UX patterns. A dedicated `NextCard` adds catalog surface area with no semantic benefit and risks the LLM generating two synonyms for identical output.

## Changes

- `packages/core/src/prompts/system-prompt.ts`: Removed holdover `DeploymentProgress` from the built-in catalog example list (left over after PR #356's GenerationProgress rename). No other changes needed — `next-card` had zero code references to remove.

## Test
- Build: ✅ `npm run build -w @kickstart/core -w @kickstart/web`
- Tests: ✅ 1204/1204 passed