### PR TITLE
docs: fix phantom paths in getting-started + contributing

### DIFF
--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -11,14 +11,14 @@ Kickstart is built using the [Squad framework](./../) for AI-guided development.
 To add a component to the Kickstart catalog:
 
 1. Define the component type and data model in `packages/core/src/catalog/`
-2. Implement the React renderer in `packages/web/src/components/`
+2. Implement the React renderer in `packages/web/src/catalog/components/`
 3. Register the component in the catalog registry
 4. Update the system prompt to teach the AI when and how to use the new component
 5. Add documentation to `docs-site/docs/components/`
 
 ## Adding New Conversation Phases
 
-The conversation flow is defined in `packages/core/src/phases/`. To add a phase:
+The conversation flow is defined in `packages/core/src/engine/phases.ts`. To add a phase:
 
 1. Create a new phase definition file
 2. Add transition rules from adjacent phases

--- a/docs-site/docs/getting-started/project-structure.md
+++ b/docs-site/docs/getting-started/project-structure.md
@@ -9,24 +9,38 @@ Kickstart is organized as an npm workspaces monorepo.
 ```
 kickstart/
 ├── packages/
-│   ├── core/              # AI engine — phases, prompts, state machine, catalog
+│   ├── core/              # AI engine — phases, prompts, catalog, tools
 │   │   ├── src/
-│   │   │   ├── phases/    # Conversation phase definitions
+│   │   │   ├── engine/    # Phase definitions, state, skill resolver
+│   │   │   │   └── phases.ts  # Conversation phase definitions
 │   │   │   ├── prompts/   # System prompt templates
 │   │   │   ├── catalog/   # A2UI component catalog definitions
+│   │   │   ├── tools/     # LLM tool definitions
 │   │   │   └── index.ts   # Package entry point
 │   │   └── package.json
 │   │
-│   └── web/               # React frontend + Azure Functions API
-│       ├── src/            # React app source
-│       │   ├── vendor/     # Vendored A2UI v0.9 renderer
-│       │   ├── components/ # React components
-│       │   └── App.tsx     # Root component
-│       ├── api/            # Azure Functions (SWA managed)
-│       │   └── chat/       # /api/chat endpoint
-│       ├── css/            # Fluent 2 stylesheets
-│       ├── public/         # Static assets (icons, favicon)
-│       ├── dist/           # Vite build output
+│   ├── web/               # React frontend + Azure Functions API
+│   │   ├── src/            # React app source
+│   │   │   ├── vendor/     # Vendored A2UI renderer
+│   │   │   ├── catalog/    # A2UI catalog component implementations
+│   │   │   │   └── components/  # Rendered A2UI components (CodeBlock, AuthCard, …)
+│   │   │   ├── components/ # App-shell components (Layout, Sidebar, Topbar, …)
+│   │   │   ├── pages/      # Route-level pages (Chat, Playground, Landing, …)
+│   │   │   ├── hooks/      # React hooks (useStreaming, useNavigation, …)
+│   │   │   └── App.tsx     # Root component
+│   │   ├── api/            # Azure Functions (SWA managed)
+│   │   │   └── src/
+│   │   │       └── functions/  # Individual function handlers
+│   │   │           └── converse.ts  # /api/converse endpoint
+│   │   ├── public/         # Static assets (icons, favicon)
+│   │   ├── dist/           # Vite build output
+│   │   └── package.json
+│   │
+│   └── mcp-server/        # MCP server — exposes Kickstart tools via Model Context Protocol
+│       ├── src/
+│       │   ├── app/        # Server bootstrap and protocol handler
+│       │   ├── tools/      # MCP tool implementations
+│       │   └── index.ts    # Package entry point
 │       └── package.json
 │
 ├── docs-site/              # This documentation site (Docusaurus)
@@ -43,10 +57,10 @@ kickstart/
 
 The AI engine package. Contains:
 
-- **Phase definitions** — the 6-phase conversation flow (Discover → Design → Generate → Review → Handoff → Deploy)
+- **Phase definitions** — the 6-phase conversation flow (Discover → Design → Generate → Review → Handoff → Deploy), defined in `src/engine/phases.ts`
 - **System prompts** — templates that instruct the LLM on response format, tone, and behavior
 - **A2UI catalog** — component type definitions for the custom Kickstart catalog
-- **State machine** — tracks conversation phase transitions
+- **LLM tools** — tool definitions used by the AI engine
 
 This package has no UI dependencies and can be used independently.
 
@@ -55,9 +69,13 @@ This package has no UI dependencies and can be used independently.
 The frontend application and API layer. Contains:
 
 - **React SPA** — the main user interface, built with React 19 and Vite 6
-- **A2UI renderer** — vendored `@a2ui/react` v0.9 in `src/vendor/a2ui/`
-- **Azure Functions** — the `/api/chat` endpoint in `api/`
-- **Styles** — Fluent 2 design tokens in `css/`
+- **A2UI renderer** — vendored renderer in `src/vendor/`
+- **Catalog components** — A2UI component implementations in `src/catalog/components/`
+- **Azure Functions** — the `/api/converse` endpoint in `api/src/functions/converse.ts`
+
+### `packages/mcp-server`
+
+The Model Context Protocol (MCP) server. Exposes Kickstart's AI tools to MCP-compatible clients (e.g. GitHub Copilot, Claude Desktop). Lives alongside `core` and `web` in the monorepo.
 
 ### `docs-site`
 


### PR DESCRIPTION
Closes #394

Working as Fry (Frontend Dev + docs)

## Summary
Rewrites `project-structure.md` and `contributing.md` to match the actual repo layout. Every directory path shown in these docs is now verified against `ls` on main.

## Changes
- **project-structure.md**: Removed 3 phantom paths (`packages/core/src/phases/`, `packages/web/api/chat/`, `packages/web/css/`), corrected paths to real locations, added `packages/mcp-server/` with full description
- **contributing.md**: Fixed A2UI component implementation path to `packages/web/src/catalog/components/`; fixed phases reference from phantom dir to `packages/core/src/engine/phases.ts`

## Testing
Docs-only change. Verified with grep sweep — zero occurrences of all 4 phantom path patterns in docs-site/.