### PR TITLE
docs: rewrite FSM docs to reflect completed cleanup

### DIFF
--- a/docs-site/docs/architecture/fsm.md
+++ b/docs-site/docs/architecture/fsm.md
@@ -2,102 +2,87 @@
 sidebar_position: 3
 ---
 
-# FSM — Confirmed for Deletion
+# Phase System
 
-:::danger Scheduled for deletion
-`machine.ts` and `phases.ts` are confirmed for deletion per architectural decision in `.squad/decisions.md`. Do not add new dependencies on the FSM. The migration plan is below.
+Kickstart's conversation engine uses a lightweight, LLM-driven phase system to guide users from project discovery through deployment.
+
+:::note Historical context
+An earlier version of the codebase included a TypeScript state machine (`machine.ts`) with explicit transition functions, event types, and condition fields (`entryConditions`, `exitConditions`, `promptTemplate`) on `PhaseDefinition`. This was removed in PR #412 because the machine was never exercised at runtime — the LLM navigated phases entirely from its system prompt. The reasoning is in `.squad/decisions.md`.
 :::
 
 ---
 
-## What Is Being Deleted
+## Current State
 
-| File | Lines | Purpose |
-|------|-------|---------|
-| `packages/core/src/engine/machine.ts` | 157 | Pure-function state machine: `transition()`, `handleImplicitFlags()`, `canAdvance()` |
-| `packages/core/src/engine/phases.ts` | ~120 | Phase definitions with `exitConditions`, `entryConditions`, prompt templates |
-| `ConversationState.engineState` | — | FSM state slice in session: `currentPhase`, `phaseStatuses`, `phaseData` |
-| `ConversationEvent` type | — | `USER_MESSAGE`, `PHASE_COMPLETE` enum used by machine |
-| `PhaseStatus` type | — | `"active"` / `"complete"` string enum read in `converse.ts` and `action.ts` |
+### Phase Catalog
 
-### Dead Code That Goes Away Automatically
-
-:::note
-These fields and code paths are currently in the codebase but never exercised at runtime. FSM removal deletes them without any behavioral change.
-:::
-
-- `exitConditions` / `entryConditions` — defined in `PhaseDefinition`, never read at runtime
-- `PHASE_COMPLETE` event — handled in `machine.ts`, never emitted by any handler
-- `phaseData` on `ConversationState` — written only by the dead `PHASE_COMPLETE` path, never read
-- `_phaseData` param in `canAdvance()` — unused placeholder
-
----
-
-## What Replaces It
-
-### Plain Phase String
+Phases are defined in `packages/core/src/engine/phases.ts` as a static array:
 
 ```typescript
-// Before: session.engineState.currentPhase (FSM-managed enum)
-// After:  session.state.currentPhase (plain string, LLM sets directly via JSON envelope)
+export interface PhaseDefinition {
+  id: Phase;
+  label: string;
+  description: string;
+  nextPhase: Phase | null;
+}
 ```
 
-### Numbered Prompt Blocks
+The six phases in conversation order:
 
-Phase progression moves from `phases.ts` TypeScript structs into `═══ N. SECTION ═══` narrative blocks in the system prompt (pattern from `sabbour/adaptive-ui-try-aks`):
+| Phase | Label | nextPhase |
+|-------|-------|-----------|
+| `discover` | Discover | `design` |
+| `design` | Design | `generate` |
+| `generate` | Generate | `review` |
+| `review` | Review | `handoff` |
+| `handoff` | Handoff | `deploy` |
+| `deploy` | Deploy | `null` (terminal) |
 
-```
-═══ 1. BEFORE YOU START ═══
-...
-═══ 2. GATHER REQUIREMENTS ═══
-...
-═══ 3. GENERATE ═══
-...
-```
+### Session State
 
-The full sequence is always present. The LLM reads the numbered blocks and knows its position from conversation history.
-
-### Model Routing — Interface Unchanged
-
-`resolveConverseModelRoute` reads a phase string. Only the source changes:
+The current phase is stored as a plain string on the server-side session:
 
 ```typescript
-// Before: session.engineState.currentPhase  (FSM enum)
-// After:  session.state.currentPhase         (plain string)
+session.state.currentPhase  // e.g. "generate"
 ```
 
-`routingPhaseTrusted` flag is unchanged. `Phase.Generate` enum becomes `"generate"` string literal.
+This is the single source of truth. There is no separate FSM state slice, no `phaseStatuses` map, and no `phaseData` bag.
 
-### `filesComplete` Flag — Unchanged
+### Phase Advancement
 
-The `filesComplete` auto-continue flag is **not FSM**. It is a client-side reactive check. It stays exactly as-is.
+`advancePhase()` in `converse.ts` looks up the current phase in `PHASE_DEFINITIONS` and returns `nextPhase`:
 
----
+```typescript
+function advancePhase(currentPhase: Phase): Phase {
+  const def = PHASE_DEFINITIONS.find((p) => p.id === currentPhase);
+  return def?.nextPhase ?? currentPhase;
+}
+```
 
-## Migration Checklist
+The LLM signals that a phase is complete via `phaseComplete: true` in its JSON response envelope. The `converse` handler reads this flag and calls `advancePhase()` — there is no event system or transition guard.
 
-- [ ] Delete `packages/core/src/engine/machine.ts`
-- [ ] Delete `packages/core/src/engine/phases.ts`
-- [ ] Remove `ConversationState.engineState` slice; add `state: Record<string, string>`
-- [ ] Remove `ConversationEvent`, `PhaseStatus`, `PhaseDefinition` types from `types.ts`
-- [ ] Update `system-prompt.ts`: replace phase-template selection with numbered blocks
-- [ ] Update `converse.ts`: replace `session.engineState.currentPhase` with `session.state.currentPhase`
-- [ ] Update `converse-model-router.ts`: replace `Phase.Generate` enum with `"generate"` string
-- [ ] Update `session-store.ts`: remove FSM state from session initializer and rehydration
-- [ ] Delete `packages/core/src/__tests__/machine.test.ts`
-- [ ] Delete `packages/core/src/__tests__/phases.test.ts`
-- [ ] Update `packages/core/src/engine/index.ts`: remove `machine` and `phases` exports
-- [ ] Verify `resolveSkills(phase, kits)` and `resolveConversationSkills(message, phase, context)` — both accept phase strings; no changes needed to either function
+### How the LLM Knows Its Phase
+
+The system prompt includes the current phase identifier and the `description` from its `PhaseDefinition`. This tells the LLM what to focus on and when to signal completion.
 
 ---
 
-## Why
+## What Was Removed
 
-The FSM added TypeScript enforcement for phase transitions that:
+The original `machine.ts` implemented a pure-function state machine with:
 
-1. **Was never actually used** — `exitConditions` and `entryConditions` are typed but not read at runtime
-2. **Duplicated the LLM's judgment** — the LLM navigates transitions from its system prompt, not the state machine
-3. **Added coupling** — `converse.ts` called `transition()` even though the LLM was the real decision-maker
-4. **Has dead internal paths** — `PHASE_COMPLETE` is handled but never emitted; `phaseData` is written by a dead path and never read
+- `transition(state, event)` — pure transition function
+- `handleImplicitFlags()` — auto-advance on LLM signals
+- `canAdvance()` — gate check before advancing
+- `ConversationState` — FSM state slice (`phaseStatuses`, `phaseData`)
+- `ConversationEvent` enum — `USER_MESSAGE`, `PHASE_COMPLETE`
 
-Replacing it with `session.state.currentPhase` removes the redundant layer while keeping all behavior.
+`PhaseDefinition` also carried `entryConditions`, `exitConditions`, and `promptTemplate` fields — all typed, none read at runtime.
+
+The machine was removed because it duplicated the LLM's own phase judgment without adding correctness guarantees.
+
+---
+
+## Future Direction
+
+Phase behavior is expected to evolve significantly with the Agents SDK integration. See issue [#330](https://github.com/sabbour/kickstart/issues/330) for the planned redesign. The current plain-string approach is intentionally minimal — a clean baseline before that work begins.

--- a/docs-site/docs/architecture/overview.md
+++ b/docs-site/docs/architecture/overview.md
@@ -12,7 +12,7 @@ Kickstart is a monorepo with three packages — a shared core engine, a React SP
 kickstart/
 ├── packages/
 │   ├── core/          @kickstart/core — shared TypeScript engine
-│   │   ├── engine/        Skill Resolver (machine.ts ⚠️ DELETE, skill-resolver.ts)
+│   │   ├── engine/        phase catalog (phases.ts), skill resolver (skill-resolver.ts)
 │   │   ├── kits/          IntegrationKit interface + defaultKitRegistry
 │   │   ├── prompts/       buildSystemPrompt(), phase templates, component catalog
 │   │   ├── services/      resolveConversationSkills (per-turn injection)
@@ -39,7 +39,7 @@ POST /api/converse { sessionId, message, messages? }
   5. buildSystemPrompt({ phase, kitPrompts, artifactSummary })
   6. resolveConversationSkills(msg)     ← per-turn domain injection (Mechanism B)
   7. Call Azure OpenAI
-  8. Parse JSON → handleImplicitFlags() → may advance FSM phase
+  8. Parse JSON → if phaseComplete: true → advancePhase()
   9. Extract FileEditor artifacts → session store
  10. Stream SSE events to client
 ```
@@ -51,7 +51,7 @@ See [Prompt Pipeline](./prompt-pipeline.md) for the full assembly order with cod
 | What | Where | Lifetime |
 |------|-------|----------|
 | Conversation messages | Server (memory) | 1 hour |
-| FSM phase state | Server (memory) | 1 hour |
+| Phase string (`currentPhase`) | Server session | 1 hour |
 | Generated artifact metadata | Server (memory) | 1 hour |
 | Full generated file content | Client message history | Browser session |
 | Virtual FS (file content for sidebar) | Client memory + optional IndexedDB (`kickstart-vfs`) | No TTL |
@@ -65,11 +65,7 @@ See [Prompt Pipeline](./prompt-pipeline.md) for the full assembly order with cod
 - **Azure OpenAI GPT-5.4** for Generate phase when server-trusted (`AZURE_OPENAI_CODEX_DEPLOYMENT`)
 - Model selection is trust-based, not phase-based — see [Prompt Pipeline: Model Routing](./prompt-pipeline.md#model-routing)
 - Two skill injection mechanisms run every turn — see [Skill Injection](./skill-injection.md)
-- FSM (`machine.ts`, `phases.ts`) **is scheduled for deletion** — see [FSM](./fsm.md)
-
-:::danger FSM scheduled for deletion
-`machine.ts` and `phases.ts` are confirmed for deletion per architectural decision in `.squad/decisions.md`. The FSM is being replaced by a plain `session.state.currentPhase` string + numbered `═══ N. SECTION ═══` blocks in the system prompt. Do not add new FSM dependencies. See [FSM](./fsm.md) for the migration plan.
-:::
+- Phase tracking: `session.state.currentPhase` (plain string) — see [Phase System](./fsm.md)
 
 ## A2UI Component Catalog
 
@@ -117,8 +113,6 @@ Garbage collection
 
 ## What Should Be Cleaned Up
 
-1. **Delete `machine.ts` and `phases.ts`** (confirmed architectural decision) — see [FSM](./fsm.md) for migration checklist.
-2. **`resolveSkillsAsync` / `resolveSkillsFromList`** — remove or mark `@internal` before Agent SDK integration.
-3. **Typed `Skill` path in `skill-resolver.ts`** — consolidate to one path; both existing kits use legacy.
-4. **Keyword vocabulary** — extract a shared constants module referenced by both mechanisms.
-5. **`exitConditions`/`entryConditions` in `phases.ts`** — moot on FSM removal; will be deleted with `phases.ts`.
+1. **`resolveSkillsAsync` / `resolveSkillsFromList`** — remove or mark `@internal` before Agent SDK integration.
+2. **Typed `Skill` path in `skill-resolver.ts`** — consolidate to one path; both existing kits use legacy.
+3. **Keyword vocabulary** — extract a shared constants module referenced by both mechanisms.

--- a/docs-site/docs/extending/conversation-phases.md
+++ b/docs-site/docs/extending/conversation-phases.md
@@ -4,15 +4,13 @@ sidebar_position: 2
 
 # Conversation Phases
 
-Kickstart guides users through a multi-phase conversation — Discover, Design, Generate, Review, Handoff, Deploy. The phase engine is a pure-function state machine that determines what the AI focuses on, which skills are available, and how the system prompt is assembled at each step.
-
-This guide explains the phase system and walks you through adding a new phase.
+Kickstart guides users through six phases — Discover, Design, Generate, Review, Handoff, Deploy. This guide explains how the phase system works and how to extend it.
 
 ## How Phases Work
 
 ### The Phase Enum
 
-Every phase is identified by a string-valued enum, defined in `packages/core/src/engine/types.ts`:
+Every phase is a string constant defined in `packages/core/src/engine/types.ts`:
 
 ```typescript
 export enum Phase {
@@ -27,54 +25,47 @@ export enum Phase {
 
 ### Phase Definitions
 
-Each phase has a `PhaseDefinition` that describes its purpose, transition conditions, and system prompt template. Definitions live in `packages/core/src/engine/phases.ts`:
+Each phase has a `PhaseDefinition` in `packages/core/src/engine/phases.ts`:
 
 ```typescript
 export interface PhaseDefinition {
   id: Phase;
   label: string;
   description: string;
-  entryConditions: string[];  // Human-readable — used in system prompt
-  exitConditions: string[];   // Human-readable — used in system prompt
-  promptTemplate: string;     // Injected as Layer 3 of the system prompt
-  nextPhase: Phase | null;    // null = terminal phase
+  nextPhase: Phase | null;   // null = terminal phase
 }
 ```
 
-The `PHASE_DEFINITIONS` array in `phases.ts` is the authoritative phase order. The first entry is the initial phase; `nextPhase` chains them.
+The `PHASE_DEFINITIONS` array is the authoritative phase order. The first entry is the initial phase; `nextPhase` chains them together.
 
-### The State Machine
+### Session State
 
-`packages/core/src/engine/machine.ts` implements a pure state machine:
+The current phase is a plain string stored on the server-side session:
 
 ```typescript
-export interface ConversationState {
-  currentPhase: Phase;
-  phaseStatus: Record<Phase, "pending" | "active" | "complete" | "skipped">;
-  phaseData: Record<Phase, unknown>;
-  isComplete: boolean;
-}
-
-// Pure transition function — no side effects
-transition(state: ConversationState, event: PhaseEvent): ConversationState
+session.state.currentPhase  // e.g. "generate"
 ```
 
-Valid events:
+This is the single source of truth. No FSM state slice, no `phaseStatuses` map.
 
-| Event | Description |
-|---|---|
-| `START` | Begin the conversation (activates first phase) |
-| `ADVANCE` | Move to `nextPhase` |
-| `SKIP` | Skip current phase, same as ADVANCE but marks it `skipped` |
-| `RESET` | Return to the first phase |
-| `USER_INPUT` | Notify state of new user message |
-| `PHASE_COMPLETE` | Mark current phase complete without advancing |
+### Phase Advancement
 
-### Auto-Advance
+Phase transitions happen in `converse.ts` when the LLM returns `phaseComplete: true` in its JSON response envelope:
 
-The LLM can trigger a phase transition autonomously. When the LLM response includes `phaseComplete: true` in the JSON envelope, `handleImplicitFlags()` in `machine.ts` fires a `PHASE_COMPLETE` event automatically — no user action required.
+```typescript
+// converse.ts — simplified
+if (llmResponse.phaseComplete) {
+  session.state.currentPhase = advancePhase(session.state.currentPhase);
+}
+```
 
-Similarly, A2UI actions with `navigate:` or `complete:` prefixes (handled in `packages/core/src/engine/auto-continue.ts`) can trigger transitions from button clicks in the UI.
+`advancePhase()` looks up the current phase in `PHASE_DEFINITIONS` and returns `nextPhase`. There is no event system or transition guard — the LLM's signal is the only trigger.
+
+A2UI actions with `navigate:` or `complete:` prefixes (handled in `packages/core/src/engine/auto-continue.ts`) can also trigger phase transitions from button clicks in the UI.
+
+### How the LLM Navigates Phases
+
+The system prompt includes the current phase identifier and the `description` from its `PhaseDefinition`. The LLM reads this context, determines when the phase goals are met, and signals `phaseComplete: true`. There are no TypeScript-enforced entry or exit conditions — the LLM decides.
 
 ### Skill Resolution
 
@@ -84,7 +75,7 @@ Skills are filtered by phase. `packages/core/src/engine/skill-resolver.ts` runs 
 2. **keywordActivation** — boosts skills that match keywords in the user message
 3. **priorityOrder** — sorts remaining skills by priority
 
-Convenience groups are exported for registration:
+Phase group constants for skill registration:
 
 ```typescript
 export const DISCOVERY_PHASES  = [Phase.Discover];
@@ -95,15 +86,15 @@ export const DEPLOYMENT_PHASES = [Phase.Handoff, Phase.Deploy];
 
 ### System Prompt Architecture
 
-The system prompt builder (`packages/core/src/prompts/system-prompt.ts`) stacks three layers per turn:
+The system prompt builder (`packages/core/src/prompts/system-prompt.ts`) assembles context per turn:
 
 | Layer | Content |
 |---|---|
-| Layer 1 | Active skills (resolved for current phase) |
-| Layer 2 | Copilot extension instructions |
-| Layer 3 | Phase-specific `promptTemplate` from `PhaseDefinition` |
+| Active skills | Resolved for current phase (Mechanism A) |
+| Copilot extension instructions | Static per-turn context |
+| Per-turn domain injection | Resolved from user message (Mechanism B) |
 
-This means the `promptTemplate` you write in a `PhaseDefinition` is injected verbatim as the innermost context ring for that phase.
+Phase context (current phase + description) is included in the prompt so the LLM knows where it is in the conversation.
 
 ---
 
@@ -125,42 +116,24 @@ export enum Phase {
 }
 ```
 
-### Step 2 — Define the phase
+### Step 2 — Add the phase definition
 
-Open `packages/core/src/engine/phases.ts` and add a `PhaseDefinition` to the `PHASE_DEFINITIONS` array at the correct position. Update the `nextPhase` of the preceding phase to point to your new one:
+Open `packages/core/src/engine/phases.ts` and insert a `PhaseDefinition` at the correct position in `PHASE_DEFINITIONS`. Update the `nextPhase` of the preceding entry to point to your new phase:
 
 ```typescript
 {
   id: Phase.Validate,
   label: "Validate",
-  description: "Verify that the proposed architecture meets the user's requirements before generating artifacts.",
-  entryConditions: [
-    "Architecture design is complete",
-    "User has confirmed service selection",
-  ],
-  exitConditions: [
-    "User has approved the architecture",
-    "All required fields are populated",
-  ],
-  promptTemplate: `
-You are in the VALIDATE phase. Your goal is to confirm the architecture before generating files.
-
-Review the proposed design with the user:
-- Confirm service tiers and scaling settings
-- Highlight any cost or security implications
-- Ask for explicit approval before proceeding
-
-When the user approves, set phaseComplete: true in your response envelope.
-  `.trim(),
+  description: "Verify that the proposed architecture meets requirements before generating artifacts.",
   nextPhase: Phase.Generate,
 },
 ```
 
-Also update the `Design` phase definition so its `nextPhase` points to `Phase.Validate` instead of `Phase.Generate`.
+Also update the `Design` entry so its `nextPhase` is `Phase.Validate`.
 
 ### Step 3 — Register skills for the new phase
 
-If you have skills that should be active during this phase, add `Phase.Validate` to their `phases` array in your `IntegrationKit` definitions. You can also define a new phase group constant in `skill-resolver.ts`:
+Add `Phase.Validate` to the `phases` array of any skills that should activate during this phase. Define a phase group constant in `skill-resolver.ts` if needed:
 
 ```typescript
 export const VALIDATE_PHASES = [Phase.Validate];
@@ -168,7 +141,7 @@ export const VALIDATE_PHASES = [Phase.Validate];
 
 ### Step 4 — Add phase-specific prompts to kits (optional)
 
-If an `IntegrationKit` needs to inject additional context during your phase, add it to `phasePrompts`:
+If an `IntegrationKit` needs to inject extra context during your phase, use `phasePrompts`:
 
 ```typescript
 const myKit: IntegrationKit = {
@@ -183,23 +156,7 @@ const myKit: IntegrationKit = {
 
 ### Step 5 — Write tests
 
-Add test cases to:
-
-- `packages/core/src/__tests__/phases.test.ts` — verify your `PhaseDefinition` is well-formed, `entryConditions` and `exitConditions` are populated, `nextPhase` chains correctly
-- `packages/core/src/__tests__/machine.test.ts` — verify state transitions flow through your new phase correctly, auto-advance works, SKIP routes past it
-
-```typescript
-it("transitions through Validate phase", () => {
-  const state = transition(initialState, { type: "START" });
-  // advance to Validate
-  const validated = transition(
-    transition(state, { type: "ADVANCE" }), // Design
-    { type: "ADVANCE" }                      // Validate
-  );
-  expect(validated.currentPhase).toBe(Phase.Validate);
-  expect(validated.phaseStatus[Phase.Validate]).toBe("active");
-});
-```
+Add test cases to `packages/core/src/__tests__/phases.test.ts` to verify your `PhaseDefinition` is well-formed and `nextPhase` chains correctly.
 
 ---
 
@@ -208,10 +165,7 @@ it("transitions through Validate phase", () => {
 | File | Purpose |
 |---|---|
 | `packages/core/src/engine/types.ts` | `Phase` enum and `PhaseDefinition` interface |
-| `packages/core/src/engine/phases.ts` | `PHASE_DEFINITIONS` array — phase order and templates |
-| `packages/core/src/engine/machine.ts` | State machine: `ConversationState`, `transition()`, `handleImplicitFlags()` |
+| `packages/core/src/engine/phases.ts` | `PHASE_DEFINITIONS` — phase catalog and order |
 | `packages/core/src/engine/skill-resolver.ts` | Phase-aware skill filtering and phase group constants |
 | `packages/core/src/engine/auto-continue.ts` | A2UI action → phase transition wiring |
-| `packages/core/src/prompts/system-prompt.ts` | 3-layer system prompt assembly |
-| `packages/core/src/__tests__/phases.test.ts` | Phase definition tests |
-| `packages/core/src/__tests__/machine.test.ts` | State machine transition tests |
+| `packages/core/src/prompts/system-prompt.ts` | System prompt assembly including phase context |


### PR DESCRIPTION
Closes #398
Depends on #412

## Summary
Rewrites the FSM architecture docs and conversation-phases extender guide to reflect the actual current state after PR #412 completed the FSM removal. No more 'scheduled for deletion' — the machine is gone.

## Changes
- **fsm.md**: Renamed intent to "Phase System". Historical context callout, current state description (plain string, phases.ts catalog, advancePhase() in converse.ts), future direction link to #330
- **conversation-phases.md**: Full rewrite — no entryConditions/exitConditions/promptTemplate, no machine.ts references. Accurate how-to for adding phases with current PhaseDefinition shape
- **overview.md** (surgical): machine.ts removed from package tree, FSM state table row updated, FSM danger callout removed, AI Engine FSM line replaced, two completed cleanup items removed
- **docs/fsm.md**: Converted to redirect stub — migration is done

## What's NOT changed
- Component counts section (PR #396)
- Skill-path section (PR #399)

⚠️ Working as Bender (Backend Dev)