### PR TITLE
docs: fix component-count drift (33 base, 22 custom)

### DIFF
--- a/docs-site/docs/architecture/overview.md
+++ b/docs-site/docs/architecture/overview.md
@@ -21,7 +21,7 @@ kickstart/
 │   │   ├── api/           Azure Functions (converse, health, proxies)
 │   │   │   └── src/lib/   session-store, openai-client, model-router, rate-limiter
 │   │   └── src/
-│   │       ├── catalog/   A2UI component implementations (28+ components)
+│   │       ├── catalog/   A2UI component implementations (22 custom; base catalog has 33 entries — asserted in `component-catalog.test.ts`)
 │   │       ├── components/ Chat UI, FileEditor sidebar, Landing
 │   │       └── services/  virtual-fs.ts (browser-side virtual file store with IndexedDB persistence)
 │   └── mcp-server/    @kickstart/mcp-server — optional IDE adapter

--- a/docs-site/docs/components/custom-catalog.md
+++ b/docs-site/docs/components/custom-catalog.md
@@ -4,17 +4,19 @@ sidebar_position: 1
 
 # Custom Kickstart Catalog
 
-Kickstart extends the A2UI v0.9 basic catalog with **16 custom components** designed for the AKS deployment onboarding experience. These components are registered in `packages/web/src/catalog/kickstart-catalog.ts`.
+Kickstart extends the A2UI v0.9 basic catalog with **22 custom components** designed for the AKS deployment onboarding experience. These components are registered in `packages/web/src/catalog/kickstart-catalog.ts`.
 
 ## Component Categories
 
 | Category | Components |
 |----------|-----------|
-| **Forms & Input** | RadioGroup, FormGroup |
-| **Content** | CodeBlock, ProgressSteps, Markdown |
-| **GitHub** | GitHubLoginCard, GitHubRepoPicker, GitHubAction, GitHubCommit |
-| **Azure** | AzureLoginCard, AzureResourcePicker, AzureResourceForm |
-| **Deployment** | ArchitectureDiagram, FileEditor, CostEstimate, DeploymentProgress |
+| **Auth** | AuthCard, AzureLoginCard, GitHubLoginCard |
+| **Forms & Input** | RadioGroup, FormGroup, Questionnaire |
+| **Content & Display** | CodeBlock, Markdown, SummaryCard, DecisionCard |
+| **Navigation & Progress** | ProgressSteps, SteppedCarousel, GenerationProgress |
+| **GitHub** | GitHubRepoPicker, GitHubAction, GitHubCommit |
+| **Azure** | AzureResourcePicker, AzureResourceForm, AzureAction |
+| **Deployment** | ArchitectureDiagram, FileEditor, CostEstimate |
 
 ## Forms & Input
 
@@ -185,6 +187,6 @@ Interactive code editor for reviewing and editing generated deployment files. Ba
 
 Monthly cost breakdown by Azure service with a total. Line items include name, SKU, and monthly cost. Populated from the Azure Retail Prices API via `estimate_cost` tool.
 
-### DeploymentProgress
+### GenerationProgress
 
-Multi-step deployment tracker with per-step status (pending / running / success / error / skipped) and an overall status indicator. Used during the Deploy phase to show live state.
+Multi-step generation and deployment tracker with per-step status (pending / running / success / error / skipped) and an overall status indicator. Used during the Generate and Deploy phases to show live progress.


### PR DESCRIPTION
Closes #396

Working as Fry (Frontend Dev + docs)

## Summary
Fixes stale component counts in two docs files.

- Base catalog: **33** entries (asserted by `component-catalog.test.ts:264`)
- Custom kickstart catalog: **22** renderers (`packages/web/src/catalog/components/*.tsx`)

## Changes
- `overview.md`: `28+` → `22 custom; base catalog has 33 entries — asserted in component-catalog.test.ts`
- `custom-catalog.md`: `16 custom components` → `22 custom components`; category table rebuilt to enumerate all 22 `.tsx` files; `DeploymentProgress` renamed to `GenerationProgress` (correct file name)

## Testing
Docs-only change. Verified with `grep` — no stale counts remain in either file.