### PR TITLE
chore: upgrade hono and follow-redirects (#366 #367)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8580,9 +8580,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -9099,9 +9099,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "overrides": {
     "cookie": "0.7.2",
-    "tmp": "0.2.5"
+    "tmp": "0.2.5",
+    "hono": "4.12.14",
+    "follow-redirects": "1.16.0"
   },
   "devDependencies": {
     "@azure/static-web-apps-cli": "^2.0.8",


### PR DESCRIPTION
Working as Bender (Backend Dev)

Closes #366
Closes #367

## Changes

- **hono** `4.12.12` → `4.12.14`: fixes HTML injection in JSX SSR renderer (GHSA-458j-xx4x-4375). Enforced via root `overrides` — transitive dep through `@modelcontextprotocol/sdk`.
- **follow-redirects** `1.15.11` → `1.16.0`: fixes Authorization header leak on cross-host redirect. Enforced via root `overrides` — transitive dep through `axios`.

## Test Results

✅ 59 test files, 1412 tests passed — no regressions.

## Files Changed

- `package.json`: added `hono` and `follow-redirects` to `overrides`
- `package-lock.json`: resolved versions updated accordingly