### PR TITLE
sec: fix incomplete sanitization, bad tag filter, and ReDoS (#359 #360 #361)

### DIFF
--- a/packages/core/src/artifacts/in-memory.ts
+++ b/packages/core/src/artifacts/in-memory.ts
@@ -63,13 +63,29 @@ function artifactSizeBytes(content: string, metadata?: Record<string, unknown>):
 /**
  * Convert a glob pattern to a RegExp.
  * Supports `*` (matches within a path segment) and `**` (matches across segments).
+ *
+ * Uses segment-aware replacements (`[^/]+`, `[^/]*`) instead of `.*` to
+ * prevent polynomial ReDoS from adjacent unbounded quantifiers (CodeQL alert).
+ * Input is validated to guard against patterns that could still produce slow
+ * regex even with the safer quantifiers.
  */
 function globToRegExp(pattern: string): RegExp {
+  if (pattern.length > 256) {
+    throw new Error(`Glob pattern too long (max 256 characters): "${pattern.slice(0, 40)}…"`);
+  }
+  const doubleStars = (pattern.match(/\*\*/g) ?? []).length;
+  if (doubleStars > 8) {
+    throw new Error(`Glob pattern contains too many '**' wildcards (max 8)`);
+  }
+
   const escaped = pattern
     .replace(/[.+^${}()|[\]\\]/g, "\\$&") // escape regex specials (except * and ?)
-    .replace(/\*\*/g, "\x00") // placeholder for **
-    .replace(/\*/g, "[^/]*") // * → match within segment
-    .replace(/\x00/g, ".*"); // ** → match across segments
+    .replace(/\*\*/g, "\x00")              // placeholder for **
+    .replace(/\*/g, "[^/]*")              // * → within-segment wildcard (no slash)
+    // ** replacements use [^/]+ (no slash) to prevent overlapping quantifiers:
+    .replace(/\x00\//g, "(?:[^/]+/)*")    // **/ → zero or more "segment/" prefixes
+    .replace(/\/\x00/g, "(?:/[^/]+)*")   // /** → zero or more "/segment" suffixes
+    .replace(/\x00/g, "(?:[^/]+/)*[^/]*"); // standalone ** → any path segments
   return new RegExp(`^${escaped}$`);
 }
 
@@ -78,23 +94,29 @@ function globToRegExp(pattern: string): RegExp {
 // Artifacts are code/config (YAML, Dockerfiles, etc.), not HTML documents.
 // ---------------------------------------------------------------------------
 
-/** Patterns that should never appear in stored artifact content. */
-const DANGEROUS_HTML_RE =
-  /<\s*\/?\s*(script|iframe|object|embed|form|input|link|meta|style|svg|base|applet)[^>]*>/gi;
+/**
+ * Attribute-aware HTML tag pattern.
+ * Uses `(?:[^>"']|"[^"]*"|'[^']*')*` so that `>` inside a quoted attribute
+ * value does not prematurely end the match (CodeQL bad-tag-filter fix).
+ */
+const HTML_TAG_RE = /<(?:[^>"']|"[^"]*"|'[^']*')*>/g;
 
 /**
- * Sanitize artifact content: strip dangerous HTML tags and event handlers.
+ * Matches script/style blocks including content via a back-reference.
+ * Replaces the previous chain of per-tag removes that was bypassable through
+ * nested/interleaved tag injection (CodeQL incomplete-sanitization fix).
+ */
+const SCRIPT_STYLE_BLOCK_RE =
+  /<(script|style)\b(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/\1\s*>/gi;
+
+/**
+ * Sanitize artifact content: strip script/style blocks and all HTML tags.
  * Only applied to non-HTML artifacts (YAML, JSON, Dockerfiles, etc.).
  */
 function sanitizeContent(content: string): string {
   return content
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<iframe[\s\S]*?<\/iframe>/gi, "")
-    .replace(/<object[\s\S]*?<\/object>/gi, "")
-    .replace(/<embed[\s\S]*?<\/embed>/gi, "")
-    .replace(DANGEROUS_HTML_RE, "")
-    .replace(/\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, "");
+    .replace(SCRIPT_STYLE_BLOCK_RE, "")
+    .replace(HTML_TAG_RE, "");
 }
 
 /** Languages whose content legitimately contains HTML-like tags. */

--- a/packages/core/src/engine/data-binding.ts
+++ b/packages/core/src/engine/data-binding.ts
@@ -69,8 +69,10 @@ export function resolveDataPath(
   let current: unknown = dataModel;
   for (const rawSegment of segments) {
     if (current === null || current === undefined) return defaultValue;
-    // RFC 6901: ~1 → '/', ~0 → '~'
-    const segment = rawSegment.replace(/~1/g, '/').replace(/~0/g, '~');
+    // RFC 6901: decode ~1 → '/' and ~0 → '~' in a single pass so that the
+    // order of replacements is unambiguous and CodeQL incomplete-sanitization
+    // checks are satisfied (chained two-pass replace is no longer used).
+    const segment = rawSegment.replace(/~([01])/g, (_, c) => c === "1" ? "/" : "~");
     if (Array.isArray(current)) {
       const idx = Number(segment);
       current = Number.isInteger(idx) ? current[idx] : undefined;

--- a/packages/core/src/skills/skill-policy.ts
+++ b/packages/core/src/skills/skill-policy.ts
@@ -51,9 +51,13 @@ const EXECUTABLE_INLINE_PATTERNS = [
   /\bFunction\s*\(/i,      // new Function()
 ];
 
-/** HTML tags that could be used for injection. */
+/** HTML tags that could be used for injection.
+ * Uses `(?:[^>"']|"[^"]*"|'[^']*')*` instead of `[^>]*` so that `>` inside
+ * a quoted attribute value does not prematurely terminate the match
+ * (CodeQL bad-tag-filter / incomplete-sanitization fix).
+ */
 const HTML_INJECTION_PATTERN =
-  /<\s*(script|style|iframe|object|embed|form|input|button|link|meta|base)\b[^>]*>/gi;
+  /<\s*(script|style|iframe|object|embed|form|input|button|link|meta|base)\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi;
 
 /** Event handler attributes in any HTML. */
 const EVENT_HANDLER_PATTERN =

--- a/packages/core/src/tools/fetch-webpage.ts
+++ b/packages/core/src/tools/fetch-webpage.ts
@@ -69,17 +69,23 @@ function isBlockedHost(hostname: string): boolean {
 /**
  * Minimal HTML → plain text conversion.
  * Strips tags, decodes common entities, and collapses whitespace.
+ *
+ * Uses an attribute-aware tag pattern `(?:[^>"']|"[^"]*"|'[^']*')*` instead
+ * of `[^>]*` so that `>` inside quoted attribute values does not prematurely
+ * end a tag match (fixes CodeQL bad-tag-filter / incomplete-sanitization).
+ * script/style block content is removed via a single back-reference pattern
+ * instead of two separate chains.
  */
 function htmlToText(html: string): string {
   return html
-    // Remove script/style blocks
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    // Remove script/style blocks including their content (single pattern,
+    // back-reference covers both tag names — no incomplete-chain bypass)
+    .replace(/<(script|style)\b(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/\1\s*>/gi, "")
     // Block elements → newlines
     .replace(/<\/(p|div|h[1-6]|li|tr|blockquote|section|article)>/gi, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
-    // Strip remaining tags
-    .replace(/<[^>]+>/g, "")
+    // Strip remaining tags (attribute-aware: handles > inside quoted values)
+    .replace(/<(?:[^>"']|"[^"]*"|'[^']*')*>/g, "")
     // Decode common HTML entities
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")

--- a/packages/web/api/src/lib/sanitize-tool-output.ts
+++ b/packages/web/api/src/lib/sanitize-tool-output.ts
@@ -12,24 +12,37 @@
 /** Maximum characters allowed in a single tool result (before JSON encoding). */
 const MAX_TOOL_OUTPUT_LENGTH = 16_000;
 
-/** Patterns that should never appear in tool output sent to the client. */
-const DANGEROUS_HTML_RE =
-  /<\s*\/?\s*(script|iframe|object|embed|form|input|link|meta|style|svg|base|applet)[^>]*>/gi;
+/**
+ * Attribute-aware HTML tag pattern.
+ * Uses `(?:[^>"']|"[^"]*"|'[^']*')*` instead of `[^>]*` so that a `>`
+ * inside a quoted attribute value (e.g. `src=">"`) does not prematurely
+ * terminate the match — fixing the CodeQL bad-tag-filter alert.
+ */
+const HTML_TAG_RE = /<(?:[^>"']|"[^"]*"|'[^']*')*>/g;
 
 /**
- * Strip dangerous HTML tags from a string while leaving plain text intact.
- * This is intentionally aggressive — tool results are plain-text data, not
- * HTML documents. Any residual HTML is an injection vector.
+ * Matches `<script>…</script>` and `<style>…</style>` blocks including their
+ * content, using a back-reference so a single replacement covers both tag
+ * names and avoids chaining multiple incomplete patterns.
+ */
+const SCRIPT_STYLE_BLOCK_RE =
+  /<(script|style)\b(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/\1\s*>/gi;
+
+/**
+ * Strip all HTML from a string leaving plain text intact.
+ * Tool results are plain-text data, not HTML documents — any HTML is an
+ * injection vector.
+ *
+ * Strategy (avoids incomplete multi-character sanitisation chains):
+ *   1. Remove `<script>` / `<style>` blocks *with their content* so that
+ *      inline JS/CSS does not surface as plain text in the LLM context.
+ *   2. Strip every remaining tag in one comprehensive pass using an
+ *      attribute-aware regex that handles `>` inside quoted attribute values.
  */
 function stripDangerousHtml(text: string): string {
   return text
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<iframe[\s\S]*?<\/iframe>/gi, "")
-    .replace(/<object[\s\S]*?<\/object>/gi, "")
-    .replace(/<embed[\s\S]*?<\/embed>/gi, "")
-    .replace(DANGEROUS_HTML_RE, "")
-    .replace(/\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, "");
+    .replace(SCRIPT_STYLE_BLOCK_RE, "")
+    .replace(HTML_TAG_RE, "");
 }
 
 /**
@@ -37,8 +50,10 @@ function stripDangerousHtml(text: string): string {
  * dependency versions don't leak to the LLM or client.
  */
 function sanitizeErrorText(text: string): string {
+  // Use [^\n]+ instead of .+ to make the per-line scope explicit and prevent
+  // polynomial backtracking in the repeated group (ReDoS fix).
   return text.replace(
-    /(\n\s+at\s+.+){2,}/g,
+    /(\n\s+at\s+[^\n]+){2,}/g,
     "\n    [stack trace redacted]",
   );
 }


### PR DESCRIPTION
Closes #359
Closes #360
Closes #361

Working as Bender (Backend Dev)

Fixes three classes of CodeQL alerts across five files.

### Alerts 3-17 (incomplete multi-char sanitization)
Replaced per-tag .replace() chains with a single back-reference pattern covering script/style block content, followed by a comprehensive all-tag strip. No selective-removal chain = no interleaved-tag bypass.

### Alerts 19-21 (bad tag filter regexp)
All five files: replaced [^>]* with attribute-aware (?:[^>"']|"[^"]*"|'[^']*')* so > inside quoted attribute values does not terminate the match early.

### Alerts 30-32 (polynomial ReDoS)
- globToRegExp() in-memory.ts: ** now maps to segment-aware [^/]+ / [^/]* patterns instead of .*, eliminating overlapping unbounded quantifiers. Input validation added (max 256 chars, max 8 ** segments).
- sanitizeErrorText() sanitize-tool-output.ts: .+ replaced with [^\n]+ for explicit per-line scope.

Files: sanitize-tool-output.ts, fetch-webpage.ts, in-memory.ts, skill-policy.ts, data-binding.ts

Tests: 59 files / 1412 tests - all pass.

Note: DOMPurify was not used because jsdom is absent from the dependency tree and @kickstart/core is imported by Node.js API/MCP contexts. The regex approach is environment-agnostic with no new dependencies.