### PR TITLE
refactor: unify skill-injection keyword vocabulary into shared module

### DIFF
--- a/packages/core/src/__tests__/skill-vocabulary.test.ts
+++ b/packages/core/src/__tests__/skill-vocabulary.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @module @kickstart/core/__tests__/skill-vocabulary.test
+ *
+ * Tests for the shared skill-vocabulary module.
+ *
+ * Verifies that:
+ *   - Vocabulary constants contain the expected canonical terms
+ *   - Helper functions correctly detect domain terminology
+ *   - Both Mechanism A (skill-resolver) and Mechanism B (resolveConversationSkills)
+ *     react correctly to shared vocabulary terms
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AKS_KEYWORDS,
+  AKS_PATTERNS,
+  AUTH_KEYWORDS,
+  AUTH_PATTERNS,
+  CICD_KEYWORDS,
+  CICD_PATTERNS,
+  DATABASE_KEYWORDS,
+  DATABASE_RELATIONAL_PATTERNS,
+  DOCKER_KEYWORDS,
+  DOCKER_PATTERNS,
+  isAKSRelated,
+  isAuthRelated,
+  isCICDRelated,
+  isDatabaseRelated,
+  isDockerRelated,
+} from "../engine/skill-vocabulary.js";
+import { Phase } from "../engine/types.js";
+import { resolveSkills } from "../engine/skill-resolver.js";
+import { resolveConversationSkills } from "../services/resolveConversationSkills.js";
+import type { IntegrationKit } from "../kits/types.js";
+
+function makeKit(name: string, overrides: Partial<IntegrationKit> = {}): IntegrationKit {
+  return { name, description: `${name} kit`, tools: [], connectors: [], ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Vocabulary constants — structure checks
+// ---------------------------------------------------------------------------
+
+describe("skill-vocabulary — DOCKER constants", () => {
+  it("DOCKER_KEYWORDS includes dockerfile", () => {
+    expect(DOCKER_KEYWORDS).toContain("dockerfile");
+  });
+  it("DOCKER_PATTERNS match 'dockerfile'", () => {
+    expect(DOCKER_PATTERNS.some((p) => p.test("write a Dockerfile"))).toBe(true);
+  });
+  it("DOCKER_PATTERNS match 'container'", () => {
+    expect(DOCKER_PATTERNS.some((p) => p.test("container image"))).toBe(true);
+  });
+  it("isDockerRelated returns true for docker text", () => {
+    expect(isDockerRelated("multi-stage Dockerfile")).toBe(true);
+  });
+  it("isDockerRelated returns false for unrelated text", () => {
+    expect(isDockerRelated("spring boot REST endpoint")).toBe(false);
+  });
+});
+
+describe("skill-vocabulary — AKS constants", () => {
+  it("AKS_KEYWORDS includes manifest", () => {
+    expect(AKS_KEYWORDS).toContain("manifest");
+  });
+  it("AKS_KEYWORDS includes aks", () => {
+    expect(AKS_KEYWORDS).toContain("aks");
+  });
+  it("AKS_PATTERNS match 'manifest'", () => {
+    expect(AKS_PATTERNS.some((p) => p.test("apply the manifest"))).toBe(true);
+  });
+  it("isAKSRelated returns true for helm", () => {
+    expect(isAKSRelated("helm upgrade --install")).toBe(true);
+  });
+  it("isAKSRelated returns false for unrelated text", () => {
+    expect(isAKSRelated("react component tree")).toBe(false);
+  });
+});
+
+describe("skill-vocabulary — CICD constants", () => {
+  it("CICD_KEYWORDS includes pipeline", () => {
+    expect(CICD_KEYWORDS).toContain("pipeline");
+  });
+  it("CICD_KEYWORDS includes ci/cd", () => {
+    expect(CICD_KEYWORDS).toContain("ci/cd");
+  });
+  it("CICD_PATTERNS match 'pipeline'", () => {
+    expect(CICD_PATTERNS.some((p) => p.test("CI/CD pipeline"))).toBe(true);
+  });
+  it("isCICDRelated returns true for github actions", () => {
+    expect(isCICDRelated("set up GitHub Actions workflow")).toBe(true);
+  });
+  it("isCICDRelated returns false for unrelated text", () => {
+    expect(isCICDRelated("design a database schema")).toBe(false);
+  });
+});
+
+describe("skill-vocabulary — AUTH constants", () => {
+  it("AUTH_KEYWORDS includes oidc", () => {
+    expect(AUTH_KEYWORDS).toContain("oidc");
+  });
+  it("AUTH_KEYWORDS includes credential", () => {
+    expect(AUTH_KEYWORDS).toContain("credential");
+  });
+  it("AUTH_PATTERNS match 'managed identity'", () => {
+    expect(AUTH_PATTERNS.some((p) => p.test("managed identity setup"))).toBe(true);
+  });
+  it("isAuthRelated returns true for jwt", () => {
+    expect(isAuthRelated("validate a JWT token")).toBe(true);
+  });
+  it("isAuthRelated returns false for unrelated text", () => {
+    expect(isAuthRelated("deploy the helm chart")).toBe(false);
+  });
+});
+
+describe("skill-vocabulary — DATABASE constants", () => {
+  it("DATABASE_KEYWORDS includes database", () => {
+    expect(DATABASE_KEYWORDS).toContain("database");
+  });
+  it("DATABASE_RELATIONAL_PATTERNS match 'postgres'", () => {
+    expect(DATABASE_RELATIONAL_PATTERNS.some((p) => p.test("connect to PostgreSQL"))).toBe(true);
+  });
+  it("isDatabaseRelated returns true for SQL", () => {
+    expect(isDatabaseRelated("run a SQL query")).toBe(true);
+  });
+  it("isDatabaseRelated returns false for unrelated text", () => {
+    expect(isDatabaseRelated("build a Dockerfile")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mechanism A (skill-resolver) uses shared vocabulary
+// ---------------------------------------------------------------------------
+
+describe("skill-vocabulary — Mechanism A uses shared keywords", () => {
+  it("classifies kit prompt with 'dockerfile' to Generate phase", () => {
+    const kit = makeKit("ci-kit", { prompts: ["Generate a dockerfile for your Node.js app"] });
+    const result = resolveSkills(Phase.Generate, [kit]);
+    expect(result.prompts).toHaveLength(1);
+    expect(result.prompts[0]).toContain("dockerfile");
+  });
+
+  it("classifies kit prompt with 'manifest' to Generate phase", () => {
+    const kit = makeKit("k8s-kit", { prompts: ["Create a Kubernetes manifest for your deployment"] });
+    const result = resolveSkills(Phase.Generate, [kit]);
+    expect(result.prompts).toHaveLength(1);
+  });
+
+  it("classifies kit prompt with 'pipeline' to Generate phase", () => {
+    const kit = makeKit("cicd-kit", { prompts: ["Set up your CI/CD pipeline with GitHub Actions"] });
+    const result = resolveSkills(Phase.Generate, [kit]);
+    expect(result.prompts).toHaveLength(1);
+  });
+
+  it("classifies kit prompt with 'database' to Design phase", () => {
+    const kit = makeKit("db-kit", { prompts: ["Choose a database type for your application"] });
+    const designResult = resolveSkills(Phase.Design, [kit]);
+    expect(designResult.prompts).toHaveLength(1);
+  });
+
+  it("classifies kit prompt with 'aks' to Design phase", () => {
+    const kit = makeKit("aks-kit", { prompts: ["Configure your AKS cluster settings and node pools"] });
+    const designResult = resolveSkills(Phase.Design, [kit]);
+    expect(designResult.prompts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mechanism B (resolveConversationSkills) uses shared vocabulary
+// ---------------------------------------------------------------------------
+
+describe("skill-vocabulary — Mechanism B uses shared patterns", () => {
+  it("detects Docker domain via shared DOCKER_PATTERNS", () => {
+    const { domainKnowledge } = resolveConversationSkills(
+      "help me write a Dockerfile",
+      "design",
+      { phase: "design" },
+    );
+    expect(domainKnowledge).not.toBeNull();
+    expect(domainKnowledge).toContain("[Domain knowledge: Dockerfile best practices]");
+  });
+
+  it("detects AKS domain via shared AKS_PATTERNS (manifest)", () => {
+    const { domainKnowledge } = resolveConversationSkills(
+      "apply the kubernetes manifest",
+      "design",
+      { phase: "design" },
+    );
+    expect(domainKnowledge).toContain("[Domain knowledge: AKS Automatic deployment]");
+  });
+
+  it("detects CI/CD domain via shared CICD_PATTERNS (pipeline)", () => {
+    const { domainKnowledge } = resolveConversationSkills(
+      "set up a CI/CD pipeline",
+      "design",
+      { phase: "design" },
+    );
+    expect(domainKnowledge).toContain("[Domain knowledge: GitHub Actions CI/CD for AKS]");
+  });
+
+  it("detects auth domain via shared AUTH_PATTERNS (managed identity)", () => {
+    const { domainKnowledge } = resolveConversationSkills(
+      "configure managed identity for the pod",
+      "design",
+      { phase: "design" },
+    );
+    expect(domainKnowledge).toContain("[Domain knowledge: Azure authentication patterns]");
+  });
+
+  it("detects database domain via shared DATABASE_RELATIONAL_PATTERNS", () => {
+    const { domainKnowledge } = resolveConversationSkills(
+      "connect to a PostgreSQL database",
+      "design",
+      { phase: "design" },
+    );
+    expect(domainKnowledge).toContain("[Domain knowledge: Relational database on Azure]");
+  });
+});

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -22,6 +22,24 @@ export {
 export type { ResolvedSkills, SkillResolverMiddleware } from "./skill-resolver.js";
 
 export {
+  DOCKER_KEYWORDS,
+  DOCKER_PATTERNS,
+  isDockerRelated,
+  AKS_KEYWORDS,
+  AKS_PATTERNS,
+  isAKSRelated,
+  CICD_KEYWORDS,
+  CICD_PATTERNS,
+  isCICDRelated,
+  AUTH_KEYWORDS,
+  AUTH_PATTERNS,
+  isAuthRelated,
+  DATABASE_KEYWORDS,
+  DATABASE_RELATIONAL_PATTERNS,
+  isDatabaseRelated,
+} from "./skill-vocabulary.js";
+
+export {
   CopilotSkillsRegistry,
   defaultCopilotSkillsRegistry,
   AZURE_COPILOT_SKILLS,

--- a/packages/core/src/engine/skill-resolver.ts
+++ b/packages/core/src/engine/skill-resolver.ts
@@ -21,6 +21,13 @@
 import { Phase } from "./types.js";
 import type { Skill, SkillResolverContext } from "./types.js";
 import type { IntegrationKit } from "../kits/types.js";
+import {
+  AKS_KEYWORDS,
+  AUTH_KEYWORDS,
+  CICD_KEYWORDS,
+  DATABASE_KEYWORDS,
+  DOCKER_KEYWORDS,
+} from "./skill-vocabulary.js";
 
 // ---------------------------------------------------------------------------
 // Phase groups — used to filter general prompts to relevant phases
@@ -53,13 +60,18 @@ const DISCOVER_KEYWORDS = [
 ];
 
 const DESIGN_KEYWORDS = [
-  "architecture", "recommend", "prefer", "design", "database", "service",
-  "plan", "default", "unless", "aks automatic", "managed",
+  "architecture", "recommend", "prefer", "design", "service",
+  "plan", "default", "unless", "managed",
+  ...DATABASE_KEYWORDS,  // database, sql, postgres, mysql
+  ...AKS_KEYWORDS,       // aks, kubernetes, k8s, helm, manifest, bicep, workload identity, gateway api
 ];
 
 const GENERATE_KEYWORDS = [
-  "generat", "workflow", "dockerfile", "manifest", "artifact", "ci/cd",
-  "pipeline", "template", "oidc", "credential",
+  "generat", "artifact", "template",
+  ...DOCKER_KEYWORDS,    // dockerfile, container, multi-stage, docker
+  ...AKS_KEYWORDS,       // manifest, helm, aks, kubernetes, k8s, bicep, workload identity, gateway api
+  ...CICD_KEYWORDS,      // ci/cd, pipeline, workflow, github actions
+  ...AUTH_KEYWORDS,      // oidc, credential, managed identity, token
 ];
 
 const DEPLOYMENT_KEYWORDS = [

--- a/packages/core/src/engine/skill-vocabulary.ts
+++ b/packages/core/src/engine/skill-vocabulary.ts
@@ -1,0 +1,139 @@
+/**
+ * @module @kickstart/core/engine/skill-vocabulary
+ *
+ * Canonical keyword and regex vocabulary for skill-injection mechanisms.
+ *
+ * Single source of truth for domain term sets used by:
+ *   - Mechanism A (`skill-resolver.ts`): substring arrays classify kit prompt
+ *     text to conversation phases via `.includes()`.
+ *   - Mechanism B (`resolveConversationSkills.ts`): regex arrays detect domains
+ *     from user messages via `.test()`.
+ *
+ * Each domain exports:
+ *   - `XXX_KEYWORDS`  — readonly string tuple for Mechanism A
+ *   - `XXX_PATTERNS`  — RegExp[] for Mechanism B
+ *   - `isXxxRelated(text)` — boolean helper wrapping the regex array
+ */
+
+// ---------------------------------------------------------------------------
+// Docker
+// ---------------------------------------------------------------------------
+
+/** Substring keywords for Docker-related kit prompts (Mechanism A). */
+export const DOCKER_KEYWORDS = [
+  "dockerfile", "container", "multi-stage", "docker",
+] as const;
+
+/** Regex patterns for Docker-related user messages (Mechanism B). */
+export const DOCKER_PATTERNS: RegExp[] = [
+  /\bdocker(file)?\b/i,
+  /\bcontainer\b/i,
+  /\bimage\b.*\btag\b/i,
+  /\bmulti.?stage\b/i,
+];
+
+/** Returns true if `text` contains Docker-related terminology. */
+export function isDockerRelated(text: string): boolean {
+  return DOCKER_PATTERNS.some((p) => p.test(text));
+}
+
+// ---------------------------------------------------------------------------
+// AKS / Kubernetes
+// ---------------------------------------------------------------------------
+
+/** Substring keywords for AKS/Kubernetes-related kit prompts (Mechanism A). */
+export const AKS_KEYWORDS = [
+  "aks", "kubernetes", "k8s", "helm", "manifest", "bicep",
+  "workload identity", "gateway api",
+] as const;
+
+/** Regex patterns for AKS/Kubernetes-related user messages (Mechanism B). */
+export const AKS_PATTERNS: RegExp[] = [
+  /\baks\b/i,
+  /\bkubernetes\b/i,
+  /\bk8s\b/i,
+  /\bhelm\b/i,
+  /\bmanifest\b/i,
+  /\bbicep\b/i,
+  /\bworkload identity\b/i,
+  /\bgateway api\b/i,
+];
+
+/** Returns true if `text` contains AKS/Kubernetes-related terminology. */
+export function isAKSRelated(text: string): boolean {
+  return AKS_PATTERNS.some((p) => p.test(text));
+}
+
+// ---------------------------------------------------------------------------
+// CI/CD
+// ---------------------------------------------------------------------------
+
+/** Substring keywords for CI/CD-related kit prompts (Mechanism A). */
+export const CICD_KEYWORDS = [
+  "ci/cd", "pipeline", "workflow", "github actions",
+] as const;
+
+/** Regex patterns for CI/CD-related user messages (Mechanism B). */
+export const CICD_PATTERNS: RegExp[] = [
+  /\bci\/?cd\b/i,
+  /\bgithub actions?\b/i,
+  /\bpipeline\b/i,
+  /\bbuild.*push\b/i,
+  /\bdeploy.*workflow\b/i,
+];
+
+/** Returns true if `text` contains CI/CD-related terminology. */
+export function isCICDRelated(text: string): boolean {
+  return CICD_PATTERNS.some((p) => p.test(text));
+}
+
+// ---------------------------------------------------------------------------
+// Authentication / Identity
+// ---------------------------------------------------------------------------
+
+/** Substring keywords for auth/identity-related kit prompts (Mechanism A). */
+export const AUTH_KEYWORDS = [
+  "oidc", "credential", "managed identity", "token",
+] as const;
+
+/** Regex patterns for auth/identity-related user messages (Mechanism B). */
+export const AUTH_PATTERNS: RegExp[] = [
+  /\bauth(entication|orization)?\b/i,
+  /\blogin\b/i,
+  /\boauth\b/i,
+  /\bjwt\b/i,
+  /\bmsal\b/i,
+  /\btoken\b/i,
+  /\bmanaged identity\b/i,
+  /\bentra\b/i,
+];
+
+/** Returns true if `text` contains authentication/identity-related terminology. */
+export function isAuthRelated(text: string): boolean {
+  return AUTH_PATTERNS.some((p) => p.test(text));
+}
+
+// ---------------------------------------------------------------------------
+// Database / Relational persistence
+// ---------------------------------------------------------------------------
+
+/** Substring keywords for database-related kit prompts (Mechanism A). */
+export const DATABASE_KEYWORDS = [
+  "database", "sql", "postgres", "mysql",
+] as const;
+
+/** Regex patterns for relational-database-related user messages (Mechanism B). */
+export const DATABASE_RELATIONAL_PATTERNS: RegExp[] = [
+  /\bpostgres(ql)?\b/i,
+  /\bmysql\b/i,
+  /\bsql\b/i,
+  /\bdatabase\b/i,
+  /\bprisma\b/i,
+  /\bsequelize\b/i,
+  /\borm\b/i,
+];
+
+/** Returns true if `text` contains relational-database-related terminology. */
+export function isDatabaseRelated(text: string): boolean {
+  return DATABASE_RELATIONAL_PATTERNS.some((p) => p.test(text));
+}

--- a/packages/core/src/services/resolveConversationSkills.ts
+++ b/packages/core/src/services/resolveConversationSkills.ts
@@ -22,6 +22,14 @@
  *   // snapshot without relying on conversation history alone.
  */
 
+import {
+  AKS_PATTERNS,
+  AUTH_PATTERNS,
+  CICD_PATTERNS,
+  DATABASE_RELATIONAL_PATTERNS,
+  DOCKER_PATTERNS,
+} from "../engine/skill-vocabulary.js";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -104,23 +112,23 @@ const DOMAIN_PATTERNS: Array<{ domain: Domain; patterns: RegExp[] }> = [
   },
   {
     domain: "infra-docker",
-    patterns: [/\bdocker(file)?\b/i, /\bcontainer\b/i, /\bimage\b.*\btag\b/i, /\bmulti.?stage\b/i],
+    patterns: DOCKER_PATTERNS,
   },
   {
     domain: "infra-aks",
-    patterns: [/\baks\b/i, /\bkubernetes\b/i, /\bk8s\b/i, /\bhelm\b/i, /\bmanifest\b/i, /\bbicep\b/i, /\bworkload identity\b/i, /\bgateway api\b/i],
+    patterns: AKS_PATTERNS,
   },
   {
     domain: "infra-cicd",
-    patterns: [/\bci\/?cd\b/i, /\bgithub actions?\b/i, /\bpipeline\b/i, /\bbuild.*push\b/i, /\bdeploy.*workflow\b/i],
+    patterns: CICD_PATTERNS,
   },
   {
     domain: "auth",
-    patterns: [/\bauth(entication|orization)?\b/i, /\blogin\b/i, /\boauth\b/i, /\bjwt\b/i, /\bmsal\b/i, /\btoken\b/i, /\bmanaged identity\b/i, /\bentra\b/i],
+    patterns: AUTH_PATTERNS,
   },
   {
     domain: "data-relational",
-    patterns: [/\bpostgres(ql)?\b/i, /\bmysql\b/i, /\bsql\b/i, /\bdatabase\b/i, /\bprisma\b/i, /\bsequelize\b/i, /\borm\b/i],
+    patterns: DATABASE_RELATIONAL_PATTERNS,
   },
   {
     domain: "data-nosql",


### PR DESCRIPTION
Closes #403

Working as Bender (Backend Dev)

## Summary
Extracts `packages/core/src/engine/skill-vocabulary.ts` as the single canonical source for domain keyword sets. Both Mechanism A (`skill-resolver.ts`) and Mechanism B (`resolveConversationSkills.ts`) now import from it, eliminating silent vocabulary drift when one mechanism's terms are updated.

## Changes
- **New**: `packages/core/src/engine/skill-vocabulary.ts` — canonical keyword sets and regex patterns for docker, aks, cicd, auth, and database domains; exports `XXX_KEYWORDS` (substring arrays for Mechanism A), `XXX_PATTERNS` (RegExp[] for Mechanism B), and `isXxxRelated()` boolean helpers
- **Updated**: `skill-resolver.ts` — `GENERATE_KEYWORDS` and `DESIGN_KEYWORDS` spread from shared vocabulary; removes duplicate literals: `dockerfile`, `manifest`, `pipeline`, `ci/cd`, `workflow`, `oidc`, `credential`, `database`, `aks automatic`
- **Updated**: `resolveConversationSkills.ts` — `DOMAIN_PATTERNS` entries for `infra-docker`, `infra-aks`, `infra-cicd`, `auth`, `data-relational` now reference shared pattern arrays
- **Updated**: `engine/index.ts` — re-exports all vocabulary symbols for external consumers
- **New test**: `skill-vocabulary.test.ts` (34 tests) — verifies constants, helpers, and that both mechanisms respond to the same canonical terms

## Testing
All 918 tests pass (34 new). New test verifies vocabulary is single-sourced and both mechanisms react to shared terms.