### PR TITLE
fix(harness): Pack.skills[] for inline skill registration

### DIFF
--- a/packages/harness/src/__tests__/registry.test.ts
+++ b/packages/harness/src/__tests__/registry.test.ts
@@ -257,4 +257,93 @@ Bad.
     registry.register({ name: 'a', version: '1.0.0', dependsOn: ['b'] });
     expect(() => registry.register({ name: 'b', version: '1.0.0', dependsOn: ['a'] })).toThrow(/Circular dependency/);
   });
+
+  it('merges skillsDir file skills with inline skills[] and detects cross-source duplicates', () => {
+    // Create a skill file on disk
+    const skillsDir = fileDir('merge-test/skills/dir-skill');
+    writeFixture('merge-test/skills/dir-skill/SKILL.md', `---
+name: dir-skill
+description: Skill loaded from directory
+version: 1.0.0
+x-kickstart:
+  appliesTo:
+    - mergetest.*
+  keywords:
+    - dir
+  priority: 10
+---
+
+Use the dir skill.
+`);
+
+    // Create an agent file so we can retrieve skills via getSkillsForAgent
+    const agentsDir = fileDir('merge-test/agents');
+    writeFixture('merge-test/agents/mergetest.tester.agent.md', `---
+name: mergetest.tester
+description: Test agent for merge coverage
+model:
+  envVar: MODEL
+tools: []
+---
+
+Tester agent.
+`);
+
+    const registry = new PackRegistry();
+    registry.register({
+      name: 'mergetest',
+      version: '1.0.0',
+      skillsDir,
+      agentsDir,
+      skills: [{
+        id: 'mergetest/inline-skill',
+        name: 'inline-skill',
+        description: 'Inline skill without a .md file',
+        version: '1.0.0',
+        instructions: 'Use the inline skill.',
+        appliesTo: ['mergetest.*'],
+        keywords: ['inline'],
+        priority: 20,
+        source: { kind: 'inline' },
+      }],
+    });
+
+    // Both the dir-loaded and inline skills must be visible for the agent
+    const ids = registry.getSkillsForAgent('mergetest.tester').map((s) => s.id).sort();
+    expect(ids).toEqual(['mergetest/dir-skill', 'mergetest/inline-skill']);
+
+    // Deduplication: same id in both skillsDir and skills[] must throw
+    const dedupSkillsDir = fileDir('dedup-test/skills/same-skill');
+    writeFixture('dedup-test/skills/same-skill/SKILL.md', `---
+name: same-skill
+description: Dir version
+version: 1.0.0
+x-kickstart:
+  appliesTo:
+    - deduptest.*
+  keywords:
+    - dup
+  priority: 10
+---
+
+Dir version.
+`);
+    const registry2 = new PackRegistry();
+    expect(() => registry2.register({
+      name: 'deduptest',
+      version: '1.0.0',
+      skillsDir: dedupSkillsDir,
+      skills: [{
+        id: 'deduptest/same-skill',
+        name: 'same-skill',
+        description: 'Inline duplicate',
+        version: '1.0.0',
+        instructions: 'Dup.',
+        appliesTo: ['deduptest.*'],
+        keywords: ['dup'],
+        priority: 10,
+        source: { kind: 'inline' },
+      }],
+    })).toThrow(/Duplicate skill id/);
+  });
 });

--- a/packages/harness/src/runtime/loader-skill.ts
+++ b/packages/harness/src/runtime/loader-skill.ts
@@ -18,6 +18,23 @@ const skillFrontmatterSchema = z.object({
   }).strict(),
 }).strict();
 
+export const inlineSkillSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  version: z.string().min(1),
+  author: z.string().min(1).optional(),
+  license: z.string().min(1).optional(),
+  instructions: z.string().min(1),
+  appliesTo: z.array(z.string().min(1)).min(1),
+  keywords: z.array(z.string().min(1)).min(1),
+  priority: z.number().int(),
+  source: z.object({
+    kind: z.enum(['inline', 'file']),
+    path: z.string().optional(),
+  }),
+});
+
 function validateSkillName(name: string): string {
   if (name.includes('..') || name.includes('/') || name.includes('\\')) {
     throw new Error(`Skill name contains an invalid path-like segment: ${name}`);

--- a/packages/harness/src/runtime/registry.ts
+++ b/packages/harness/src/runtime/registry.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildCatalogSnapshot, negotiateCatalog } from './catalog.js';
 import { loadAgentFile } from './loader-agent.js';
-import { loadSkillFile } from './loader-skill.js';
+import { loadSkillFile, inlineSkillSchema } from './loader-skill.js';
 import type { AgentContribution } from '../types/agent.js';
 import type { ComponentContribution } from '../types/component.js';
 import type { GuardrailContribution } from '../types/guardrail.js';
@@ -224,19 +224,42 @@ export class PackRegistry {
   }
 
   private loadSkills(pack: Pack): Skill[] {
-    const loaded: Skill[] = [];
+    const fileSkills: Skill[] = [];
     if (pack.skillsDir) {
       const baseDir = directoryURLToPath(pack.skillsDir);
       for (const entry of collectMarkdownFiles(baseDir, 'SKILL.md')) {
-        loaded.push(loadSkillFile(pack, entry));
+        fileSkills.push(loadSkillFile(pack, entry));
       }
     }
+
+    const inlineSkills: Skill[] = [];
     if (pack.skills) {
-      for (const skill of pack.skills) {
-        loaded.push(skill);
+      for (const raw of pack.skills) {
+        // Fix 2: enforce pack-name prefix — fail-closed, no auto-correction
+        if (!raw.id.startsWith(`${pack.name}/`)) {
+          throw new Error(`Inline skill id "${raw.id}" must be namespaced under "${pack.name}/"`);
+        }
+        // Fix 1: zod validation — same rigor as file-backed skills
+        const parsed = inlineSkillSchema.parse(raw);
+        const normalized = this.normalizeInlineSkill(pack, parsed as Skill);
+        // Fix 4: freeze to prevent post-registration mutation
+        const frozen = Object.freeze({
+          ...normalized,
+          appliesTo: Object.freeze([...(normalized.appliesTo ?? [])]),
+          keywords: Object.freeze([...(normalized.keywords ?? [])]),
+        }) as Skill;
+        inlineSkills.push(frozen);
       }
     }
-    return loaded;
+
+    // Fix 3: detect duplicates within the merged batch before any insertion
+    const seen = new Set<string>();
+    for (const id of [...fileSkills.map((s) => s.id), ...inlineSkills.map((s) => s.id)]) {
+      if (seen.has(id)) throw new Error(`Duplicate skill id "${id}" in pack "${pack.name}"`);
+      seen.add(id);
+    }
+
+    return [...fileSkills, ...inlineSkills];
   }
 
   private buildDependencyScope(pack: Pack): { tools: Map<string, ToolContribution>; userActions: Map<string, UserActionContribution> } {

--- a/packages/harness/src/runtime/registry.ts
+++ b/packages/harness/src/runtime/registry.ts
@@ -225,10 +225,16 @@ export class PackRegistry {
 
   private loadSkills(pack: Pack): Skill[] {
     const loaded: Skill[] = [];
-    if (!pack.skillsDir) return loaded;
-    const baseDir = directoryURLToPath(pack.skillsDir);
-    for (const entry of collectMarkdownFiles(baseDir, 'SKILL.md')) {
-      loaded.push(loadSkillFile(pack, entry));
+    if (pack.skillsDir) {
+      const baseDir = directoryURLToPath(pack.skillsDir);
+      for (const entry of collectMarkdownFiles(baseDir, 'SKILL.md')) {
+        loaded.push(loadSkillFile(pack, entry));
+      }
+    }
+    if (pack.skills) {
+      for (const skill of pack.skills) {
+        loaded.push(skill);
+      }
     }
     return loaded;
   }

--- a/packages/harness/src/types/pack.ts
+++ b/packages/harness/src/types/pack.ts
@@ -1,6 +1,7 @@
 import type { ComponentContribution } from './component.js';
 import type { GuardrailContribution } from './guardrail.js';
 import type { PlaygroundScenario } from './playground.js';
+import type { Skill } from './skill.js';
 import type { ToolContribution } from './tool.js';
 import type { UserActionContribution } from './user-action.js';
 
@@ -12,6 +13,7 @@ export interface Pack {
   dependsOn?: string[];
   agentsDir?: URL;
   skillsDir?: URL;
+  skills?: Skill[];          // inline skill registrations (no .md file required)
   tools?: ToolContribution[];
   userActions?: UserActionContribution[];
   components?: ComponentContribution[];


### PR DESCRIPTION
Working as Bender (Backend Dev)

Micro-fix: adds `skills?: Skill[]` to the `Pack` interface and merges inline skills in `PackRegistry.loadSkills()`.

Required by #483 (pack-aks-automatic deployment-safeguards).

### Changes
- `packages/harness/src/types/pack.ts`: added `Skill` import and `skills?: Skill[]` field to `Pack` interface
- `packages/harness/src/runtime/registry.ts`: updated `loadSkills()` to merge inline skills after dir-based load

### Tests
56 passed / 2 pre-existing failures (agent dependency scoping — unrelated to this fix).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>