### PR TITLE
feat: A2UI custom component expansion — audit and quick-wins (#351)

### DIFF
--- a/packages/core/src/__tests__/a2ui-schema.test.ts
+++ b/packages/core/src/__tests__/a2ui-schema.test.ts
@@ -58,8 +58,8 @@ describe("PAYLOAD_LIMITS", () => {
 // ---------------------------------------------------------------------------
 
 describe("KNOWN_COMPONENT_TYPES", () => {
-  it("contains exactly 46 types", () => {
-    expect(KNOWN_COMPONENT_TYPES.size).toBe(46);
+  it("contains exactly 48 types", () => {
+    expect(KNOWN_COMPONENT_TYPES.size).toBe(48);
   });
 
   it("includes all expected component types", () => {

--- a/packages/core/src/__tests__/component-catalog.test.ts
+++ b/packages/core/src/__tests__/component-catalog.test.ts
@@ -2,13 +2,13 @@
  * Tests for dynamic A2UI component catalog injection (Issue #185).
  *
  * Verifies:
- *   - Base catalog generates all 28 component entries
+ *   - Base catalog generates all 33 component entries
  *   - Kit-contributed components appear in the generated section
  *   - Kit entries override base entries of the same type (dedup)
  *   - Component count updates dynamically
  *   - buildSystemPrompt injects the catalog via the placeholder
  *   - IntegrationKitRegistry.getComponentCatalogEntries() works
- *   - Backward-compatible: no kit entries means base 28 components appear
+ *   - Backward-compatible: no kit entries means base 33 components appear
  */
 
 import { describe, it, expect } from "vitest";
@@ -29,9 +29,9 @@ import type { IntegrationKit } from "../kits/types.js";
 // ---------------------------------------------------------------------------
 
 describe("generateComponentCatalogSection", () => {
-  it("generates all 28 base components", () => {
+  it("generates all 33 base components", () => {
     const section = generateComponentCatalogSection();
-    expect(section).toContain("You have 28 components");
+    expect(section).toContain("You have 33 components");
   });
 
   it("includes all four category headings", () => {
@@ -71,7 +71,7 @@ describe("generateComponentCatalogSection", () => {
       },
     ];
     const section = generateComponentCatalogSection(BASE_COMPONENT_CATALOG, kitEntries);
-    expect(section).toContain("You have 29 components");
+    expect(section).toContain("You have 34 components");
     expect(section).toContain("- AzureResourcePicker:");
     expect(section).toContain("Picks Azure resources");
   });
@@ -86,7 +86,7 @@ describe("generateComponentCatalogSection", () => {
       },
     ];
     const section = generateComponentCatalogSection(BASE_COMPONENT_CATALOG, kitEntries);
-    expect(section).toContain("You have 28 components");
+    expect(section).toContain("You have 33 components");
     expect(section).toContain("customized by kit");
   });
 
@@ -117,7 +117,7 @@ describe("buildSystemPrompt with dynamic component catalog", () => {
   it("includes the dynamically generated catalog in the prompt", () => {
     const prompt = buildSystemPrompt({ phase: Phase.Discover });
     expect(prompt).toContain("## 5. A2UI COMPONENT CATALOG");
-    expect(prompt).toContain("You have 28 components");
+    expect(prompt).toContain("You have 33 components");
     expect(prompt).toContain("### Layout Components");
   });
 
@@ -137,13 +137,13 @@ describe("buildSystemPrompt with dynamic component catalog", () => {
         },
       ],
     });
-    expect(prompt).toContain("You have 29 components");
+    expect(prompt).toContain("You have 34 components");
     expect(prompt).toContain("- GitHubRepoPicker:");
   });
 
-  it("backward-compatible: no kitComponentEntries means base 28 appear", () => {
+  it("backward-compatible: no kitComponentEntries means base 33 appear", () => {
     const prompt = buildSystemPrompt({ phase: Phase.Design });
-    expect(prompt).toContain("You have 28 components");
+    expect(prompt).toContain("You have 33 components");
     expect(prompt).toContain("- Row:");
     expect(prompt).toContain("- GenerationProgress:");
   });
@@ -260,8 +260,8 @@ describe("IntegrationKitRegistry.getComponentCatalogEntries", () => {
 // ---------------------------------------------------------------------------
 
 describe("BASE_COMPONENT_CATALOG", () => {
-  it("has exactly 28 entries", () => {
-    expect(BASE_COMPONENT_CATALOG).toHaveLength(28);
+  it("has exactly 33 entries", () => {
+    expect(BASE_COMPONENT_CATALOG).toHaveLength(33);
   });
 
   it("has unique type names", () => {

--- a/packages/core/src/prompts/component-catalog.ts
+++ b/packages/core/src/prompts/component-catalog.ts
@@ -19,7 +19,8 @@ export type ComponentCategory =
   | "layout"
   | "content"
   | "input"
-  | "domain";
+  | "domain"
+  | "feedback";
 
 /**
  * A catalog entry carries the metadata needed to render one component's
@@ -94,6 +95,25 @@ export const BASE_COMPONENT_CATALOG: readonly ComponentCatalogEntry[] = [
     type: "Markdown",
     category: "content",
     example: '{"id":"md1","component":"Markdown","content":"### Features\\\\n- Auto-scaling\\\\n- Health checks\\\\n- Zero-downtime deploys"}',
+    notes: "Use for free-form prose only. For structured label-value summaries use SummaryCard. For recommendations use DecisionCard. For tabular data use Table. For status messages use Alert.",
+  },
+  {
+    type: "Table",
+    category: "content",
+    example: '{"id":"tbl1","component":"Table","caption":"AKS Node Pools","columns":["Pool","VM Size","Min Nodes","Max Nodes"],"rows":[["system","Standard_D2s_v5","1","3"],["user","Standard_D4s_v5","0","10"]]}',
+    notes: "Use whenever data has clear columns — never use Markdown tables. columns is an array of header strings; rows is an array of string arrays.",
+  },
+  {
+    type: "Link",
+    category: "content",
+    example: '{"id":"lnk1","component":"Link","text":"Azure Pricing Calculator","url":"https://azure.microsoft.com/pricing/calculator/","external":true}',
+    notes: "Use for standalone hyperlinks. For inline links within prose, embed them in Markdown content.",
+  },
+  {
+    type: "Alert",
+    category: "content",
+    example: '{"id":"alert1","component":"Alert","message":"Your app will be publicly accessible. Add network policies before production.","severity":"warning","dismissible":true}',
+    notes: "severities: info, warning, error, success. Use instead of ⚠️/ℹ️ emoji in Markdown.",
   },
   {
     type: "Image",
@@ -193,6 +213,18 @@ export const BASE_COMPONENT_CATALOG: readonly ComponentCatalogEntry[] = [
     category: "domain",
     example: '{"id":"dp1","component":"GenerationProgress","runId":"deploy-123","overallStatus":"running","steps":[{"id":"s1","label":"Build image","status":"complete"},{"id":"s2","label":"Push to registry","status":"running","detail":"Publishing image to ACR"},{"id":"s3","label":"Deploy","status":"pending"}]}',
   },
+  {
+    type: "SummaryCard",
+    category: "domain",
+    example: '{"id":"sum1","component":"SummaryCard","title":"Your App","items":[{"label":"App type","value":"REST API"},{"label":"Runtime","value":"Node.js 20","badge":"success"},{"label":"Database","value":"PostgreSQL Flexible Server"},{"label":"Region","value":"East US"}]}',
+    notes: "Use to summarize gathered facts at the end of Discover, confirm architecture choices, or recap before deployment. Each item may include an optional badge: success, warning, info, danger, neutral.",
+  },
+  {
+    type: "DecisionCard",
+    category: "domain",
+    example: '{"id":"dec1","component":"DecisionCard","title":"Database","recommendation":"PostgreSQL Flexible Server","rationale":"Best fit for your relational workload. Managed service with automatic backups and Entra auth support.","alternatives":["Cosmos DB for NoSQL/global","Azure SQL for SQL Server compat"],"badge":"recommended"}',
+    notes: "Use to present architecture recommendations with rationale instead of Markdown prose. badge: recommended | best-practice | required | optional.",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -204,6 +236,7 @@ const CATEGORY_LABELS: Record<ComponentCategory, string> = {
   content: "Content Components",
   input: "Input Components",
   domain: "Kickstart Domain Components",
+  feedback: "Feedback Components",
 };
 
 const CATEGORY_ORDER: readonly ComponentCategory[] = [
@@ -211,6 +244,7 @@ const CATEGORY_ORDER: readonly ComponentCategory[] = [
   "content",
   "input",
   "domain",
+  "feedback",
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -110,7 +110,7 @@ Ask ONE question at a time, in this priority:
 3. Whether they have existing code — Two Buttons: "I have existing code" / "Starting fresh"
 If the user gives enough info in one message, skip redundant questions.
 Between discovery questions, do NOT acknowledge or summarize the user's previous answer — move directly to the next question.
-When all key facts are gathered, provide a single summary in a Card with Markdown, then include a primary Button with action {"event":{"name":"complete:navigate:design","context":{"label":"Continue to architecture design"}}}.
+When all key facts are gathered, provide a single summary using SummaryCard (title "What you told me", items for app type, runtime, DB etc.), then include a primary Button with action {"event":{"name":"complete:navigate:design","context":{"label":"Continue to architecture design"}}}.
 
 ### STEP 2 — DESIGN
 Figure out what services the app needs, then present the architecture.
@@ -217,10 +217,14 @@ ABSOLUTE RULES:
   - Open-ended / free-form answer → TextField
   This is NON-NEGOTIABLE. If you write a question like "Do you X or Y?" as bare text inside a Card without interactive components, that is a critical failure.
 - If you have information to present → use Card, Tabs, Markdown, Text, or Accordion.
+- If you have a discovery summary or "what you told me" recap → use SummaryCard.
+- If you have a recommendation with rationale → use DecisionCard.
 - If you have generated files or configs → use FileEditor. Use CodeBlock only for short illustrative snippets that should stay inline in chat.
 - If you have progress → use GenerationProgress or ProgressSteps.
 - If you have costs → use CostEstimate.
 - If you have architecture → use ArchitectureDiagram.
+- If you have tabular data → use Table (never Markdown tables).
+- If you have a warning or informational message → use Alert (never ⚠️ emoji in Markdown).
 - The "message" field is a SHORT summary (1-3 sentences). The COMPONENTS carry the content.
 
 ### JSON Envelope Fields
@@ -282,7 +286,10 @@ ALWAYS pick the RICHEST component for the situation:
 | Yes/No or binary choice | Two Buttons in a Row | Asking "yes or no?" in text |
 | Either/or question (2 options) | Two Buttons in a Row, or RadioGroup | Bare text question with no interactive component |
 | Asking for a name or value | TextField | Asking them to type in chat |
+| Summarizing gathered facts / choices made | SummaryCard | Card with Markdown "**Field:** value" patterns |
+| Presenting an architecture recommendation | DecisionCard | Markdown prose "I recommend X because Y" |
 | Presenting information | Card + Text + Markdown | Wall of text in message |
+| Showing tabular data | Table | Markdown tables |
 | Showing code or config | FileEditor | Code in message field |
 | Multiple sections of info | Tabs or Accordion | Long single-column text |
 | Showing architecture | ArchitectureDiagram | Describing architecture in text |
@@ -290,6 +297,8 @@ ALWAYS pick the RICHEST component for the situation:
 | Tracking progress | GenerationProgress | Saying "step 2 of 5" in text |
 | Explaining concepts | Card with Markdown inside | Long paragraphs |
 | Highlighting a status | Badge inside a Row | Parenthetical "(recommended)" |
+| Status or warning message | Alert | ⚠️ or ℹ️ emoji in Markdown |
+| Standalone hyperlink | Link | Bare URL in message text |
 | Feature toggles | Toggle or CheckBox | Asking "do you want X?" in text |
 | Multi-option selection | MultiSelect | Multiple CheckBox components |
 | Searchable dropdown | ComboBox | Long ChoicePicker list |
@@ -304,7 +313,7 @@ Study these examples carefully. Every response you give should match this level 
 {"message":"Welcome! Tell me about the app you want to deploy — I'll figure out the best setup.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-1","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-1","components":[{"id":"root","component":"Column","children":["welcome-card","picker-card"],"gap":"16px"},{"id":"welcome-card","component":"Card","children":["welcome-col"]},{"id":"welcome-col","component":"Column","children":["title","subtitle"]},{"id":"title","component":"Text","text":"Let's deploy your app","variant":"h2"},{"id":"subtitle","component":"Text","text":"I'll guide you through setting up a scalable cloud environment. Just tell me what you're building and I'll handle the rest.","variant":"body"},{"id":"picker-card","component":"Card","children":["picker-col"]},{"id":"picker-col","component":"Column","children":["picker-label","picker"]},{"id":"picker-label","component":"Text","text":"Or pick a common app type to get started faster:","variant":"body"},{"id":"picker","component":"ChoicePicker","label":"What are you building?","options":[{"label":"Web API / REST service","value":"web-api"},{"label":"Full-stack web app","value":"full-stack"},{"label":"AI agent / chatbot","value":"ai-agent"},{"label":"Background worker / job processor","value":"worker"},{"label":"Microservices system","value":"microservices"}],"action":{"event":{"name":"select-app-type","context":{"label":"What are you building?"}}}}]}}],"actions":[],"phaseComplete":false,"filesComplete":null}
 
 ### Example 2: Discover step — asking runtime (after user described their app)
-{"message":"A Node.js REST API — nice. Let me confirm the runtime.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-2","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-2","components":[{"id":"root","component":"Column","children":["summary-card","runtime-card"],"gap":"16px"},{"id":"summary-card","component":"Card","children":["summary-col"]},{"id":"summary-col","component":"Column","children":["summary-text"]},{"id":"summary-text","component":"Markdown","content":"**Your app:** REST API for managing a product catalog with search and filtering."},{"id":"runtime-card","component":"Card","children":["runtime-col"]},{"id":"runtime-col","component":"Column","children":["runtime-label","runtime-picker"]},{"id":"runtime-label","component":"Text","text":"Which runtime does your app use?","variant":"body"},{"id":"runtime-picker","component":"ChoicePicker","label":"Runtime","options":[{"label":"Node.js / TypeScript","value":"node"},{"label":"Python","value":"python"},{"label":".NET / C#","value":"dotnet"},{"label":"Java / Spring","value":"java"},{"label":"Go","value":"go"}],"action":{"event":{"name":"pick-runtime","context":{"label":"Runtime"}}}}]}}],"actions":[],"phaseComplete":false,"filesComplete":null}
+{"message":"A Node.js REST API — nice. Let me confirm the runtime.","a2ui":[{"version":"v0.9","createSurface":{"surfaceId":"msg-2","catalogId":"kickstart"}},{"version":"v0.9","updateComponents":{"surfaceId":"msg-2","components":[{"id":"root","component":"Column","children":["summary-card","runtime-card"],"gap":"16px"},{"id":"summary-card","component":"SummaryCard","title":"What you told me","items":[{"label":"App type","value":"REST API for product catalog with search and filtering"}]},{"id":"runtime-card","component":"Card","children":["runtime-col"]},{"id":"runtime-col","component":"Column","children":["runtime-label","runtime-picker"]},{"id":"runtime-label","component":"Text","text":"Which runtime does your app use?","variant":"body"},{"id":"runtime-picker","component":"ChoicePicker","label":"Runtime","options":[{"label":"Node.js / TypeScript","value":"node"},{"label":"Python","value":"python"},{"label":".NET / C#","value":"dotnet"},{"label":"Java / Spring","value":"java"},{"label":"Go","value":"go"}],"action":{"event":{"name":"pick-runtime","context":{"label":"Runtime"}}}}]}}],"actions":[],"phaseComplete":false,"filesComplete":null}
 
 ### Example 3: Design step — architecture review only
 {

--- a/packages/core/src/services/a2ui-schema.ts
+++ b/packages/core/src/services/a2ui-schema.ts
@@ -73,6 +73,7 @@ export const KNOWN_COMPONENT_TYPES = new Set([
   "ComboBox",
   "CostEstimate",
   "DateTimeInput",
+  "DecisionCard",
   "GenerationProgress",
   "Divider",
   "FileEditor",
@@ -94,6 +95,7 @@ export const KNOWN_COMPONENT_TYPES = new Set([
   "Row",
   "Slider",
   "SteppedCarousel",
+  "SummaryCard",
   "Tabs",
   "Table",
   "Text",
@@ -894,6 +896,35 @@ const MultiSelectPropsSchema = z
 // Component schema registry
 // ---------------------------------------------------------------------------
 
+// SummaryCard and DecisionCard — new domain components
+
+const SummaryItemSchema = z.object({
+  label: dynamicString,
+  value: dynamicString,
+  badge: z.enum(["neutral", "success", "warning", "danger", "info"]).optional(),
+});
+
+const SummaryCardPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("SummaryCard"),
+    title: dynamicString.optional(),
+    items: z.array(SummaryItemSchema),
+  })
+  .strip();
+
+const DecisionCardPropsSchema = z
+  .object({
+    id: boundedString,
+    component: z.literal("DecisionCard"),
+    title: dynamicString,
+    recommendation: dynamicString,
+    rationale: dynamicString.optional(),
+    alternatives: z.array(dynamicString).optional(),
+    badge: z.enum(["recommended", "best-practice", "required", "optional"]).optional(),
+  })
+  .strip();
+
 /**
  * Maps each known component type to its Zod schema.
  * Used by the response processor to validate per-component props.
@@ -918,6 +949,7 @@ export const COMPONENT_SCHEMA_REGISTRY: Record<string, z.ZodType> = {
   ComboBox: ComboBoxPropsSchema,
   CostEstimate: CostEstimatePropsSchema,
   DateTimeInput: DateTimeInputPropsSchema,
+  DecisionCard: DecisionCardPropsSchema,
   GenerationProgress: GenerationProgressPropsSchema,
   Divider: DividerPropsSchema,
   FileEditor: FileEditorPropsSchema,
@@ -939,6 +971,7 @@ export const COMPONENT_SCHEMA_REGISTRY: Record<string, z.ZodType> = {
   Row: RowPropsSchema,
   Slider: SliderPropsSchema,
   SteppedCarousel: SteppedCarouselPropsSchema,
+  SummaryCard: SummaryCardPropsSchema,
   Tabs: TabsPropsSchema,
   Table: TablePropsSchema,
   Text: TextPropsSchema,

--- a/packages/web/src/catalog/components/DecisionCard.tsx
+++ b/packages/web/src/catalog/components/DecisionCard.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { createReactComponent } from '../../vendor/a2ui/react/adapter';
+import { z } from 'zod';
+import { DynamicStringSchema } from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Badge,
+  Body1,
+  Caption1,
+  Card,
+  Subtitle2,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { CheckmarkCircleRegular } from '@fluentui/react-icons';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const DecisionCardApi = {
+  name: 'DecisionCard',
+  schema: z
+    .object({
+      title: DynamicStringSchema,
+      recommendation: DynamicStringSchema,
+      rationale: DynamicStringSchema.optional(),
+      alternatives: z.array(DynamicStringSchema).optional(),
+      badge: z.enum(['recommended', 'best-practice', 'required', 'optional']).optional(),
+    })
+    .strict(),
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const useStyles = makeStyles({
+  card: {
+    padding: tokens.spacingVerticalM,
+    paddingLeft: tokens.spacingHorizontalM,
+    paddingRight: tokens.spacingHorizontalM,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  titleText: {
+    color: tokens.colorNeutralForeground3,
+  },
+  recommendationRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  checkIcon: {
+    color: tokens.colorPaletteGreenForeground1,
+    fontSize: '20px',
+    flexShrink: 0,
+  },
+  rationale: {
+    color: tokens.colorNeutralForeground2,
+    marginTop: tokens.spacingVerticalXS,
+  },
+  alternativesLabel: {
+    display: 'block',
+    marginTop: tokens.spacingVerticalS,
+    color: tokens.colorNeutralForeground3,
+  },
+  alternativesList: {
+    margin: 0,
+    paddingLeft: tokens.spacingHorizontalL,
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Badge colour + label mapping
+// ---------------------------------------------------------------------------
+
+type BadgeColor = 'success' | 'brand' | 'important' | 'subtle';
+
+const BADGE_CONFIG: Record<string, { color: BadgeColor; label: string }> = {
+  recommended: { color: 'success', label: 'Recommended' },
+  'best-practice': { color: 'brand', label: 'Best Practice' },
+  required: { color: 'important', label: 'Required' },
+  optional: { color: 'subtle', label: 'Optional' },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const DecisionCard = createReactComponent(DecisionCardApi, ({ props }) => {
+  const classes = useStyles();
+  const badgeCfg = props.badge ? BADGE_CONFIG[props.badge] : undefined;
+  const alternatives = props.alternatives ?? [];
+
+  return (
+    <Card className={classes.card}>
+      <div className={classes.header}>
+        <Caption1 className={classes.titleText}>{props.title}</Caption1>
+        {badgeCfg && (
+          <Badge color={badgeCfg.color} appearance="tint" size="small">
+            {badgeCfg.label}
+          </Badge>
+        )}
+      </div>
+
+      <div className={classes.recommendationRow}>
+        <CheckmarkCircleRegular className={classes.checkIcon} />
+        <Subtitle2>{props.recommendation}</Subtitle2>
+      </div>
+
+      {props.rationale && (
+        <Body1 className={classes.rationale}>{props.rationale}</Body1>
+      )}
+
+      {alternatives.length > 0 && (
+        <>
+          <Caption1 className={classes.alternativesLabel}>Alternatives considered</Caption1>
+          <ul className={classes.alternativesList}>
+            {alternatives.map((alt, idx) => (
+              <li key={idx}>
+                <Body1>{alt}</Body1>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </Card>
+  );
+});

--- a/packages/web/src/catalog/components/SummaryCard.tsx
+++ b/packages/web/src/catalog/components/SummaryCard.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { createReactComponent } from '../../vendor/a2ui/react/adapter';
+import { z } from 'zod';
+import { DynamicStringSchema } from '../../vendor/a2ui/web_core/schema/common-types';
+import {
+  Badge,
+  Body1,
+  Body1Strong,
+  Caption1,
+  Card,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const SummaryItemSchema = z.object({
+  label: DynamicStringSchema,
+  value: DynamicStringSchema,
+  badge: z.enum(['neutral', 'success', 'warning', 'danger', 'info']).optional(),
+});
+
+const SummaryCardApi = {
+  name: 'SummaryCard',
+  schema: z
+    .object({
+      title: DynamicStringSchema.optional(),
+      items: z.array(SummaryItemSchema),
+    })
+    .strict(),
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const useStyles = makeStyles({
+  card: {
+    padding: tokens.spacingVerticalM,
+    paddingLeft: tokens.spacingHorizontalM,
+    paddingRight: tokens.spacingHorizontalM,
+  },
+  title: {
+    display: 'block',
+    marginBottom: tokens.spacingVerticalS,
+    color: tokens.colorNeutralForeground2,
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    columnGap: tokens.spacingHorizontalL,
+    rowGap: tokens.spacingVerticalXS,
+    alignItems: 'center',
+  },
+  label: {
+    color: tokens.colorNeutralForeground3,
+    whiteSpace: 'nowrap',
+  },
+  valueRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+    flexWrap: 'wrap',
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Badge colour mapping
+// ---------------------------------------------------------------------------
+
+type BadgeColor = 'neutral' | 'success' | 'warning' | 'danger' | 'informative';
+
+const BADGE_COLOR_MAP: Record<string, BadgeColor> = {
+  neutral: 'neutral',
+  success: 'success',
+  warning: 'warning',
+  danger: 'danger',
+  info: 'informative',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const SummaryCard = createReactComponent(SummaryCardApi, ({ props }) => {
+  const classes = useStyles();
+  const items = props.items ?? [];
+
+  return (
+    <Card className={classes.card}>
+      {props.title && (
+        <Caption1 className={classes.title}>{props.title}</Caption1>
+      )}
+      <div className={classes.grid}>
+        {items.map((item, idx) => (
+          <React.Fragment key={idx}>
+            <Body1 className={classes.label}>{item.label}</Body1>
+            <div className={classes.valueRow}>
+              <Body1Strong>{item.value}</Body1Strong>
+              {item.badge && (
+                <Badge
+                  color={BADGE_COLOR_MAP[item.badge] ?? 'neutral'}
+                  appearance="tint"
+                  size="small"
+                >
+                  {item.badge}
+                </Badge>
+              )}
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
+    </Card>
+  );
+});

--- a/packages/web/src/catalog/components/SummaryCard.tsx
+++ b/packages/web/src/catalog/components/SummaryCard.tsx
@@ -70,10 +70,10 @@ const useStyles = makeStyles({
 // Badge colour mapping
 // ---------------------------------------------------------------------------
 
-type BadgeColor = 'neutral' | 'success' | 'warning' | 'danger' | 'informative';
+type BadgeColor = 'subtle' | 'success' | 'warning' | 'danger' | 'informative';
 
 const BADGE_COLOR_MAP: Record<string, BadgeColor> = {
-  neutral: 'neutral',
+  neutral: 'subtle',
   success: 'success',
   warning: 'warning',
   danger: 'danger',
@@ -101,7 +101,7 @@ export const SummaryCard = createReactComponent(SummaryCardApi, ({ props }) => {
               <Body1Strong>{item.value}</Body1Strong>
               {item.badge && (
                 <Badge
-                  color={BADGE_COLOR_MAP[item.badge] ?? 'neutral'}
+                  color={BADGE_COLOR_MAP[item.badge] ?? 'subtle'}
                   appearance="tint"
                   size="small"
                 >

--- a/packages/web/src/catalog/kickstart-catalog.ts
+++ b/packages/web/src/catalog/kickstart-catalog.ts
@@ -22,6 +22,8 @@ import { CostEstimate } from './components/CostEstimate';
 import { GenerationProgress } from './components/GenerationProgress';
 import { SteppedCarousel } from './components/SteppedCarousel';
 import { Questionnaire } from './components/Questionnaire';
+import { SummaryCard } from './components/SummaryCard';
+import { DecisionCard } from './components/DecisionCard';
 
 const kickstartComponents: ReactComponentImplementation[] = [
   ...Array.from(basicCatalog.components.values()),
@@ -46,6 +48,8 @@ const kickstartComponents: ReactComponentImplementation[] = [
   GenerationProgress,
   SteppedCarousel,
   Questionnaire,
+  SummaryCard,
+  DecisionCard,
 ];
 
 export const kickstartCatalog = new Catalog<ReactComponentImplementation>(


### PR DESCRIPTION
Closes #351
Working as Leela (Lead / Architect)

## Audit Summary

**46 types in schema vs 28 in LLM catalog.** 18 components existed (vendor or custom) but were undocumented — the model could never generate them.

### Key Markdown overuse patterns found
- Discovery summaries: `Card > Column > Row > bold-text Markdown` → replace with `SummaryCard`
- Architecture recommendations: `Card > Markdown prose` → replace with `DecisionCard`  
- Warning/info messages: ⚠️ emoji in Markdown → replace with `Alert`
- Tabular data: Markdown tables → replace with `Table`
- Reference links: bare URLs in text → replace with `Link`

## New Components

### SummaryCard
Renders a Fluent `Card` with a 2-column label/value grid and optional per-item badge.
Replaces the `Card > Column > (Row > Text > Text)` pattern for discovery/design summaries.

### DecisionCard  
Renders a recommendation with `Subtitle2` + checkmark icon, optional rationale, optional alternatives list, and a decision badge (recommended / best-practice / required / optional).
Replaces `Card > Markdown` for architecture service recommendations.

## Catalog additions (existing components, newly documented to LLM)
- **Alert** — Fluent MessageBar, exists in vendor. Severities: info/warning/error/success. Now steered over emoji-in-Markdown.
- **Table** — Fluent Table, exists in vendor. Columns + rows string arrays. Now steered over Markdown tables.  
- **Link** — Fluent Link, exists in vendor. Supports `external: true` with new-tab + icon.

## System prompt changes
- MANDATORY section: 4 new bullet points for SummaryCard, DecisionCard, Alert, Table
- Component selection guide: 4 new rows
- Discover step summary instruction: use SummaryCard instead of Card+Markdown
- Example 2 updated to demonstrate SummaryCard

## Stats
- Base catalog: 28 → 33 components
- KNOWN_COMPONENT_TYPES: 46 → 48

⚠️ This task was flagged as architecture-scope — Zapp should review the Zod schemas before merge.