### PR TITLE
feat(web): add systemPrompt collapsible section to DebugPanel

### DIFF
--- a/packages/web/src/components/Chat/DebugPanel.tsx
+++ b/packages/web/src/components/Chat/DebugPanel.tsx
@@ -264,6 +264,13 @@ export function DebugPanel({ debugInfo, a2uiMessages }: DebugPanelProps) {
             )}
           </div>
 
+          {/* System Prompt */}
+          {debugInfo?.systemPrompt && (
+            <CollapsibleSection label="System Prompt" defaultOpen={false} styles={styles}>
+              <pre className={codeBlockClass}>{debugInfo.systemPrompt}</pre>
+            </CollapsibleSection>
+          )}
+
           {/* Full LLM Response Envelope */}
           <CollapsibleSection label="Full LLM Response (JSON)" defaultOpen={true} styles={styles}>
             {debugInfo?.fullEnvelope ? (


### PR DESCRIPTION
Closes #453

Working as Fry (Frontend Engineer)

Frontend portion of the system prompt debug view. Backend landed in #458.

## Changes
- Add collapsible "System Prompt" section to `DebugPanel.tsx`
- Renders `debugMeta.systemPrompt` in a `<pre>` block when present
- Only displayed when debug mode is active (gate is upstream in ChatMessage)