### PR TITLE
docs(process): establish docs freshness sweep process

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -1,0 +1,147 @@
+name: Docs Freshness Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/web/api/src/**'
+      - 'packages/web/src/**'
+      - 'packages/core/src/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Docs freshness reminder
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine affected doc areas
+        id: areas
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          NEEDS_API_DOCS=false
+          NEEDS_FRONTEND_DOCS=false
+          NEEDS_ENGINE_DOCS=false
+          NEEDS_PROMPTS_DOCS=false
+          NEEDS_KITS_DOCS=false
+
+          if echo "$CHANGED" | grep -q '^packages/web/api/src/'; then NEEDS_API_DOCS=true; fi
+          if echo "$CHANGED" | grep -q '^packages/web/src/'; then NEEDS_FRONTEND_DOCS=true; fi
+          if echo "$CHANGED" | grep -q '^packages/core/src/engine/'; then NEEDS_ENGINE_DOCS=true; fi
+          if echo "$CHANGED" | grep -q '^packages/core/src/prompts/'; then NEEDS_PROMPTS_DOCS=true; fi
+          if echo "$CHANGED" | grep -q '^packages/core/src/kits/'; then NEEDS_KITS_DOCS=true; fi
+
+          echo "needs_api_docs=$NEEDS_API_DOCS" >> "$GITHUB_OUTPUT"
+          echo "needs_frontend_docs=$NEEDS_FRONTEND_DOCS" >> "$GITHUB_OUTPUT"
+          echo "needs_engine_docs=$NEEDS_ENGINE_DOCS" >> "$GITHUB_OUTPUT"
+          echo "needs_prompts_docs=$NEEDS_PROMPTS_DOCS" >> "$GITHUB_OUTPUT"
+          echo "needs_kits_docs=$NEEDS_KITS_DOCS" >> "$GITHUB_OUTPUT"
+
+      - name: Print docs freshness reminder
+        run: |
+          echo "⚠️  This PR touches source files. Please verify relevant docs are up to date."
+          echo ""
+          if [ "${{ steps.areas.outputs.needs_api_docs }}" = "true" ]; then
+            echo "  📄 packages/web/api/src/ changed:"
+            echo "     - docs-site/docs/engineering/api-layer.md"
+            echo "     - docs-site/docs/architecture/json-envelope.md"
+            echo "     - Security docs: auth model, API boundaries"
+          fi
+          if [ "${{ steps.areas.outputs.needs_frontend_docs }}" = "true" ]; then
+            echo "  📄 packages/web/src/ changed:"
+            echo "     - docs-site/docs/engineering/frontend-context-map.md"
+            echo "     - docs-site/docs/architecture/a2ui-integration.md"
+          fi
+          if [ "${{ steps.areas.outputs.needs_engine_docs }}" = "true" ]; then
+            echo "  📄 packages/core/src/engine/ changed:"
+            echo "     - docs-site/docs/architecture/overview.md"
+            echo "     - docs-site/docs/architecture/prompt-pipeline.md"
+            echo "     - docs-site/docs/architecture/skill-injection.md"
+          fi
+          if [ "${{ steps.areas.outputs.needs_prompts_docs }}" = "true" ]; then
+            echo "  📄 packages/core/src/prompts/ changed:"
+            echo "     - docs-site/docs/architecture/prompt-pipeline.md"
+            echo "     - docs-site/docs/architecture/json-envelope.md"
+          fi
+          if [ "${{ steps.areas.outputs.needs_kits_docs }}" = "true" ]; then
+            echo "  📄 packages/core/src/kits/ changed:"
+            echo "     - docs-site/docs/architecture/skill-injection.md"
+            echo "     - docs-site/docs/architecture/a2ui-integration.md"
+          fi
+          echo ""
+          echo "  🔒 Always review security-relevant docs when changing API or auth code:"
+          echo "     - Auth model, connector model, debug gate, API boundaries"
+          echo ""
+          echo "  📋 Full sweep checklist: docs-site/docs/process/docs-freshness.md"
+          echo "  🏷️  Apply the 'needs-docs' label if this PR requires a documentation update."
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const areas = [];
+            if ('${{ steps.areas.outputs.needs_api_docs }}' === 'true') {
+              areas.push('**API layer** (`packages/web/api/src/`)\n  - `docs-site/docs/engineering/api-layer.md`\n  - `docs-site/docs/architecture/json-envelope.md`\n  - Security docs: auth model, API boundaries');
+            }
+            if ('${{ steps.areas.outputs.needs_frontend_docs }}' === 'true') {
+              areas.push('**Frontend** (`packages/web/src/`)\n  - `docs-site/docs/engineering/frontend-context-map.md`\n  - `docs-site/docs/architecture/a2ui-integration.md`');
+            }
+            if ('${{ steps.areas.outputs.needs_engine_docs }}' === 'true') {
+              areas.push('**Conversation engine** (`packages/core/src/engine/`)\n  - `docs-site/docs/architecture/overview.md`\n  - `docs-site/docs/architecture/prompt-pipeline.md`\n  - `docs-site/docs/architecture/skill-injection.md`');
+            }
+            if ('${{ steps.areas.outputs.needs_prompts_docs }}' === 'true') {
+              areas.push('**Prompts** (`packages/core/src/prompts/`)\n  - `docs-site/docs/architecture/prompt-pipeline.md`\n  - `docs-site/docs/architecture/json-envelope.md`');
+            }
+            if ('${{ steps.areas.outputs.needs_kits_docs }}' === 'true') {
+              areas.push('**Kits** (`packages/core/src/kits/`)\n  - `docs-site/docs/architecture/skill-injection.md`\n  - `docs-site/docs/architecture/a2ui-integration.md`');
+            }
+
+            if (areas.length === 0) return;
+
+            const body = [
+              '## 📋 Docs Freshness Check',
+              '',
+              'This PR touches source files. Please verify that the relevant docs are up to date before merging.',
+              '',
+              ...areas.map(a => `- ${a}`),
+              '',
+              '> 🔒 **Security reminder:** Always review auth model, connector model, debug gate, and API boundary docs when changing API or auth code.',
+              '> 📋 Full checklist: [`docs-site/docs/process/docs-freshness.md`](./docs-site/docs/process/docs-freshness.md)',
+              '> 🏷️  Apply the [`needs-docs`](https://github.com/${{ github.repository }}/labels/needs-docs) label if a documentation update is required.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## 📋 Docs Freshness Check')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ npm run dev:vite
 packages/
   core/           Core conversation engine, A2UI catalog, and code generators
   web/            Web frontend — Azure Portal-style UX
+  web/api/        Azure Functions backend (converse, health, proxies)
   mcp-server/     MCP server exposing conversation tools and A2UI responses
 infra/            Azure infrastructure (Bicep templates)
 ```
@@ -54,7 +55,12 @@ infra/            Azure infrastructure (Bicep templates)
 |---------|-------------|
 | `@kickstart/core` | Conversation engine, A2UI component catalog, code generators |
 | `@kickstart/web` | React 19 frontend with Fluent UI 2, Vite 6 dev server |
+| `@kickstart/web` (api) | Azure Functions backend; uses OpenAI Agents SDK for route management |
 | `@kickstart/mcp-server` | Model Context Protocol server for tool integration |
+
+### Conversation engine
+
+The conversation engine uses the **OpenAI Agents SDK** (migrated in #330/#445). The previous TypeScript state machine (`machine.ts`) and `phaseComplete`/`filesComplete` model flags were removed. Route management is now server-authored via the SDK — see [Architecture Overview](https://sabbour.github.io/kickstart/docs/architecture/overview) for current details.
 
 ## Development Workflow
 
@@ -85,6 +91,7 @@ For the full release workflow — cutting releases, tagging, deploying — see *
 
 - **Web UI:** `packages/web/index.html`
 - **Engine phases:** `packages/core/src/engine/phases.ts`
+- **Agents SDK backend:** `packages/web/api/src/functions/converse.ts`
 - **MCP server:** `packages/mcp-server/src/index.ts`
 
 ## Code Style

--- a/docs-site/docs/architecture/fsm.md
+++ b/docs-site/docs/architecture/fsm.md
@@ -2,87 +2,14 @@
 sidebar_position: 3
 ---
 
-# Phase System
+# Phase System (archived)
 
-Kickstart's conversation engine uses a lightweight, LLM-driven phase system to guide users from project discovery through deployment.
+:::caution This page is archived
+The TypeScript state machine (`machine.ts`) documented here was removed in [PR #412](https://github.com/sabbour/kickstart/pull/412). The FSM was never exercised at runtime — the LLM navigated phases entirely from its system prompt.
 
-:::note Historical context
-An earlier version of the codebase included a TypeScript state machine (`machine.ts`) with explicit transition functions, event types, and condition fields (`entryConditions`, `exitConditions`, `promptTemplate`) on `PhaseDefinition`. This was removed in PR #412 because the machine was never exercised at runtime — the LLM navigated phases entirely from its system prompt. The reasoning is in `.squad/decisions.md`.
+**For current phase documentation see [Architecture Overview](./overview.md) and [Prompt Pipeline](./prompt-pipeline.md).**
 :::
 
----
+The conversation engine now uses a lightweight, LLM-driven phase system. Phases are a static array in `packages/core/src/engine/phases.ts`; the current phase is a plain string on the server-side session (`session.state.currentPhase`). Phase advancement happens when the model emits `phaseComplete: true` in the JSON envelope — no event system, no transition guards.
 
-## Current State
-
-### Phase Catalog
-
-Phases are defined in `packages/core/src/engine/phases.ts` as a static array:
-
-```typescript
-export interface PhaseDefinition {
-  id: Phase;
-  label: string;
-  description: string;
-  nextPhase: Phase | null;
-}
-```
-
-The six phases in conversation order:
-
-| Phase | Label | nextPhase |
-|-------|-------|-----------|
-| `discover` | Discover | `design` |
-| `design` | Design | `generate` |
-| `generate` | Generate | `review` |
-| `review` | Review | `handoff` |
-| `handoff` | Handoff | `deploy` |
-| `deploy` | Deploy | `null` (terminal) |
-
-### Session State
-
-The current phase is stored as a plain string on the server-side session:
-
-```typescript
-session.state.currentPhase  // e.g. "generate"
-```
-
-This is the single source of truth. There is no separate FSM state slice, no `phaseStatuses` map, and no `phaseData` bag.
-
-### Phase Advancement
-
-`advancePhase()` in `converse.ts` looks up the current phase in `PHASE_DEFINITIONS` and returns `nextPhase`:
-
-```typescript
-function advancePhase(currentPhase: Phase): Phase {
-  const def = PHASE_DEFINITIONS.find((p) => p.id === currentPhase);
-  return def?.nextPhase ?? currentPhase;
-}
-```
-
-The LLM signals that a phase is complete via `phaseComplete: true` in its JSON response envelope. The `converse` handler reads this flag and calls `advancePhase()` — there is no event system or transition guard.
-
-### How the LLM Knows Its Phase
-
-The system prompt includes the current phase identifier and the `description` from its `PhaseDefinition`. This tells the LLM what to focus on and when to signal completion.
-
----
-
-## What Was Removed
-
-The original `machine.ts` implemented a pure-function state machine with:
-
-- `transition(state, event)` — pure transition function
-- `handleImplicitFlags()` — auto-advance on LLM signals
-- `canAdvance()` — gate check before advancing
-- `ConversationState` — FSM state slice (`phaseStatuses`, `phaseData`)
-- `ConversationEvent` enum — `USER_MESSAGE`, `PHASE_COMPLETE`
-
-`PhaseDefinition` also carried `entryConditions`, `exitConditions`, and `promptTemplate` fields — all typed, none read at runtime.
-
-The machine was removed because it duplicated the LLM's own phase judgment without adding correctness guarantees.
-
----
-
-## Future Direction
-
-Phase behavior is expected to evolve significantly with the Agents SDK integration. See issue [#330](https://github.com/sabbour/kickstart/issues/330) for the planned redesign. The current plain-string approach is intentionally minimal — a clean baseline before that work begins.
+With the Agents SDK migration (#330) the route-management model has changed further. See the decisions log (`.squad/decisions.md`) for the full rationale.

--- a/docs-site/docs/process/docs-freshness.md
+++ b/docs-site/docs/process/docs-freshness.md
@@ -1,0 +1,113 @@
+---
+sidebar_position: 1
+---
+
+# Docs Freshness Sweep
+
+> Every edge case is a regulation waiting to be enforced — including stale documentation.
+
+This process defines **when to sweep**, **what to check**, and **who owns what** so docs never quietly rot.
+
+---
+
+## Staleness Indicators
+
+| Indicator | Meaning |
+|-----------|---------|
+| 🔴 **Confirmed stale** | Known to contradict the codebase. Must be fixed before the next release. |
+| 🟠 **Likely stale** | Code or architecture changed in an area this doc covers. Needs review. |
+| 🟢 **Fresh** | Verified against the current codebase within the last release cycle. |
+
+When you find a 🔴 or 🟠 page during a sweep, open a GitHub issue with label `documentation` + `priority:important` and tag the area owner.
+
+---
+
+## Trigger 1 — Release-triggered sweep
+
+Run this checklist before cutting any release (see [RELEASING.md](../../RELEASING.md)):
+
+### Architecture docs
+
+- [ ] `docs-site/docs/architecture/overview.md` — monorepo structure still accurate?
+- [ ] `docs-site/docs/architecture/prompt-pipeline.md` — skill injection mechanisms still correct?
+- [ ] `docs-site/docs/architecture/json-envelope.md` — envelope shape matches `converse.ts`?
+- [ ] `docs-site/docs/architecture/a2ui-integration.md` — component catalog size matches assertions?
+- [ ] `docs-site/docs/architecture/skill-injection.md` — mechanisms A and B still exist?
+
+### Engineering docs
+
+- [ ] `docs-site/docs/engineering/api-layer.md` — endpoint list matches actual Functions?
+- [ ] `docs-site/docs/engineering/frontend-context-map.md` — context providers and state accurate?
+- [ ] `docs-site/docs/engineering/configuration-reference.md` — all env vars documented?
+
+### Security-relevant docs (mandatory — Zapp scope)
+
+- [ ] Auth model — MSAL config, token flow, SWA auth still matches implementation
+- [ ] API boundaries — which routes are authenticated vs public
+- [ ] Connector model — client-side vs proxy execution documented correctly
+- [ ] Debug gate — debug endpoints, feature flags, and their guards documented
+
+### ADRs
+
+- [ ] Does any merged PR since the last release introduce a decision not recorded in `docs-site/docs/adrs/`?
+- [ ] Are all pending ADRs in `docs-site/docs/adrs/` still marked with correct status?
+
+### Getting started / contributing
+
+- [ ] `CONTRIBUTING.md` — setup instructions still work end-to-end?
+- [ ] `docs-site/docs/getting-started/` — deployment guide matches current infra?
+
+---
+
+## Trigger 2 — PR-triggered sweep
+
+When a PR touches certain source paths, the corresponding docs **must** be reviewed before merge.
+
+| Source path changed | Docs to review |
+|---------------------|---------------|
+| `packages/web/api/src/**` | `api-layer.md`, `json-envelope.md`, security auth/connector docs |
+| `packages/web/src/**` | `frontend-context-map.md`, `a2ui-integration.md` |
+| `packages/core/src/engine/**` | `architecture/overview.md`, `prompt-pipeline.md`, `skill-injection.md` |
+| `packages/core/src/prompts/**` | `prompt-pipeline.md`, `json-envelope.md` |
+| `packages/core/src/kits/**` | `skill-injection.md`, `a2ui-integration.md` |
+| `infra/**` | `getting-started/deployment.md`, `configuration-reference.md` |
+| `.github/workflows/**` | `ops/ci-overview.md` (if it exists) |
+
+If you're unsure whether your change requires a docs update, apply the `needs-docs` label to the PR. The CI check (`docs-freshness.yml`) will also remind you automatically.
+
+---
+
+## CI Enforcement
+
+The workflow `.github/workflows/docs-freshness.yml` runs on every PR that touches `packages/web/api/src/`, `packages/web/src/`, or `packages/core/src/`. It posts a reminder listing the docs that are likely affected.
+
+**The `needs-docs` label is mandatory (not optional)** on any PR that makes a user-visible or API-contract change. Reviewers must verify the label is either applied and resolved, or explicitly waived with a comment explaining why no docs update is needed.
+
+Label: [`needs-docs`](https://github.com/sabbour/kickstart/labels/needs-docs) — color `#0075ca`
+
+---
+
+## Per-area owners
+
+| Area | Owner | Docs path |
+|------|-------|-----------|
+| Conversation engine / phases | Leela (Lead) | `architecture/` |
+| Prompt pipeline / skill injection | Leela (Lead) | `architecture/prompt-pipeline.md`, `architecture/skill-injection.md` |
+| API layer / Azure Functions | Bender (Backend) | `engineering/api-layer.md` |
+| Frontend / A2UI | Fry (Frontend) | `engineering/frontend-context-map.md`, `architecture/a2ui-integration.md` |
+| Security: auth, connectors, debug gate | Zapp (Security) | Security-relevant docs (see checklist above) |
+| Tests / CI | Hermes (Tester) | `engineering/` + this process doc |
+| ADRs | Scribe (Session Logger) | `docs-site/docs/adrs/` |
+| Infrastructure / deployment | Bender (Backend) | `getting-started/deployment.md` |
+
+---
+
+## Archiving stale docs
+
+When a feature is removed:
+
+1. Replace the page body with a short archived stub (see `architecture/fsm.md` as a reference).
+2. Keep the file at its original path so existing links don't 404.
+3. Add a `:::caution This page is archived` admonition at the top.
+4. Link to the current replacement doc.
+5. Record the removal in `.squad/decisions/inbox/hermes-archive-{slug}.md`.


### PR DESCRIPTION
Closes #425

Working as Hermes (Technical Writer/Tester)

## Changes

- **Archives stale `fsm.md`** — replaced with a concise stub noting the FSM was removed in #412, with links to `overview.md` and `prompt-pipeline.md`
- **Updates `CONTRIBUTING.md`** — adds `packages/web/api/` to the project structure table and notes the Agents SDK migration (#330/#445), replacing the outdated phase-system description; updates key entry points
- **New `docs-site/docs/process/docs-freshness.md`** — full sweep process doc with staleness indicators (🔴/🟠/🟢), release-triggered checklist, PR-triggered doc mapping, CI enforcement note (`needs-docs` label as mandatory), security-relevant docs scope (Zapp condition: auth model, connector model, debug gate, API boundaries), and per-area owners table
- **New `.github/workflows/docs-freshness.yml`** — CI workflow triggered on PRs touching `packages/web/api/src/`, `packages/web/src/`, or `packages/core/src/`; posts a targeted reminder comment on the PR listing the specific docs affected; deduplicates comments on re-push
- **Creates `needs-docs` label** on the repo (Leela condition: mandatory, not optional)

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.