### PR TITLE
feat(core,api): add prompt construction trace to debug metadata

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,7 @@ export type {
   SystemPromptContext,
   ComponentCatalogEntry,
   ComponentCategory,
+  PromptTraceStep,
 } from "./prompts/index.js";
 
 // Tool registry

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -25,4 +25,5 @@ export type {
   DeploymentSafeguard,
   SafeguardSeverity,
   SystemPromptContext,
+  PromptTraceStep,
 } from "./system-prompt.js";

--- a/packages/core/src/prompts/system-prompt.ts
+++ b/packages/core/src/prompts/system-prompt.ts
@@ -23,6 +23,19 @@ import type { ComponentCatalogEntry } from "./component-catalog.js";
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * A single step captured during buildSystemPrompt() assembly.
+ * Canonical definition — consumed by @kickstart/core consumers (e.g. Fry #460).
+ */
+export interface PromptTraceStep {
+  /** Logical section name, e.g. "base-prompt", "azure-context". */
+  name: string;
+  /** Text this step contributed; capped at 8 KB. */
+  content: string;
+  /** content.length before truncation. */
+  charCount: number;
+}
+
 /** Severity of a deployment safeguard violation. */
 export type SafeguardSeverity = "error" | "warning";
 
@@ -76,6 +89,11 @@ export interface SystemPromptContext {
    * Built by the harness each turn so the LLM has running context.
    */
   artifactSummary?: string;
+  /**
+   * When provided, each prompt section is recorded here as it is assembled.
+   * Zero overhead when omitted. Consumed by debug-mode metadata (#459).
+   */
+  trace?: PromptTraceStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -741,50 +759,79 @@ export function buildSystemPrompt(context: SystemPromptContext): string {
   // Compose: unified narrative + phase marker + context + artifact summary + capabilities
   const unified = interpolate(KICKSTART_SYSTEM_PROMPT, vars);
 
+  /** Record a section into context.trace when tracing is active. */
+  function recordTrace(name: string, content: string): void {
+    if (!context.trace) return;
+    context.trace.push({
+      name,
+      content: content.length > 8192 ? content.slice(0, 8192) + "\u2026[truncated]" : content,
+      charCount: content.length,
+    });
+  }
+
+  const baseContent = PROMPT_BOUNDARY_INSTRUCTION + unified;
+  const phaseContent = `## Current Phase: ${phaseDefinition.label}\n\n${phaseDefinition.description}`;
+
   const parts = [
-    PROMPT_BOUNDARY_INSTRUCTION + unified,
+    baseContent,
     `## Current Phase: ${phaseDefinition.label}`,
     phaseDefinition.description,
   ];
 
+  recordTrace("base-prompt", baseContent);
+  recordTrace("phase-context", phaseContent);
+
   // Inject collected app context so the LLM has the current session state.
   // Previously this was driven by per-phase promptTemplates; now injected uniformly.
   if (context.appDefinition && Object.keys(context.appDefinition).length > 0) {
-    parts.push(`\n## Collected App Info\n\n${vars["knownInfo"]}`);
-    parts.push(`\n## App Definition\n\n${vars["appDefinition"]}`);
+    const knownSection = `\n## Collected App Info\n\n${vars["knownInfo"]}`;
+    const defSection = `\n## App Definition\n\n${vars["appDefinition"]}`;
+    parts.push(knownSection);
+    parts.push(defSection);
+    recordTrace("app-info", knownSection + "\n\n" + defSection);
   }
 
   // Inject Azure subscription/resource context so the LLM can reference real
   // resource names, locations, and subscription IDs in DEPLOY/REVIEW phases.
   if (context.azureContext) {
-    parts.push(`\n## Azure Context\n\n${vars["azureContext"]}`);
+    const azureSection = `\n## Azure Context\n\n${vars["azureContext"]}`;
+    parts.push(azureSection);
+    // Note: contains tenant/subscription identifiers and GitHub username — debug only
+    recordTrace("azure-context", azureSection);
   }
 
   // Inject GitHub repo context so the LLM can reference the real repo owner,
   // name, and default branch in the HANDOFF phase.
   if (context.githubContext) {
-    parts.push(`\n## Repository Info\n\n${vars["repoInfo"]}`);
+    const githubSection = `\n## Repository Info\n\n${vars["repoInfo"]}`;
+    parts.push(githubSection);
+    // Note: contains tenant/subscription identifiers and GitHub username — debug only
+    recordTrace("github-context", githubSection);
   }
 
   // Artifact summary — gives the LLM running context of generated files.
   // Sanitize to prevent prompt injection via LLM-generated file names/content.
   if (context.artifactSummary) {
-    parts.push(
-      `\n## Generated Artifacts\n\n${wrapWithBoundary(
-        sanitizePromptValue(context.artifactSummary, 10000),
-      )}`,
-    );
+    const artifactSection = `\n## Generated Artifacts\n\n${wrapWithBoundary(
+      sanitizePromptValue(context.artifactSummary, 10000),
+    )}`;
+    parts.push(artifactSection);
+    recordTrace("artifact-summary", artifactSection);
   }
 
   // Inject resolved kit skills as "Available Capabilities"
   if (context.kitPrompts && context.kitPrompts.length > 0) {
     const capabilities = context.kitPrompts.map((p) => p.trim()).join("\n\n");
-    parts.push(`\n## Available Capabilities\n\n${capabilities}`);
+    const kitSection = `\n## Available Capabilities\n\n${capabilities}`;
+    parts.push(kitSection);
+    recordTrace("kit-capabilities", kitSection);
   }
 
   // Copilot extension skills — suggest public extensions when relevant
   if (context.copilotSkillsPrompt) {
-    parts.push(`\n${context.copilotSkillsPrompt}`);
+    const skillsSection = `\n${context.copilotSkillsPrompt}`;
+    parts.push(skillsSection);
+    recordTrace("copilot-skills", skillsSection);
   }
 
   return parts.join("\n\n");

--- a/packages/web/api/src/functions/converse.ts
+++ b/packages/web/api/src/functions/converse.ts
@@ -50,6 +50,7 @@ import { chatCompletionWithAutoContinue, isTruncated } from "../lib/auto-continu
 import { sanitizeToolOutput } from "../lib/sanitize-tool-output.js";
 import { isDebugMode, buildConverseDebugMeta, formatRenderDecisions } from "../lib/debug-mode.js";
 import type { DebugMetadata } from "../lib/debug-mode.js";
+import type { PromptTraceStep } from "@kickstart/core";
 import { buildTurnUsage, sumChatUsage } from "../lib/usage-tracking.js";
 import type { UsageSummary, ChatUsage } from "../lib/usage-tracking.js";
 import {
@@ -270,11 +271,13 @@ app.http("converse", {
       addMessage(state.sessionId, "user", body.message);
       const artifactSummary = buildArtifactSummary(session.generatedArtifacts);
 
+      const promptTrace: PromptTraceStep[] | undefined = debugMode ? [] : undefined;
       const freshSystemPrompt = buildSystemPrompt({
         phase: currentPhase,
         appDefinition: state.appDefinition,
         kitPrompts: resolvedSkills.prompts,
         artifactSummary: artifactSummary || undefined,
+        trace: promptTrace,
       });
       // Note: azureContext and githubContext are intentionally excluded from DebugMetadata to prevent tenant ID leakage
 
@@ -336,7 +339,7 @@ app.http("converse", {
       if (wantsStream) {
         return handleStreaming(
           messages, state.sessionId, session, modelRoute, context,
-          toolContext, debugMode, session.generatedArtifacts, freshSystemPrompt,
+          toolContext, debugMode, session.generatedArtifacts, freshSystemPrompt, promptTrace,
         );
       }
 
@@ -419,14 +422,15 @@ app.http("converse", {
       // Attach debug metadata when requested
       if (debugMode) {
         const hadExplicitA2UI = processed.a2uiMessages.length > 0;
-        const debugMeta = buildConverseDebugMeta(
-          modelRoute.model,
-          finalContent,
-          processed.a2uiMessages.length,
+        const debugMeta = buildConverseDebugMeta({
+          model: modelRoute.model,
+          rawContent: finalContent,
+          a2uiCount: processed.a2uiMessages.length,
           hadExplicitA2UI,
-          session.state.currentPhase,
-          freshSystemPrompt,
-        );
+          currentPhase: session.state.currentPhase,
+          systemPrompt: freshSystemPrompt,
+          promptTrace,
+        });
         responseBody.debug = debugMeta;
         responseBody.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
       }
@@ -493,13 +497,13 @@ async function handleSetupGenerationResponse(
   };
 
   if (debugMode) {
-    const debugMeta = buildConverseDebugMeta(
-      modelRoute.model,
-      result.message,
-      result.a2uiMessages.length,
-      result.a2uiMessages.length > 0,
-      session.state.currentPhase,
-    );
+    const debugMeta = buildConverseDebugMeta({
+      model: modelRoute.model,
+      rawContent: result.message,
+      a2uiCount: result.a2uiMessages.length,
+      hadExplicitA2UI: result.a2uiMessages.length > 0,
+      currentPhase: session.state.currentPhase,
+    });
     responseBody.debug = debugMeta;
     responseBody.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
   }
@@ -559,13 +563,13 @@ function handleSetupGenerationStreaming(
         };
 
         if (debugMode) {
-          const debugMeta = buildConverseDebugMeta(
-            modelRoute.model,
-            result.message,
-            result.a2uiMessages.length,
-            result.a2uiMessages.length > 0,
-            session.state.currentPhase,
-          );
+          const debugMeta = buildConverseDebugMeta({
+            model: modelRoute.model,
+            rawContent: result.message,
+            a2uiCount: result.a2uiMessages.length,
+            hadExplicitA2UI: result.a2uiMessages.length > 0,
+            currentPhase: session.state.currentPhase,
+          });
           donePayload.debug = debugMeta;
           donePayload.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
         }
@@ -606,6 +610,7 @@ function handleStreaming(
   debugMode: boolean,
   sessionArtifacts: GeneratedArtifact[],
   systemPrompt?: string,
+  promptTrace?: PromptTraceStep[],
 ): HttpResponseInit {
   const encoder = new TextEncoder();
   let accumulatedUsage: ChatUsage | undefined;
@@ -703,14 +708,15 @@ function handleStreaming(
 
             if (debugMode) {
               const hadExplicitA2UI = processed.a2uiMessages.length > 0;
-              const debugMeta = buildConverseDebugMeta(
-                modelRoute.model,
-                fullContent,
-                processed.a2uiMessages.length,
+              const debugMeta = buildConverseDebugMeta({
+                model: modelRoute.model,
+                rawContent: fullContent,
+                a2uiCount: processed.a2uiMessages.length,
                 hadExplicitA2UI,
-                session.state.currentPhase,
+                currentPhase: session.state.currentPhase,
                 systemPrompt,
-              );
+                promptTrace,
+              });
               donePayload.debug = debugMeta;
               donePayload.renderDecisions = formatRenderDecisions(debugMeta.renderDecisions);
             }

--- a/packages/web/api/src/lib/debug-mode.test.ts
+++ b/packages/web/api/src/lib/debug-mode.test.ts
@@ -54,21 +54,21 @@ describe("isDebugMode", () => {
 describe("buildConverseDebugMeta", () => {
   it("includes systemPrompt in metadata", async () => {
     const { buildConverseDebugMeta } = await import("./debug-mode.js");
-    const meta = buildConverseDebugMeta("gpt-4o", "raw", 0, false, "idea", "my system prompt");
+    const meta = buildConverseDebugMeta({ model: "gpt-4o", rawContent: "raw", a2uiCount: 0, hadExplicitA2UI: false, currentPhase: "idea", systemPrompt: "my system prompt" });
     expect(meta.systemPrompt).toBe("my system prompt");
   });
 
   it("truncates systemPrompt exceeding 8192 chars", async () => {
     const { buildConverseDebugMeta } = await import("./debug-mode.js");
     const longPrompt = "x".repeat(9000);
-    const meta = buildConverseDebugMeta("gpt-4o", "raw", 0, false, "idea", longPrompt);
+    const meta = buildConverseDebugMeta({ model: "gpt-4o", rawContent: "raw", a2uiCount: 0, hadExplicitA2UI: false, currentPhase: "idea", systemPrompt: longPrompt });
     expect(meta.systemPrompt).toHaveLength(8192 + "\u2026[truncated]".length);
     expect(meta.systemPrompt?.endsWith("\u2026[truncated]")).toBe(true);
   });
 
   it("omits systemPrompt when not provided", async () => {
     const { buildConverseDebugMeta } = await import("./debug-mode.js");
-    const meta = buildConverseDebugMeta("gpt-4o", "raw", 0, false, "idea");
+    const meta = buildConverseDebugMeta({ model: "gpt-4o", rawContent: "raw", a2uiCount: 0, hadExplicitA2UI: false, currentPhase: "idea" });
     expect(meta.systemPrompt).toBeUndefined();
   });
 });

--- a/packages/web/api/src/lib/debug-mode.ts
+++ b/packages/web/api/src/lib/debug-mode.ts
@@ -9,6 +9,7 @@
  */
 
 import type { HttpRequest } from "@azure/functions";
+import type { PromptTraceStep } from "@kickstart/core";
 
 // Warn at module load time if debug is allowed in production.
 if (process.env.KICKSTART_DEBUG_ALLOWED && process.env.NODE_ENV === "production") {
@@ -43,6 +44,8 @@ export interface DebugMetadata {
   renderDecisions: RenderDecision[];
   /** System prompt used for this LLM call (truncated at 8 KB). */
   systemPrompt?: string;
+  /** Prompt construction trace — one entry per named section assembled. */
+  promptTrace?: PromptTraceStep[];
 }
 
 /** Maximum characters of raw LLM content exposed in debug metadata. */
@@ -60,24 +63,31 @@ function redactRawContent(raw: string): string {
 /** Maximum characters of system prompt exposed in debug metadata (8 KB soft cap). */
 const SYSTEM_PROMPT_MAX_LENGTH = 8192;
 
+/** Options for buildConverseDebugMeta — grouped to avoid long positional param lists. */
+export interface ConverseDebugMetaOptions {
+  /** The deployment/model name used. */
+  model: string;
+  /** The raw LLM output before processing. */
+  rawContent: string;
+  /** Number of A2UI messages extracted. */
+  a2uiCount: number;
+  /** Whether the LLM returned explicit A2UI JSON. */
+  hadExplicitA2UI: boolean;
+  /** Current conversation phase name. */
+  currentPhase?: string;
+  /** System prompt used for this LLM call (truncated at 8 KB). */
+  systemPrompt?: string;
+  /** Prompt construction trace captured by buildSystemPrompt(). */
+  promptTrace?: PromptTraceStep[];
+}
+
 /**
  * Build debug metadata for a converse response.
- *
- * @param model      - The deployment/model name used
- * @param rawContent - The raw LLM output before processing
- * @param a2uiCount  - Number of A2UI messages extracted
- * @param hadExplicitA2UI - Whether the LLM returned explicit A2UI JSON
- * @param currentPhase - Current conversation phase name
- * @param systemPrompt - System prompt used for this LLM call (truncated at 8 KB)
  */
 export function buildConverseDebugMeta(
-  model: string,
-  rawContent: string,
-  a2uiCount: number,
-  hadExplicitA2UI: boolean,
-  currentPhase?: string,
-  systemPrompt?: string,
+  options: ConverseDebugMetaOptions,
 ): DebugMetadata {
+  const { model, rawContent, a2uiCount, hadExplicitA2UI, currentPhase, systemPrompt, promptTrace } = options;
   const renderDecisions: RenderDecision[] = [];
 
   // Phase indicator is always injected
@@ -107,7 +117,13 @@ export function buildConverseDebugMeta(
     ? systemPrompt.slice(0, SYSTEM_PROMPT_MAX_LENGTH) + "\u2026[truncated]"
     : systemPrompt;
 
-  return { model, rawContent: redactRawContent(rawContent), renderDecisions, ...(truncatedPrompt !== undefined ? { systemPrompt: truncatedPrompt } : {}) };
+  return {
+    model,
+    rawContent: redactRawContent(rawContent),
+    renderDecisions,
+    ...(truncatedPrompt !== undefined ? { systemPrompt: truncatedPrompt } : {}),
+    ...(promptTrace !== undefined ? { promptTrace } : {}),
+  };
 }
 
 /**

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,5 +1,7 @@
 // Shared TypeScript types for the Kickstart chat application
 
+import type { PromptTraceStep } from "@kickstart/core";
+
 /** A logged action dispatch event for debug visibility. */
 export interface ActionDebugEvent {
   /** Timestamp (ms) when the action was dispatched. */
@@ -31,6 +33,8 @@ export interface DebugMetadata {
   };
   /** System prompt used for this LLM call (truncated at 8 KB). */
   systemPrompt?: string;
+  /** Prompt construction trace — one entry per named section assembled. */
+  promptTrace?: PromptTraceStep[];
 }
 
 export interface SetupStepStartEvent {


### PR DESCRIPTION
Closes #459

Working as Bender (Backend Engineer)

## Changes
- `PromptTraceStep` type defined in `@kickstart/core` (canonical — Fry's #460 imports from here)
- Optional trace accumulator on `buildSystemPrompt()` — zero overhead when not collecting
- 8 named steps wired: `base-prompt`, `phase-context`, `app-info`, `azure-context`, `github-context`, `artifact-summary`, `kit-capabilities`, `copilot-skills`
- `promptTrace?` in `DebugMetadata` and frontend types
- Inline comments on azure/github steps (sensitive data categories)
- `buildConverseDebugMeta()` refactored to options object (Leela condition: was 6 positional params)
- Agents-runner path descoped (consistent with #458)

⚠️ Frontend work (#460 by Fry) depends on this PR merging first.