### PR TITLE
fix(core): make vocabulary arrays readonly; keep as internal-only exports

### DIFF
--- a/packages/core/src/engine/skill-vocabulary.ts
+++ b/packages/core/src/engine/skill-vocabulary.ts
@@ -25,7 +25,7 @@ export const DOCKER_KEYWORDS = [
 ] as const;
 
 /** Regex patterns for Docker-related user messages (Mechanism B). */
-export const DOCKER_PATTERNS: RegExp[] = [
+export const DOCKER_PATTERNS: readonly RegExp[] = [
   /\bdocker(file)?\b/i,
   /\bcontainer\b/i,
   /\bimage\b.*\btag\b/i,
@@ -48,7 +48,7 @@ export const AKS_KEYWORDS = [
 ] as const;
 
 /** Regex patterns for AKS/Kubernetes-related user messages (Mechanism B). */
-export const AKS_PATTERNS: RegExp[] = [
+export const AKS_PATTERNS: readonly RegExp[] = [
   /\baks\b/i,
   /\bkubernetes\b/i,
   /\bk8s\b/i,
@@ -74,7 +74,7 @@ export const CICD_KEYWORDS = [
 ] as const;
 
 /** Regex patterns for CI/CD-related user messages (Mechanism B). */
-export const CICD_PATTERNS: RegExp[] = [
+export const CICD_PATTERNS: readonly RegExp[] = [
   /\bci\/?cd\b/i,
   /\bgithub actions?\b/i,
   /\bpipeline\b/i,
@@ -97,7 +97,7 @@ export const AUTH_KEYWORDS = [
 ] as const;
 
 /** Regex patterns for auth/identity-related user messages (Mechanism B). */
-export const AUTH_PATTERNS: RegExp[] = [
+export const AUTH_PATTERNS: readonly RegExp[] = [
   /\bauth(entication|orization)?\b/i,
   /\blogin\b/i,
   /\boauth\b/i,
@@ -123,7 +123,7 @@ export const DATABASE_KEYWORDS = [
 ] as const;
 
 /** Regex patterns for relational-database-related user messages (Mechanism B). */
-export const DATABASE_RELATIONAL_PATTERNS: RegExp[] = [
+export const DATABASE_RELATIONAL_PATTERNS: readonly RegExp[] = [
   /\bpostgres(ql)?\b/i,
   /\bmysql\b/i,
   /\bsql\b/i,

--- a/packages/core/src/services/resolveConversationSkills.ts
+++ b/packages/core/src/services/resolveConversationSkills.ts
@@ -89,7 +89,7 @@ type Domain =
   | "component-table"
   | "component-chart";
 
-const DOMAIN_PATTERNS: Array<{ domain: Domain; patterns: RegExp[] }> = [
+const DOMAIN_PATTERNS: Array<{ domain: Domain; patterns: readonly RegExp[] }> = [
   {
     domain: "stack-node",
     patterns: [/\bnode(\.?js)?\b/i, /\btypescript\b/i, /\bexpress\b/i, /\bnestjs\b/i, /\bnpm\b/i],


### PR DESCRIPTION
Closes #431

## Summary
All `*_PATTERNS` constants in `skill-vocabulary.ts` are now typed as `readonly RegExp[]`, preventing accidental mutation of shared arrays. `*_KEYWORDS` were already effectively readonly via `as const`.

A secondary type fix was required in `resolveConversationSkills.ts`: the `DOMAIN_PATTERNS` table's `patterns` field was widened to `readonly RegExp[]` so the narrower vocabulary types assign cleanly.

## Changes
- `packages/core/src/engine/skill-vocabulary.ts` — 5 `*_PATTERNS` constants: `RegExp[]` → `readonly RegExp[]`
- `packages/core/src/services/resolveConversationSkills.ts` — `DOMAIN_PATTERNS` patterns field: `RegExp[]` → `readonly RegExp[]`

## Public API decision
No consumers outside `packages/core` import these symbols (verified by grep across the full workspace). Symbols remain exported from `engine/index.ts` (internal barrel) but are **not** added to the public `src/index.ts` — they are an implementation detail of the skill-injection mechanism.

## Testing
- Build: `tsc` passes with zero errors
- Tests: 914/914 pass (`npm test -w packages/core`)

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)