### PR TITLE
feat(api,web): provision backend session for playground users

### DIFF
--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -39,7 +39,7 @@ import type {
 } from "@kickstart/core";
 import { getSession, createSession, getPrincipalId, hydrateSession, addMessage,
   adoptSessionPrincipal, isSessionOwnedBy, recordUsage,
-  extractArtifactsFromA2UI, upsertArtifact,
+  extractArtifactsFromA2UI, upsertArtifact, SessionCapExceededError,
 } from "../lib/session-store.js";
 import type { ApiSession, ClientMessage, GeneratedArtifact } from "../lib/session-store.js";
 import { chatCompletion, chatCompletionWithTools } from "../lib/openai-client.js";
@@ -433,6 +433,9 @@ app.http("converse", {
 
       return { status: 200, jsonBody: responseBody };
     } catch (err) {
+      if (err instanceof SessionCapExceededError) {
+        return { status: 503, jsonBody: { error: err.message } };
+      }
       return safeErrorResponse(err, context, "Converse error");
     }
   },

--- a/packages/web/api/src/functions/session-provision.ts
+++ b/packages/web/api/src/functions/session-provision.ts
@@ -1,0 +1,48 @@
+/**
+ * @module @kickstart/api/functions/session-provision
+ *
+ * POST /api/session/provision — Creates an anonymous backend session for
+ * playground users before they send their first message.
+ *
+ * Returns { sessionId } — the caller stores this as backendSessionId so that
+ * the first /api/converse call can find and reuse the session rather than
+ * orphaning a newly created one.
+ *
+ * Rate limited to 5 requests per IP to prevent session flooding.
+ */
+
+import { app } from "@azure/functions";
+import type { HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { createSession, SessionCapExceededError } from "../lib/session-store.js";
+import { checkRateLimit, rateLimitResponse } from "../lib/rate-limiter.js";
+import { safeErrorResponse } from "../lib/error-response.js";
+
+app.http("session-provision", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  route: "session/provision",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext,
+  ): Promise<HttpResponseInit> => {
+    // Tight rate limit — provisioning should happen once per playground load
+    const rateCheck = checkRateLimit(request, 5);
+    if (!rateCheck.allowed) {
+      return rateLimitResponse(rateCheck.retryAfterMs!);
+    }
+
+    try {
+      // No principal — this is an anonymous session for playground users
+      const session = createSession();
+      return {
+        status: 200,
+        jsonBody: { sessionId: session.state.sessionId },
+      };
+    } catch (err) {
+      if (err instanceof SessionCapExceededError) {
+        return { status: 503, jsonBody: { error: err.message } };
+      }
+      return safeErrorResponse(err, context, "Session provision error");
+    }
+  },
+});

--- a/packages/web/api/src/lib/session-store.ts
+++ b/packages/web/api/src/lib/session-store.ts
@@ -96,6 +96,9 @@ const sessions = new Map<string, ApiSession>();
 /** Session TTL: 1 hour. */
 const SESSION_TTL_MS = 60 * 60 * 1000;
 
+/** Hard cap on active sessions. Prevents heap exhaustion under load. */
+export const MAX_SESSIONS = 10_000;
+
 /** Purge stale sessions every 10 minutes. */
 const cleanupInterval = setInterval(() => {
   const now = Date.now();
@@ -147,8 +150,23 @@ export function adoptSessionPrincipal(session: ApiSession, principalId?: string)
   }
 }
 
+/**
+ * Error thrown when session creation is rejected because MAX_SESSIONS is reached.
+ * Callers should surface this as a 503 Service Unavailable.
+ */
+export class SessionCapExceededError extends Error {
+  constructor() {
+    super("Server is at session capacity. Please try again later.");
+    this.name = "SessionCapExceededError";
+  }
+}
+
 /** Create a new session with Discover-phase system prompt. */
 export function createSession(principalId?: string): ApiSession {
+  if (sessions.size >= MAX_SESSIONS) {
+    throw new SessionCapExceededError();
+  }
+
   const sessionId = randomUUID();
   const now = new Date().toISOString();
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,7 +20,7 @@ import { ConversationSessionProvider } from './contexts/ConversationSessionConte
 import { useTheme } from './contexts/ThemeContext';
 import { useDebug } from './contexts/DebugContext';
 import { useVirtualFS } from './contexts/VirtualFSContext';
-import { healthCheck } from './services/api-client';
+import { healthCheck, provisionSession } from './services/api-client';
 import { isMockMode, isPlaygroundMode } from './services/mock-streaming';
 import { VirtualFileSystem } from './services/virtual-fs';
 import {
@@ -82,6 +82,9 @@ export function App() {
   const streaming = useStreaming();
   const mockStreaming = useMockStreaming();
   const progressiveQueue = useProgressiveQueue();
+
+  // Holds a provisioned backend session ID until the first client session is created
+  const provisionedBackendSessionIdRef = useRef<string | null>(null);
 
   // Single VFS instance for the app lifetime
   const fs = useMemo(() => new VirtualFileSystem(), []);
@@ -161,6 +164,19 @@ export function App() {
     if (!mockEnabled) {
       healthCheck().then(setIsApiAvailable);
     }
+  }, []);
+
+  // Pre-provision a backend session for playground users so the first converse
+  // call reuses it instead of creating an orphaned new session.
+  useEffect(() => {
+    if (!playgroundEnabled || mockEnabled) return;
+    provisionSession()
+      .then(({ sessionId }) => {
+        provisionedBackendSessionIdRef.current = sessionId;
+      })
+      .catch(() => {
+        // Non-fatal — converse.ts will create a session on first message
+      });
   }, []);
 
   // Sync messages from session store when session changes
@@ -441,6 +457,11 @@ export function App() {
       sessionId = newSession.id;
       clearActionLog();
       setConversationPhase(null);
+      // Apply any pre-provisioned backend session ID so converse.ts reuses it
+      if (provisionedBackendSessionIdRef.current) {
+        sessions.updateSession(sessionId, { backendSessionId: provisionedBackendSessionIdRef.current });
+        provisionedBackendSessionIdRef.current = null;
+      }
     }
 
     const assistantMessageId = msgId('assistant');

--- a/packages/web/src/services/api-client.ts
+++ b/packages/web/src/services/api-client.ts
@@ -72,3 +72,20 @@ export async function converse(req: ConversationRequest): Promise<ConversationRe
 
   return res.json();
 }
+
+/**
+ * Call POST /api/session/provision to create an anonymous backend session
+ * before the playground user sends their first message.
+ *
+ * Returns the backend sessionId that should be stored as backendSessionId
+ * so converse.ts reuses the provisioned session instead of creating a new one.
+ *
+ * Throws on network errors or if the server returns 503 (session cap exceeded).
+ */
+export async function provisionSession(): Promise<{ sessionId: string }> {
+  const res = await apiFetch('/api/session/provision', { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Session provision failed: ${res.status}`);
+  }
+  return res.json() as Promise<{ sessionId: string }>;
+}


### PR DESCRIPTION
Closes #414

Working as Bender (Backend Engineer)

## Changes
- New `POST /api/session/provision` endpoint (rate limited to 5/IP)
- Anonymous session created via `createSession()` — no principal binding
- `MAX_SESSIONS` hard cap (10,000) in session-store prevents heap exhaustion
- `SessionCapExceededError` returns 503 in both provision and converse endpoints
- Playground client calls provision on mount, stores `backendSessionId`
- Verified `converse.ts` session reuse flow: `getSession(body.sessionId)` is called before `createSession`/`hydrateSession` (lines 187–196) — no orphaned sessions

## Leela condition
`converse.ts` already correctly calls `getSession(body.sessionId)` first. When the provisioned session ID is sent on the first message, the backend finds and reuses it. ✅

## Zapp conditions
1. Rate limit is `checkRateLimit(request, 5)` — tighter than the default 30. ✅
2. `MAX_SESSIONS = 10_000` hard cap added to `session-store.ts`. ✅