### PR TITLE
docs: remove stale 'typed skill path dormant' warning

### DIFF
--- a/docs-site/docs/architecture/overview.md
+++ b/docs-site/docs/architecture/overview.md
@@ -88,8 +88,8 @@ Base catalog: `packages/core/src/prompts/component-catalog.ts`. Kit-contributed 
 `resolveSkillsAsync()` and `resolveSkillsFromList()` are exported from `@kickstart/core` and tested, but never called in any production handler. Only `resolveSkills()` is used. These inflate the public API surface without runtime callers.
 :::
 
-:::warning Typed Skill path is dormant
-`skill-resolver.ts` has two resolution paths: a typed `kit.skills[]` (Skill objects) and a legacy `kit.prompts[]`/`kit.phasePrompts[]` path. Neither production kit (`azure-kit.ts`, `github-kit.ts`) uses the typed path. The typed path is exercised only in tests.
+:::info Both skill paths are active
+**`azure-kit.ts` uses the typed `kit.skills[]` path** (Path 1) — it registers `skills: azureIacSkills` (see `azure-kit.ts:573`). **`github-kit.ts` uses the legacy `kit.prompts[]` / `kit.phasePrompts{}` path** (Path 2). Both paths are valid for kit authors. Consolidation of the two paths into a single mechanism is tracked as future work.
 :::
 
 :::note Two keyword systems with no shared vocabulary

--- a/docs-site/docs/architecture/skill-injection.md
+++ b/docs-site/docs/architecture/skill-injection.md
@@ -74,8 +74,8 @@ interface IntegrationKit {
 }
 ```
 
-:::warning Typed `Skill` path is dormant
-**Neither production kit (`azure-kit.ts`, `github-kit.ts`) uses `kit.skills[]`.** Both use `prompts[]` / `phasePrompts{}`. The typed path is exercised only in tests. In practice, 100% of runtime skill resolution goes through the legacy path. Anyone building an Agent SDK adapter who reads the interface and chooses the typed path will be using the non-production code path.
+:::info Both skill paths are active
+**`azure-kit.ts` uses the typed `kit.skills[]` path** (Path 1) — it registers `skills: azureIacSkills` (see `azure-kit.ts:573`). **`github-kit.ts` uses the legacy `kit.prompts[]` / `kit.phasePrompts{}` path** (Path 2). Both paths are valid for kit authors. Consolidation of the two paths into a single mechanism is tracked as future work.
 :::
 
 ### Public API


### PR DESCRIPTION
Closes #399

Working as Bender (Backend Dev)

## Summary
The `:::warning Typed Skill path is dormant` blocks were telling contributors to avoid `kit.skills[]` — but `azure-kit.ts` has been using it since IAC skills were added. Both skill paths are now active.

## Changes
- **skill-injection.md**: replaced `:::warning` with `:::info` noting both paths are live
- **overview.md**: same fix, surgical — only the skill-path warning block; component counts untouched (those belong to PR #396)
- **docs/architecture.md**: updated legacy doc section (lines 144–148) with same corrected info

## Verification
- `azure-kit.ts:573` — `skills: azureIacSkills` (typed path, Path 1)
- `github-kit.ts:52,80` — `prompts[]` / `phasePrompts{}` (legacy path, Path 2)