### PR TITLE
feat(playground): Workspace tab, Codespaces buttons, Ideas cleanup

### DIFF
--- a/packages/web/src/pages/playground-scenarios.ts
+++ b/packages/web/src/pages/playground-scenarios.ts
@@ -437,7 +437,6 @@ const customGenerationProgress = (): A2uiMsg[] => {
   ] as A2uiComponent[]);
 };
 
-// ---------------------------------------------------------------------------
 // Advanced Scenarios — Data Binding, Events, Lifecycle, Dynamic Patterns
 // ---------------------------------------------------------------------------
 
@@ -784,6 +783,7 @@ const costEstimateScenario = (): A2uiMsg[] => {
 };
 
 // ---------------------------------------------------------------------------
+
 // Missing Layout scenarios
 // ---------------------------------------------------------------------------
 
@@ -1092,6 +1092,7 @@ export const CONTROL_SCENARIOS: ScenarioDef[] = [
   { id: 'life-multi',    label: 'Multi-Surface',          description: 'Three parallel surfaces',                    group: 'Surface Lifecycle', generate: lifecycleMultiSurface },
   // Dynamic Patterns
   { id: 'file-create',       label: 'Create Workflow',        description: 'File generation with progress tracker',         group: 'File Operations', catalog: 'kickstart', generate: fileEditorCreateFlow },
+
   // GitHub Components
   { id: 'ctrl-gh-login',   label: 'GitHubLoginCard',    description: 'Device code authentication flow',      group: 'GitHub Components', catalog: 'kickstart', generate: domainGitHubLogin },
   { id: 'ctrl-gh-repo',    label: 'GitHubRepoPicker',   description: 'Repository search and selection',      group: 'GitHub Components', catalog: 'kickstart', generate: domainGitHubRepoPicker },


### PR DESCRIPTION
## Summary

Closes Playground accuracy gap — everything testable without going through chat.

### Changes

#### Components tab fix (already on base branch)
- Moved `GitHub Components` and `Azure Components` groups from **Ideas** → **Components** tab
- Connectors (`AzureARMConnector`, `GitHubConnector`) always registered regardless of playground mode — no more "running in offline mode" message
- `shouldUsePlaygroundAuthStub()` hardcoded to `return false` — real auth flows in playground

#### Ideas tab cleanup
- Reduced from 36 → 16 scenarios
- Removed: Multi-Phase Demo group (×5), Integration Kits group (×3), and 8 redundant/complex scenarios
- Moved `file-single`, `file-multi`, `cost-estimate` → Custom Controls section (`ctrl-*` IDs)
- Added `GenerationProgress` to Custom Controls

#### New Workspace tab
- New `PlaygroundWorkspace.tsx` component with 7 realistic sample files:
  - `src/server.ts` (TypeScript)
  - `k8s/deployment.yaml` + `k8s/service.yaml` (Kubernetes)
  - `.github/workflows/ci.yml` (GitHub Actions)
  - `Dockerfile`
  - `infra/main.bicep` (Bicep)
  - `architecture.mmd` (Mermaid — exercises diagram rendering)
- Stub VFS (no IndexedDB dependency) wired to real `FileViewer` and `FileManagerSidebar`
- Configurable GitHub repo URL input
- **"Open in vscode.dev"** and **"Open in GitHub Codespaces"** buttons in `FileManagerSidebar` header (shown when `githubRepoUrl` prop is provided)

### Motivation

> Playground should let you test all the functionality without having to go through chat. Use it as proving grounds before attempting to integrate with the LLM. That's why it should be accurate and always capture what we have.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>