### PR TITLE
test: real auth integration test scaffolding — Phase 1 mock flows (#332)

### DIFF
--- a/packages/web/src/__tests__/azure-auth.test.ts
+++ b/packages/web/src/__tests__/azure-auth.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Phase 1 mock-based integration tests for azure-auth.ts
+ *
+ * Azure auth in this app uses SWA's built-in AAD integration — no MSAL SDK.
+ * The browser calls /.auth/me to check session state and redirects to
+ * /.auth/login/aad for sign-in. All tests stub fetch and window.location.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAzureSession,
+  signInToAzure,
+  signOutAzure,
+  type AzureAuthSessionState,
+} from "../services/azure-auth";
+import type { AzureARMConnector, AzureSubscription } from "@kickstart/core";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeClientPrincipal(overrides: Record<string, unknown> = {}) {
+  return {
+    identityProvider: "aad",
+    userDetails: "user@example.com",
+    claims: [
+      { typ: "preferred_username", val: "user@example.com" },
+      { typ: "name", val: "Test User" },
+      { typ: "tid", val: "tenant-99" },
+    ],
+    ...overrides,
+  };
+}
+
+function mockAuthMe(principal: unknown): void {
+  // Use mockImplementation (not mockResolvedValue) so that each fetch call
+  // gets a fresh Response instance — a Response body stream can only be read once.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ clientPrincipal: principal }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ),
+  );
+}
+
+function makeConnector(
+  subscriptions: AzureSubscription[] = [],
+  throwError?: Error,
+): AzureARMConnector {
+  return {
+    isAuthenticated: () => true,
+    authenticate: vi.fn(),
+    listSubscriptions: throwError
+      ? vi.fn().mockRejectedValue(throwError)
+      : vi.fn().mockResolvedValue(subscriptions),
+    listResourceGroups: vi.fn(),
+    listLocations: vi.fn(),
+    listAksClusters: vi.fn(),
+  } as unknown as AzureARMConnector;
+}
+
+const STUB_SUBSCRIPTIONS: AzureSubscription[] = [
+  {
+    subscriptionId: "sub-001",
+    displayName: "Test Subscription",
+    state: "Enabled",
+    tenantId: "tenant-99",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests: getAzureSession
+// ---------------------------------------------------------------------------
+
+describe("getAzureSession", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns authenticated state with user and subscriptions when principal is present", async () => {
+    mockAuthMe(makeClientPrincipal());
+    const connector = makeConnector(STUB_SUBSCRIPTIONS);
+
+    const session = await getAzureSession(connector);
+
+    expect(session.authenticated).toBe(true);
+    expect(session.configured).toBe(true);
+    expect(session.user?.username).toBe("user@example.com");
+    expect(session.user?.name).toBe("Test User");
+    expect(session.user?.tenantId).toBe("tenant-99");
+    expect(session.subscriptions).toHaveLength(1);
+    expect(session.subscriptions[0]?.subscriptionId).toBe("sub-001");
+  });
+
+  it("returns unauthenticated state when /.auth/me returns null principal", async () => {
+    mockAuthMe(null);
+
+    const session = await getAzureSession(makeConnector(STUB_SUBSCRIPTIONS));
+
+    expect(session.authenticated).toBe(false);
+    expect(session.subscriptions).toHaveLength(0);
+    expect(session.error).toBeUndefined();
+  });
+
+  it("returns unauthenticated state when identityProvider is not aad", async () => {
+    mockAuthMe(makeClientPrincipal({ identityProvider: "github" }));
+
+    const session = await getAzureSession(makeConnector(STUB_SUBSCRIPTIONS));
+
+    expect(session.authenticated).toBe(false);
+    expect(session.subscriptions).toHaveLength(0);
+  });
+
+  it("accepts azureActiveDirectory as a valid AAD identity provider", async () => {
+    mockAuthMe(makeClientPrincipal({ identityProvider: "azureActiveDirectory" }));
+    const connector = makeConnector(STUB_SUBSCRIPTIONS);
+
+    const session = await getAzureSession(connector);
+
+    expect(session.authenticated).toBe(true);
+  });
+
+  it("returns error state when ARM connector fails to list subscriptions", async () => {
+    mockAuthMe(makeClientPrincipal());
+    const connector = makeConnector([], new Error("ARM token expired"));
+
+    const session = await getAzureSession(connector);
+
+    expect(session.authenticated).toBe(false);
+    expect(session.error).toBe("ARM token expired");
+    expect(session.subscriptions).toHaveLength(0);
+  });
+
+  it("returns error state with fallback message when ARM throws non-Error", async () => {
+    mockAuthMe(makeClientPrincipal());
+    const connector = {
+      isAuthenticated: () => true,
+      listSubscriptions: vi.fn().mockRejectedValue("string-error"),
+    } as unknown as AzureARMConnector;
+
+    const session = await getAzureSession(connector);
+
+    expect(session.authenticated).toBe(false);
+    expect(session.error).toBeTruthy();
+  });
+
+  it("throws when /.auth/me returns a non-ok status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 500 })),
+    );
+
+    await expect(getAzureSession()).rejects.toThrow("Unable to check Microsoft sign-in status.");
+  });
+
+  it("throws when fetch rejects (network error)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network failure")),
+    );
+
+    await expect(getAzureSession()).rejects.toThrow("Network failure");
+  });
+
+  it("returns unauthenticated when no connector is provided but principal is valid", async () => {
+    mockAuthMe(makeClientPrincipal());
+
+    // No connector → listSubscriptions will throw "unavailable in this environment"
+    const session = await getAzureSession(undefined);
+
+    expect(session.authenticated).toBe(false);
+    expect(session.error).toMatch(/unavailable/i);
+  });
+
+  it("handles partial claims gracefully — only tenantId present", async () => {
+    mockAuthMe({
+      identityProvider: "aad",
+      userDetails: null,
+      claims: [{ typ: "tid", val: "tenant-42" }],
+    });
+    const connector = makeConnector(STUB_SUBSCRIPTIONS);
+
+    const session = await getAzureSession(connector);
+
+    expect(session.authenticated).toBe(true);
+    expect(session.user?.tenantId).toBe("tenant-42");
+    expect(session.user?.username).toBeUndefined();
+    expect(session.user?.name).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: signInToAzure
+// ---------------------------------------------------------------------------
+
+describe("signInToAzure", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls getAzureSession and returns state when principal is already present", async () => {
+    mockAuthMe(makeClientPrincipal());
+    const connector = makeConnector(STUB_SUBSCRIPTIONS);
+
+    const session = await signInToAzure(connector);
+
+    expect(session.authenticated).toBe(true);
+    expect(session.subscriptions).toHaveLength(1);
+  });
+
+  it("redirects to /.auth/login/aad when /.auth/me returns null principal", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("window", {
+      location: {
+        assign,
+        pathname: "/",
+        search: "",
+        hash: "",
+        origin: "http://localhost",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ clientPrincipal: null }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const session = await signInToAzure(makeConnector());
+
+    expect(assign).toHaveBeenCalledWith(
+      expect.stringContaining("/.auth/login/aad"),
+    );
+    expect(session.authenticated).toBe(false);
+  });
+
+  it("returns unauthenticated silently when /.auth/me fetch fails during signIn", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("window", {
+      location: {
+        assign,
+        pathname: "/",
+        search: "",
+        hash: "",
+        origin: "http://localhost",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network failure")),
+    );
+
+    const session = await signInToAzure(makeConnector());
+
+    expect(assign).toHaveBeenCalled();
+    expect(session.authenticated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: signOutAzure
+// ---------------------------------------------------------------------------
+
+describe("signOutAzure", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("redirects to /.auth/logout on sign-out", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("window", {
+      location: { assign },
+    });
+
+    await signOutAzure();
+
+    expect(assign).toHaveBeenCalledWith(
+      expect.stringContaining("/.auth/logout"),
+    );
+  });
+
+  it("includes post_logout_redirect_uri in the logout URL", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("window", {
+      location: { assign },
+    });
+
+    await signOutAzure();
+
+    const url: string = assign.mock.calls[0]?.[0];
+    expect(url).toMatch(/post_logout_redirect_uri/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: AzureAuthSessionState shape contract
+// ---------------------------------------------------------------------------
+
+describe("AzureAuthSessionState shape", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("always sets configured: true in all response paths", async () => {
+    const paths: Array<() => Promise<AzureAuthSessionState>> = [
+      () => {
+        mockAuthMe(null);
+        return getAzureSession();
+      },
+      () => {
+        mockAuthMe(makeClientPrincipal());
+        return getAzureSession(makeConnector(STUB_SUBSCRIPTIONS));
+      },
+      () => {
+        mockAuthMe(makeClientPrincipal());
+        return getAzureSession(makeConnector([], new Error("boom")));
+      },
+    ];
+
+    for (const path of paths) {
+      const session = await path();
+      expect(session.configured).toBe(true);
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/web/src/__tests__/github-handoff.test.ts
+++ b/packages/web/src/__tests__/github-handoff.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Phase 1 mock-based integration tests for github-handoff.ts
+ *
+ * GitHub auth uses a custom OAuth popup proxy:
+ * - GET /api/github-auth/session — check current session
+ * - GET /api/github-auth/login   — redirect/popup to start OAuth
+ * - POST /api/github-auth/logout — clear session
+ * - Popup window posts kickstart:github-auth:complete when done
+ *
+ * All tests stub fetch and window APIs. No real network calls are made.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getGitHubSession,
+  signInWithGitHubPopup,
+  signOutGitHub,
+  buildGitHubLoginUrl,
+  listGitHubRepos,
+  createGitHubRepo,
+  type GitHubSessionState,
+} from "../services/github-handoff";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AUTHENTICATED_SESSION: GitHubSessionState = {
+  authenticated: true,
+  configured: true,
+  viewer: {
+    login: "test-user",
+    name: "Test User",
+    avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+    htmlUrl: "https://github.com/test-user",
+  },
+  owners: [
+    {
+      login: "test-user",
+      type: "User",
+      label: "test-user",
+      avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+      htmlUrl: "https://github.com/test-user",
+    },
+  ],
+};
+
+const UNAUTHENTICATED_SESSION: GitHubSessionState = {
+  authenticated: false,
+  configured: true,
+  owners: [],
+};
+
+const UNCONFIGURED_SESSION: GitHubSessionState = {
+  authenticated: false,
+  configured: false,
+  owners: [],
+};
+
+function stubFetch(responses: Array<{ status: number; body: unknown }>): void {
+  let callIndex = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(() => {
+      const r = responses[callIndex] ?? responses.at(-1)!;
+      callIndex++;
+      return Promise.resolve(
+        new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: getGitHubSession
+// ---------------------------------------------------------------------------
+
+describe("getGitHubSession", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns authenticated session when API returns authenticated state", async () => {
+    stubFetch([{ status: 200, body: AUTHENTICATED_SESSION }]);
+
+    const session = await getGitHubSession();
+
+    expect(session.authenticated).toBe(true);
+    expect(session.configured).toBe(true);
+    expect(session.viewer?.login).toBe("test-user");
+    expect(session.owners).toHaveLength(1);
+  });
+
+  it("returns unauthenticated session when user is not signed in", async () => {
+    stubFetch([{ status: 200, body: UNAUTHENTICATED_SESSION }]);
+
+    const session = await getGitHubSession();
+
+    expect(session.authenticated).toBe(false);
+    expect(session.viewer).toBeUndefined();
+    expect(session.owners).toHaveLength(0);
+  });
+
+  it("returns unconfigured session when OAuth app is not registered", async () => {
+    stubFetch([{ status: 200, body: UNCONFIGURED_SESSION }]);
+
+    const session = await getGitHubSession();
+
+    expect(session.configured).toBe(false);
+    expect(session.authenticated).toBe(false);
+  });
+
+  it("throws with a descriptive message when the session API returns an error body", async () => {
+    stubFetch([{ status: 500, body: { error: "Internal server error" } }]);
+
+    await expect(getGitHubSession()).rejects.toThrow("Internal server error");
+  });
+
+  it("throws fallback message when the session API returns error without error field", async () => {
+    stubFetch([{ status: 503, body: {} }]);
+
+    await expect(getGitHubSession()).rejects.toThrow(
+      "Unable to load GitHub session state.",
+    );
+  });
+
+  it("throws when fetch rejects (network error)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network offline")));
+
+    await expect(getGitHubSession()).rejects.toThrow("Network offline");
+  });
+
+  it("calls /api/github-auth/session endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(AUTHENTICATED_SESSION), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getGitHubSession();
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/api/github-auth/session");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: signOutGitHub
+// ---------------------------------------------------------------------------
+
+describe("signOutGitHub", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves successfully on 200 response", async () => {
+    stubFetch([{ status: 200, body: {} }]);
+
+    await expect(signOutGitHub()).resolves.toBeUndefined();
+  });
+
+  it("resolves successfully on 204 No Content response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    );
+
+    await expect(signOutGitHub()).resolves.toBeUndefined();
+  });
+
+  it("throws with API error message on non-ok, non-204 response", async () => {
+    stubFetch([{ status: 401, body: { error: "Session not found" } }]);
+
+    await expect(signOutGitHub()).rejects.toThrow("Session not found");
+  });
+
+  it("throws with fallback message on non-ok response with no error field", async () => {
+    stubFetch([{ status: 500, body: {} }]);
+
+    await expect(signOutGitHub()).rejects.toThrow("Unable to sign out of GitHub.");
+  });
+
+  it("calls /api/github-auth/logout with POST method", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await signOutGitHub();
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toContain("/api/github-auth/logout");
+    expect((init as RequestInit).method).toBe("POST");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildGitHubLoginUrl
+// ---------------------------------------------------------------------------
+
+describe("buildGitHubLoginUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a URL pointing to /api/github-auth/login", () => {
+    vi.stubGlobal("window", {
+      location: { pathname: "/", search: "", hash: "", origin: "http://localhost" },
+    });
+
+    const url = buildGitHubLoginUrl("/callback");
+
+    expect(url).toContain("/api/github-auth/login");
+  });
+
+  it("encodes the returnTo parameter", () => {
+    const url = buildGitHubLoginUrl("/some/path?foo=bar");
+
+    expect(url).toContain(encodeURIComponent("/some/path?foo=bar"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: signInWithGitHubPopup — popup lifecycle
+// ---------------------------------------------------------------------------
+
+describe("signInWithGitHubPopup", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("resolves with authenticated session when popup posts AUTH_COMPLETE event", async () => {
+    vi.useFakeTimers();
+
+    // Session fetch after popup completes
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(AUTHENTICATED_SESSION), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    let capturedMessageHandler: ((event: MessageEvent) => void) | undefined;
+    const removeEventListener = vi.fn();
+    const clearInterval = vi.fn();
+    const popup = { closed: false };
+
+    vi.stubGlobal("window", {
+      location: {
+        origin: "http://localhost",
+        pathname: "/",
+        search: "",
+        hash: "",
+        assign: vi.fn(),
+      },
+      open: vi.fn().mockReturnValue(popup),
+      setInterval: vi.fn().mockReturnValue(1),
+      clearInterval,
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (event: MessageEvent) => void) => {
+          capturedMessageHandler = handler;
+        },
+      ),
+      removeEventListener,
+    });
+
+    const promise = signInWithGitHubPopup();
+
+    // Simulate popup posting AUTH_COMPLETE
+    capturedMessageHandler!({
+      origin: "http://localhost",
+      data: { type: "kickstart:github-auth:complete" },
+    } as MessageEvent);
+
+    const session = await promise;
+
+    expect(session.authenticated).toBe(true);
+    expect(session.viewer?.login).toBe("test-user");
+    expect(clearInterval).toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+
+  it("rejects when popup posts AUTH_ERROR event", async () => {
+    vi.useFakeTimers();
+
+    let capturedMessageHandler: ((event: MessageEvent) => void) | undefined;
+
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost", pathname: "/", search: "", hash: "", assign: vi.fn() },
+      open: vi.fn().mockReturnValue({ closed: false }),
+      setInterval: vi.fn().mockReturnValue(1),
+      clearInterval: vi.fn(),
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (event: MessageEvent) => void) => {
+          capturedMessageHandler = handler;
+        },
+      ),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("fetch", vi.fn());
+
+    const promise = signInWithGitHubPopup();
+
+    capturedMessageHandler!({
+      origin: "http://localhost",
+      data: { type: "kickstart:github-auth:error", error: "OAuth app not configured" },
+    } as MessageEvent);
+
+    await expect(promise).rejects.toThrow("OAuth app not configured");
+  });
+
+  it("rejects with generic error when AUTH_ERROR has no error string", async () => {
+    vi.useFakeTimers();
+
+    let capturedMessageHandler: ((event: MessageEvent) => void) | undefined;
+
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost", pathname: "/", search: "", hash: "", assign: vi.fn() },
+      open: vi.fn().mockReturnValue({ closed: false }),
+      setInterval: vi.fn().mockReturnValue(1),
+      clearInterval: vi.fn(),
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (event: MessageEvent) => void) => {
+          capturedMessageHandler = handler;
+        },
+      ),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("fetch", vi.fn());
+
+    const promise = signInWithGitHubPopup();
+
+    capturedMessageHandler!({
+      origin: "http://localhost",
+      data: { type: "kickstart:github-auth:error" },
+    } as MessageEvent);
+
+    await expect(promise).rejects.toThrow("GitHub sign-in failed.");
+  });
+
+  it("ignores messages from different origins", async () => {
+    let capturedMessageHandler: ((event: MessageEvent) => void) | undefined;
+    let storedIntervalCb: (() => void) | undefined;
+    const popup = { closed: false };
+
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost", pathname: "/", search: "", hash: "", assign: vi.fn() },
+      open: vi.fn().mockReturnValue(popup),
+      setInterval: vi.fn().mockImplementation((cb: () => void) => {
+        storedIntervalCb = cb;
+        return 1;
+      }),
+      clearInterval: vi.fn(),
+      addEventListener: vi.fn().mockImplementation(
+        (_event: string, handler: (event: MessageEvent) => void) => {
+          capturedMessageHandler = handler;
+        },
+      ),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("fetch", vi.fn());
+
+    const promise = signInWithGitHubPopup();
+
+    // Cross-origin message should be ignored
+    capturedMessageHandler!({
+      origin: "https://evil.example.com",
+      data: { type: "kickstart:github-auth:complete" },
+    } as MessageEvent);
+
+    // Close the popup and trigger the interval watcher directly
+    popup.closed = true;
+    storedIntervalCb!();
+
+    await expect(promise).rejects.toThrow("GitHub sign-in was cancelled.");
+  });
+
+  it("rejects with cancellation error when user closes the popup", async () => {
+    let storedIntervalCb: (() => void) | undefined;
+    const popup = { closed: false };
+
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost", pathname: "/", search: "", hash: "", assign: vi.fn() },
+      open: vi.fn().mockReturnValue(popup),
+      setInterval: vi.fn().mockImplementation((cb: () => void) => {
+        storedIntervalCb = cb;
+        return 1;
+      }),
+      clearInterval: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const promise = signInWithGitHubPopup();
+
+    // Simulate popup closing and trigger the close watcher directly
+    popup.closed = true;
+    storedIntervalCb!();
+
+    await expect(promise).rejects.toThrow("GitHub sign-in was cancelled.");
+  });
+
+  it("falls back to redirect when window.open returns null (popup blocked)", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost", pathname: "/", search: "", hash: "", assign },
+      open: vi.fn().mockReturnValue(null),
+    });
+
+    // signInWithGitHubPopup returns a never-resolving promise when falling back to redirect
+    signInWithGitHubPopup();
+
+    expect(assign).toHaveBeenCalledWith(
+      expect.stringContaining("/api/github-auth/login"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: listGitHubRepos
+// ---------------------------------------------------------------------------
+
+describe("listGitHubRepos", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns repos array on success", async () => {
+    const repos = [
+      { id: 1, name: "my-app", full_name: "owner/my-app" },
+    ];
+    stubFetch([{ status: 200, body: { repos } }]);
+
+    const result = await listGitHubRepos("owner");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("my-app");
+  });
+
+  it("passes owner, page, and perPage as query params", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ repos: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await listGitHubRepos("test-owner", 2, 10);
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("owner=test-owner");
+    expect(url).toContain("page=2");
+    expect(url).toContain("perPage=10");
+  });
+
+  it("throws with API error on non-ok response", async () => {
+    stubFetch([{ status: 401, body: { error: "Unauthorized" } }]);
+
+    await expect(listGitHubRepos("owner")).rejects.toThrow("Unauthorized");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: createGitHubRepo
+// ---------------------------------------------------------------------------
+
+describe("createGitHubRepo", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns created repo on success", async () => {
+    const repo = {
+      id: 42,
+      name: "new-repo",
+      full_name: "owner/new-repo",
+      private: false,
+    };
+    stubFetch([{ status: 201, body: { repo } }]);
+
+    const result = await createGitHubRepo({
+      owner: "owner",
+      name: "new-repo",
+      description: "A new repo",
+      private: false,
+    });
+
+    expect(result.name).toBe("new-repo");
+    expect(result.id).toBe(42);
+  });
+
+  it("sends POST to /api/github/repos with JSON body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ repo: { id: 1, name: "r", full_name: "o/r", private: false } }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createGitHubRepo({ owner: "o", name: "r" });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toContain("/api/github/repos");
+    expect((init as RequestInit).method).toBe("POST");
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.owner).toBe("o");
+    expect(body.name).toBe("r");
+  });
+
+  it("throws with API error on conflict", async () => {
+    stubFetch([{ status: 422, body: { error: "Repository name already taken" } }]);
+
+    await expect(
+      createGitHubRepo({ owner: "owner", name: "existing-repo" }),
+    ).rejects.toThrow("Repository name already taken");
+  });
+});


### PR DESCRIPTION
Closes #332
Working as Fry (Frontend Dev)

## Phase 1: Mock-based auth flow tests

This PR implements the Phase 1 scaffolding from the design proposal on issue #332: mock-based integration tests for the real Azure and GitHub auth service layers (not Playground stubs).

### What changed

- **`packages/web/src/__tests__/azure-auth.test.ts`** — 16 tests for `azure-auth.ts`
  - Azure auth uses SWA built-in AAD: `/.auth/me` → principal check, `/.auth/login/aad` redirect
  - Covers: authenticated session, null principal, wrong identityProvider, ARM connector failure, network error, no connector, partial claims, signOut redirect
- **`packages/web/src/__tests__/github-handoff.test.ts`** — 26 tests for `github-handoff.ts`
  - GitHub auth uses popup-based OAuth proxy via `/api/github-auth/` endpoints
  - Covers: session happy path, unauthenticated/unconfigured, network error, signOut (200/204/error), login URL encoding, popup AUTH_COMPLETE, AUTH_ERROR, cross-origin message ignored, user closes popup, popup blocked → redirect fallback, repo list/create API contracts

### Test design notes

- Uses **Vitest + `vi.stubGlobal`** — same pattern as the existing `api-client.test.ts`
- **No real network calls** — all fetch interactions are stubbed
- `mockImplementation` (not `mockResolvedValue`) used for fetch mocks to avoid consumed-body issues when the same endpoint is called twice (e.g. `signInToAzure` calls `/.auth/me` then delegates to `getAzureSession` which calls it again)
- Popup close watcher tested by capturing the `setInterval` callback and invoking it directly — avoids fake timer + stubbed-window conflicts

### What's NOT in Phase 1 (future work, blocked)

- No real MSAL credentials — Azure auth is SWA AAD, not browser MSAL
- No real GitHub OAuth App registered yet (`GITHUB_CLIENT_ID` missing — infra blocker per decisions.md)
- E2E Playwright tests with real credentials (Phase 2 — needs dedicated test AAD tenant + GitHub OAuth App)

### Test results

```
✓ packages/web/src/__tests__/azure-auth.test.ts (16 tests)
✓ packages/web/src/__tests__/github-handoff.test.ts (26 tests)
Test Files  62 passed (62)
Tests  1469 passed (1469)
```