### PR TITLE
Redirect ceremony-reference.md pointers to .squad/ceremonies.md

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -949,12 +949,12 @@ prompt: |
 
 Ceremonies are structured team meetings where agents align before or after work. Each squad configures its own ceremonies in `.squad/ceremonies.md`.
 
-**On-demand reference:** Read `.squad/templates/ceremony-reference.md` for config format, facilitator spawn template, and execution rules.
+**On-demand reference:** Read `.squad/ceremonies.md` for the automation map, per-ceremony config, facilitator assignment, and persona mechanism.
 
 **Core logic (always loaded):**
 1. Before spawning a work batch, check `.squad/ceremonies.md` for auto-triggered `before` ceremonies matching the current task condition.
 2. After a batch completes, check for `after` ceremonies. Manual ceremonies run only when the user asks.
-3. Spawn the facilitator (sync) using the template in the reference file. Facilitator spawns participants as sub-tasks.
+3. Spawn the facilitator (sync) per the ceremony's entry in `.squad/ceremonies.md`. Facilitator spawns participants as sub-tasks.
 4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record.
 5. **Ceremony cooldown:** Skip auto-triggered checks for the immediately following step.
 6. Show: `📋 {CeremonyName} completed — facilitated by {Lead}. Decisions: {count} | Action items: {count}.`

--- a/.squad/templates/squad.agent.md
+++ b/.squad/templates/squad.agent.md
@@ -877,12 +877,12 @@ prompt: |
 
 Ceremonies are structured team meetings where agents align before or after work. Each squad configures its own ceremonies in `.squad/ceremonies.md`.
 
-**On-demand reference:** Read `.squad/templates/ceremony-reference.md` for config format, facilitator spawn template, and execution rules.
+**On-demand reference:** Read `.squad/ceremonies.md` for the automation map, per-ceremony config, facilitator assignment, and persona mechanism.
 
 **Core logic (always loaded):**
 1. Before spawning a work batch, check `.squad/ceremonies.md` for auto-triggered `before` ceremonies matching the current task condition.
 2. After a batch completes, check for `after` ceremonies. Manual ceremonies run only when the user asks.
-3. Spawn the facilitator (sync) using the template in the reference file. Facilitator spawns participants as sub-tasks.
+3. Spawn the facilitator (sync) per the ceremony's entry in `.squad/ceremonies.md`. Facilitator spawns participants as sub-tasks.
 4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record.
 5. **Ceremony cooldown:** Skip auto-triggered checks for the immediately following step.
 6. Show: `📋 {CeremonyName} completed — facilitated by {Lead}. Decisions: {count} | Action items: {count}.`

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -949,12 +949,12 @@ prompt: |
 
 Ceremonies are structured team meetings where agents align before or after work. Each squad configures its own ceremonies in `.squad/ceremonies.md`.
 
-**On-demand reference:** Read `.squad/templates/ceremony-reference.md` for config format, facilitator spawn template, and execution rules.
+**On-demand reference:** Read `.squad/ceremonies.md` for the automation map, per-ceremony config, facilitator assignment, and persona mechanism.
 
 **Core logic (always loaded):**
 1. Before spawning a work batch, check `.squad/ceremonies.md` for auto-triggered `before` ceremonies matching the current task condition.
 2. After a batch completes, check for `after` ceremonies. Manual ceremonies run only when the user asks.
-3. Spawn the facilitator (sync) using the template in the reference file. Facilitator spawns participants as sub-tasks.
+3. Spawn the facilitator (sync) per the ceremony's entry in `.squad/ceremonies.md`. Facilitator spawns participants as sub-tasks.
 4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record.
 5. **Ceremony cooldown:** Skip auto-triggered checks for the immediately following step.
 6. Show: `📋 {CeremonyName} completed — facilitated by {Lead}. Decisions: {count} | Action items: {count}.`


### PR DESCRIPTION
Three `squad.agent.md` variants reference `.squad/templates/ceremony-reference.md`, which was never committed. After the v2 rewrite in #471/#481, the content it promised (config format, facilitator assignment, execution rules) now lives in `.squad/ceremonies.md`. This PR redirects the on-demand pointer and the facilitator-spawn step to the file that actually exists.

Files updated:
- `.squad/templates/squad.agent.md.template`
- `.squad/templates/squad.agent.md`
- `.github/agents/squad.agent.md`

No behavior change beyond the pointer: agents will now read the correct file when they consult the ceremony reference.
