### PR TITLE
fix(core): inject appDefinition, azureContext, repoInfo into system prompt

### DIFF
--- a/packages/core/src/__tests__/system-prompt-boundary.test.ts
+++ b/packages/core/src/__tests__/system-prompt-boundary.test.ts
@@ -92,6 +92,15 @@ describe("buildSystemPrompt — prompt injection boundary", () => {
     expect(prompt).toContain("<<<USER_CONTEXT_END>>>");
   });
 
+  it("injects azureContext as ## Azure Context section", () => {
+    const prompt = buildSystemPrompt({
+      phase: Phase.Deploy,
+      azureContext: { subscriptionId: "sub-abc", location: "eastus" } as never,
+    });
+    expect(prompt).toContain("## Azure Context");
+    expect(prompt).toContain("sub-abc");
+  });
+
   it("wraps githubContext with boundary markers", () => {
     const prompt = buildSystemPrompt({
       phase: Phase.Discover,
@@ -99,6 +108,25 @@ describe("buildSystemPrompt — prompt injection boundary", () => {
     });
     expect(prompt).toContain("<<<USER_CONTEXT_START>>>");
     expect(prompt).toContain("<<<USER_CONTEXT_END>>>");
+  });
+
+  it("injects githubContext as ## Repository Info section", () => {
+    const prompt = buildSystemPrompt({
+      phase: Phase.Handoff,
+      githubContext: { owner: "sabbour", repo: "kickstart" } as never,
+    });
+    expect(prompt).toContain("## Repository Info");
+    expect(prompt).toContain("sabbour");
+    expect(prompt).toContain("kickstart");
+  });
+
+  it("injects appDefinition full JSON as ## App Definition section", () => {
+    const prompt = buildSystemPrompt({
+      phase: Phase.Generate,
+      appDefinition: { name: "my-app", runtime: "node" as never },
+    });
+    expect(prompt).toContain("## App Definition");
+    expect(prompt).toContain("my-app");
   });
 
   it("neutralizes delimiter injection in appDefinition values", () => {

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -751,6 +751,19 @@ export function buildSystemPrompt(context: SystemPromptContext): string {
   // Previously this was driven by per-phase promptTemplates; now injected uniformly.
   if (context.appDefinition && Object.keys(context.appDefinition).length > 0) {
     parts.push(`\n## Collected App Info\n\n${vars["knownInfo"]}`);
+    parts.push(`\n## App Definition\n\n${vars["appDefinition"]}`);
+  }
+
+  // Inject Azure subscription/resource context so the LLM can reference real
+  // resource names, locations, and subscription IDs in DEPLOY/REVIEW phases.
+  if (context.azureContext) {
+    parts.push(`\n## Azure Context\n\n${vars["azureContext"]}`);
+  }
+
+  // Inject GitHub repo context so the LLM can reference the real repo owner,
+  // name, and default branch in the HANDOFF phase.
+  if (context.githubContext) {
+    parts.push(`\n## Repository Info\n\n${vars["repoInfo"]}`);
   }
 
   // Artifact summary — gives the LLM running context of generated files.


### PR DESCRIPTION
Closes #429

Working as Fry (Frontend Dev)

## Summary
Context variables built in `buildSystemPrompt()` were computed but never appended to prompt parts. The LLM narrative referenced `appDefinition`, `azureContext`, and `repoInfo` as injected but only `knownInfo` (a formatted bullet list) was actually pushed. This silently degraded LLM response quality in GENERATE, HANDOFF, and DEPLOY phases.

## Changes
- **`packages/core/src/prompts/system-prompt.ts`**: After `## Collected App Info`, append:
  - `## App Definition` — full JSON of `appDefinition` (gives GENERATE structured access to all fields)
  - `## Azure Context` — full JSON of `azureContext` when present (DEPLOY phase)
  - `## Repository Info` — full JSON of `githubContext` when present (HANDOFF phase)
- **`packages/core/src/__tests__/system-prompt-boundary.test.ts`**: 3 new assertions verifying each section header and its content appear in the built prompt.

## Testing
- All 917 core tests pass (3 new assertions added)
- `npm run build` clean (TypeScript, no errors)

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)