### PR TITLE
fix(docs): remove invalid MDX heading anchor that breaks Docusaurus build

### DIFF
--- a/docs-site/docs/architecture/prompt-pipeline.md
+++ b/docs-site/docs/architecture/prompt-pipeline.md
@@ -159,7 +159,7 @@ Both mechanisms activate in Generate phase, both inject AKS/Docker context, thro
 
 Phase exit conditions in `phases.ts` are human-readable strings. Not code-enforced. See [FSM](./fsm.md).
 
-## Model Routing {#model-routing}
+## Model Routing
 
 Trust-based, not phase-based:
 


### PR DESCRIPTION
## Problem

The `{#model-routing}` heading anchor in `prompt-pipeline.md` breaks the Docusaurus 3 MDX3 build with an acorn parse error. MDX 3 processes `{...}` as a JSX expression before Docusaurus' heading-ID remark plugin runs, and `#` is not valid JS.

This was introduced in PR #383 and is currently blocking the GitHub Pages deployment.

## Fix

Remove `{#model-routing}` — Docusaurus auto-generates the same `#model-routing` anchor from the heading text anyway, so the explicit ID was redundant.

## Root cause of the CI failure

Action run: https://github.com/sabbour/kickstart/actions/runs/24532524389

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>