### PR TITLE
refactor: deduplicate advancePhase() — move to @kickstart/core

### DIFF
--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -8,6 +8,7 @@ export {
   PHASE_DEFINITIONS,
   getPhaseDefinition,
   getPhaseOrder,
+  advancePhase,
 } from "./phases.js";
 
 export { resolveSkills } from "./skill-resolver.js";

--- a/packages/core/src/engine/phases.ts
+++ b/packages/core/src/engine/phases.ts
@@ -55,6 +55,11 @@ export const PHASE_DEFINITIONS: readonly PhaseDefinition[] = [
   },
 ] as const;
 
+/** Advance to the next phase, or return the same phase if already at the terminal phase. */
+export function advancePhase(phase: Phase): Phase {
+  return getPhaseDefinition(phase).nextPhase ?? phase;
+}
+
 /** Look up a phase definition by its ID. */
 export function getPhaseDefinition(phase: Phase): PhaseDefinition {
   const def = PHASE_DEFINITIONS.find((p) => p.id === phase);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export {
   PHASE_DEFINITIONS,
   getPhaseDefinition,
   getPhaseOrder,
+  advancePhase,
   resolveSkills,
   AUTO_CONTINUE_PREFIXES,
   AUTO_CONTINUE_MAX_CONSECUTIVE,

--- a/packages/mcp-server/src/tools/action.ts
+++ b/packages/mcp-server/src/tools/action.ts
@@ -10,6 +10,7 @@ import {
   getPhaseOrder,
   PHASE_DEFINITIONS,
   Phase,
+  advancePhase,
 } from "@kickstart/core";
 import type {
   SessionState,
@@ -63,12 +64,6 @@ export async function handleAction(
       label: getPhaseDefinition(phase).label,
       status: idx < currentIdx ? "complete" : idx === currentIdx ? "active" : "pending",
     }));
-  }
-
-  // Helper: advance to the next phase
-  function advancePhase(phase: Phase): Phase {
-    const def = PHASE_DEFINITIONS.find((p) => p.id === phase);
-    return def?.nextPhase ?? phase;
   }
 
   // Process action

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -21,7 +21,7 @@ import {
   Phase,
   getPhaseDefinition,
   getPhaseOrder,
-  PHASE_DEFINITIONS,
+  advancePhase,
   processResponse,
   resolveConversationSkills,
   defaultRegistry,
@@ -102,12 +102,6 @@ interface StreamDonePayload {
 
 function getSafeCurrentPhase(currentPhase: Phase | string): Phase {
   return normalizeConversePhase(currentPhase) ?? Phase.Discover;
-}
-
-/** Return the next phase after the given one, or the same phase if already at the end. */
-function advancePhase(currentPhase: Phase): Phase {
-  const def = PHASE_DEFINITIONS.find((p) => p.id === currentPhase);
-  return def?.nextPhase ?? currentPhase;
 }
 
 function extractSetupControlAction(


### PR DESCRIPTION
Closes #404
Depends on #412

## Summary
Moves the duplicated `advancePhase()` helper into `@kickstart/core/engine/phases` so both the web API and MCP server use a single authoritative implementation.

## Changes
- New export: `advancePhase(phase: Phase): Phase` in `packages/core/src/engine/phases.ts` (uses `getPhaseDefinition` internally — consistent with the module's own API)
- Re-exported from `packages/core/src/engine/index.ts` and `packages/core/src/index.ts`
- Removed local definition from `packages/web/api/src/functions/converse.ts` (also removed now-unused `PHASE_DEFINITIONS` import)
- Removed local definition from `packages/mcp-server/src/tools/action.ts` (kept `PHASE_DEFINITIONS` — still used for `isAtEnd` check on line ~200)
- Both call sites now import `advancePhase` from `@kickstart/core`

## Testing
All 1468 tests pass. `grep -rn "function advancePhase" packages/ --include="*.ts" | grep -v node_modules` returns exactly ONE definition.