### PR TITLE
feat(harness): Step 6 — Skill Resolver (#480)

### DIFF
--- a/packages/harness/src/__tests__/harness-exports.test.ts
+++ b/packages/harness/src/__tests__/harness-exports.test.ts
@@ -166,7 +166,7 @@ describe('runtime function stubs', () => {
   });
 
   it('resolveSkills returns an array', () => {
-    expect(Array.isArray(resolveSkills(Phase.Discover, []))).toBe(true);
+    expect(Array.isArray(resolveSkills([], { agentName: 'agent', userMessage: '', budgetTokens: 9999 }))).toBe(true);
   });
 
   it('processResponse returns an object', () => {

--- a/packages/harness/src/__tests__/resolve-skills.test.ts
+++ b/packages/harness/src/__tests__/resolve-skills.test.ts
@@ -49,14 +49,15 @@ describe('resolveSkills', () => {
 
   // Test 3: Budget truncation — skill too large for budget is excluded, smaller skill fits
   it('truncates skills that exceed token budget', () => {
-    // giant: 100 chars → 25 tokens; tiny: 4 chars → 1 token; budget = 5
+    // tiny rendered: '<skill name="pack/tiny">\nXXXX\n</skill>' = 38 chars → 10 tokens
+    // giant rendered: '<skill name="pack/giant">\n' + 100 chars + '\n</skill>' = 127 chars → 32 tokens
     // tiny has keyword match → ranks first; giant ranks second; giant doesn't fit after tiny
     const tiny = makeSkill({ id: 'pack/tiny', instructions: 'X'.repeat(4), keywords: ['deploy'] });
     const giant = makeSkill({ id: 'pack/giant', instructions: 'Y'.repeat(100), keywords: [] });
     const result = resolveSkills([giant, tiny], {
       agentName: 'agent',
       userMessage: 'deploy my app',
-      budgetTokens: 5, // tiny (1 token) fits; giant (25 tokens) does not
+      budgetTokens: 15, // tiny (10 tokens) fits; giant (32 tokens) does not
     });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('pack/tiny');

--- a/packages/harness/src/__tests__/resolve-skills.test.ts
+++ b/packages/harness/src/__tests__/resolve-skills.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSkills } from '../runtime/skill-resolver.js';
+import type { Skill } from '../types/skill.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? overrides.id,
+    description: overrides.description ?? 'A test skill',
+    version: overrides.version ?? '1.0.0',
+    instructions: overrides.instructions ?? 'Do the thing.',
+    appliesTo: overrides.appliesTo ?? ['*'],
+    keywords: overrides.keywords ?? [],
+    priority: overrides.priority ?? 0,
+    source: overrides.source ?? { kind: 'inline' },
+  };
+}
+
+// ── resolveSkills pipeline ────────────────────────────────────────────────────
+
+describe('resolveSkills', () => {
+  // Test 1: Keyword scoring — skill with matching keyword ranks above skill without
+  it('ranks skill with matching keyword above skill without', () => {
+    const withKeyword = makeSkill({ id: 'pack/with', keywords: ['deploy'], priority: 0 });
+    const withoutKeyword = makeSkill({ id: 'pack/without', keywords: ['unrelated'], priority: 0 });
+    const result = resolveSkills([withoutKeyword, withKeyword], {
+      agentName: 'agent',
+      userMessage: 'Please deploy my app',
+      budgetTokens: 9999,
+    });
+    expect(result[0].id).toBe('pack/with');
+    expect(result[1].id).toBe('pack/without');
+  });
+
+  // Test 2: Priority tiebreak — equal keyword scores use priority field
+  it('breaks keyword score ties using priority (lower = first)', () => {
+    const lowPri = makeSkill({ id: 'pack/low', keywords: ['build'], priority: 1 });
+    const highPri = makeSkill({ id: 'pack/high', keywords: ['build'], priority: 5 });
+    const result = resolveSkills([highPri, lowPri], {
+      agentName: 'agent',
+      userMessage: 'build the project',
+      budgetTokens: 9999,
+    });
+    expect(result[0].id).toBe('pack/low');
+    expect(result[1].id).toBe('pack/high');
+  });
+
+  // Test 3: Budget truncation — skill too large for budget is excluded, smaller skill fits
+  it('truncates skills that exceed token budget', () => {
+    // giant: 100 chars → 25 tokens; tiny: 4 chars → 1 token; budget = 5
+    // tiny has keyword match → ranks first; giant ranks second; giant doesn't fit after tiny
+    const tiny = makeSkill({ id: 'pack/tiny', instructions: 'X'.repeat(4), keywords: ['deploy'] });
+    const giant = makeSkill({ id: 'pack/giant', instructions: 'Y'.repeat(100), keywords: [] });
+    const result = resolveSkills([giant, tiny], {
+      agentName: 'agent',
+      userMessage: 'deploy my app',
+      budgetTokens: 5, // tiny (1 token) fits; giant (25 tokens) does not
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('pack/tiny');
+  });
+
+  // Test 4: Agent filter integration — skill with wrong appliesTo is excluded
+  it('excludes skills whose appliesTo does not match agentName', () => {
+    const forOther = makeSkill({ id: 'pack/other', appliesTo: ['other-agent'] });
+    const forThis = makeSkill({ id: 'pack/this', appliesTo: ['my-agent'] });
+    const result = resolveSkills([forOther, forThis], {
+      agentName: 'my-agent',
+      userMessage: '',
+      budgetTokens: 9999,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('pack/this');
+  });
+
+  // Test 5: Empty message — keyword scores all 0, sorted by priority
+  it('sorts by priority when userMessage is empty (all scores are 0)', () => {
+    const a = makeSkill({ id: 'pack/a', keywords: ['alpha'], priority: 2 });
+    const b = makeSkill({ id: 'pack/b', keywords: ['beta'], priority: 1 });
+    const c = makeSkill({ id: 'pack/c', keywords: ['gamma'], priority: 3 });
+    const result = resolveSkills([a, b, c], {
+      agentName: 'agent',
+      userMessage: '',
+      budgetTokens: 9999,
+    });
+    expect(result.map(s => s.id)).toEqual(['pack/b', 'pack/a', 'pack/c']);
+  });
+
+  // Test 6: No skills — returns empty array
+  it('returns empty array when no skills provided', () => {
+    const result = resolveSkills([], {
+      agentName: 'agent',
+      userMessage: 'hello',
+      budgetTokens: 9999,
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/harness/src/__tests__/skill-resolver.test.ts
+++ b/packages/harness/src/__tests__/skill-resolver.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest';
+import { matchesSkill, validateGlobPattern, FORBIDDEN_PATTERN_RE } from '../runtime/skill-matcher.js';
+import { estimateTokens, buildSkillPrompt, fitSkillsInBudget } from '../runtime/token-budget.js';
+import { PackRegistry } from '../runtime/registry.js';
+import type { Skill } from '../types/skill.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSkill(overrides: Partial<Skill> & { id: string }): Skill {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? overrides.id,
+    description: overrides.description ?? 'A test skill',
+    version: overrides.version ?? '1.0.0',
+    instructions: overrides.instructions ?? 'Do the thing.',
+    appliesTo: overrides.appliesTo ?? ['*'],
+    keywords: overrides.keywords ?? ['test'],
+    priority: overrides.priority ?? 0,
+    source: overrides.source ?? { kind: 'inline' },
+  };
+}
+
+// ── Phase A: matchesSkill ────────────────────────────────────────────────────
+
+describe('matchesSkill', () => {
+  it('matches when appliesTo is empty (applies to all)', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: [] });
+    expect(matchesSkill('any-agent', skill)).toBe(true);
+  });
+
+  it('matches when appliesTo is absent (undefined cast)', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: undefined as unknown as string[] });
+    expect(matchesSkill('any-agent', skill)).toBe(true);
+  });
+
+  it('C1: matches any agent when pattern is *', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: ['*'] });
+    expect(matchesSkill('alpha', skill)).toBe(true);
+    expect(matchesSkill('beta', skill)).toBe(true);
+  });
+
+  it('matches exact agent name', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: ['my-agent'] });
+    expect(matchesSkill('my-agent', skill)).toBe(true);
+    expect(matchesSkill('other-agent', skill)).toBe(false);
+  });
+
+  it('matches glob wildcard prefix', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: ['aks-*'] });
+    expect(matchesSkill('aks-deployer', skill)).toBe(true);
+    expect(matchesSkill('github-deployer', skill)).toBe(false);
+  });
+
+  it('matches glob wildcard suffix', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: ['*-deployer'] });
+    expect(matchesSkill('aks-deployer', skill)).toBe(true);
+    expect(matchesSkill('aks-reviewer', skill)).toBe(false);
+  });
+
+  it('returns false when no pattern matches', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: ['agent-a', 'agent-b'] });
+    expect(matchesSkill('agent-c', skill)).toBe(false);
+  });
+
+  it('returns true when at least one pattern matches', () => {
+    const skill = makeSkill({ id: 'pack/s1', appliesTo: ['agent-a', 'agent-b'] });
+    expect(matchesSkill('agent-b', skill)).toBe(true);
+  });
+});
+
+// ── Glob injection validation ────────────────────────────────────────────────
+
+describe('validateGlobPattern', () => {
+  it('accepts safe patterns', () => {
+    expect(() => validateGlobPattern('*')).not.toThrow();
+    expect(() => validateGlobPattern('aks-*')).not.toThrow();
+    expect(() => validateGlobPattern('my-agent')).not.toThrow();
+    expect(() => validateGlobPattern('pack.*')).not.toThrow();
+  });
+
+  it.each([';', '|', '&', '$', '`', '\\'])('rejects pattern containing "%s"', (char) => {
+    expect(() => validateGlobPattern(`${char}rm-rf`)).toThrow(/forbidden shell metacharacters/);
+  });
+
+  it('FORBIDDEN_PATTERN_RE matches dangerous chars', () => {
+    expect(FORBIDDEN_PATTERN_RE.test(';echo')).toBe(true);
+    expect(FORBIDDEN_PATTERN_RE.test('safe-pattern')).toBe(false);
+  });
+});
+
+describe('PackRegistry — glob injection at registration', () => {
+  it('throws when inline skill appliesTo contains shell metacharacter', () => {
+    const registry = new PackRegistry();
+    expect(() => {
+      registry.register({
+        name: 'my-pack',
+        skills: [
+          {
+            id: 'my-pack/bad-skill',
+            name: 'bad-skill',
+            description: 'Injected skill',
+            version: '1.0.0',
+            instructions: 'Some instructions',
+            appliesTo: ['*; rm -rf /'],
+            keywords: ['test'],
+            priority: 0,
+            source: { kind: 'inline' },
+          },
+        ],
+      });
+    }).toThrow(/forbidden shell metacharacters/);
+  });
+});
+
+// ── Phase B: listSkills ──────────────────────────────────────────────────────
+
+describe('PackRegistry.listSkills', () => {
+  function buildRegistry(): PackRegistry {
+    const registry = new PackRegistry();
+    registry.register({
+      name: 'pack-a',
+      skills: [
+        {
+          id: 'pack-a/skill-all',
+          name: 'skill-all',
+          description: 'Applies to all agents',
+          version: '1.0.0',
+          instructions: 'Global instructions.',
+          appliesTo: ['*'],
+          keywords: ['global'],
+          priority: 0,
+          source: { kind: 'inline' },
+        },
+        {
+          id: 'pack-a/skill-aks',
+          name: 'skill-aks',
+          description: 'Applies to aks agents only',
+          version: '1.0.0',
+          instructions: 'AKS-specific instructions.',
+          appliesTo: ['aks-*'],
+          keywords: ['aks'],
+          priority: 1,
+          source: { kind: 'inline' },
+        },
+      ],
+    });
+    registry.enable(['pack-a']);
+    return registry;
+  }
+
+  it('returns all skills when no agentName provided', () => {
+    const registry = buildRegistry();
+    const skills = registry.listSkills();
+    expect(skills).toHaveLength(2);
+  });
+
+  it('filters by agentName — matching * wildcard', () => {
+    const registry = buildRegistry();
+    const skills = registry.listSkills('aks-deployer');
+    // skill-all (*) and skill-aks (aks-*) both match
+    expect(skills.map((s) => s.id).sort()).toEqual(['pack-a/skill-aks', 'pack-a/skill-all']);
+  });
+
+  it('filters by agentName — non-matching agent gets only wildcard skills', () => {
+    const registry = buildRegistry();
+    const skills = registry.listSkills('github-agent');
+    // only skill-all (*) matches
+    expect(skills).toHaveLength(1);
+    expect(skills[0].id).toBe('pack-a/skill-all');
+  });
+
+  it('returns empty when no skills match', () => {
+    const registry = new PackRegistry();
+    registry.register({
+      name: 'pack-b',
+      skills: [
+        {
+          id: 'pack-b/niche',
+          name: 'niche',
+          description: 'Very specific skill',
+          version: '1.0.0',
+          instructions: 'Niche.',
+          appliesTo: ['special-agent'],
+          keywords: ['niche'],
+          priority: 0,
+          source: { kind: 'inline' },
+        },
+      ],
+    });
+    registry.enable(['pack-b']);
+    expect(registry.listSkills('other-agent')).toHaveLength(0);
+  });
+});
+
+// ── Phase C: token-budget ────────────────────────────────────────────────────
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('returns 0 for null', () => {
+    expect(estimateTokens(null)).toBe(0);
+  });
+
+  it('returns 0 for undefined', () => {
+    expect(estimateTokens(undefined)).toBe(0);
+  });
+
+  it('approximates token count for normal text', () => {
+    // 8 chars → Math.ceil(8/4) = 2
+    expect(estimateTokens('abcdefgh')).toBe(2);
+  });
+
+  it('rounds up (ceil) for non-divisible lengths', () => {
+    // 5 chars → Math.ceil(5/4) = 2
+    expect(estimateTokens('abcde')).toBe(2);
+    // 9 chars → Math.ceil(9/4) = 3
+    expect(estimateTokens('abcdefghi')).toBe(3);
+  });
+
+  it('does not throw on arbitrary input', () => {
+    expect(() => estimateTokens('   ')).not.toThrow();
+    expect(() => estimateTokens('\n\n\n')).not.toThrow();
+  });
+});
+
+describe('buildSkillPrompt', () => {
+  it('returns empty string for empty array', () => {
+    expect(buildSkillPrompt([])).toBe('');
+  });
+
+  it('formats a single skill', () => {
+    const skill = makeSkill({ id: 'pack/s1', instructions: 'Do this.' });
+    expect(buildSkillPrompt([skill])).toBe('## pack/s1\nDo this.');
+  });
+
+  it('joins multiple skills with double newline', () => {
+    const skills = [
+      makeSkill({ id: 'pack/s1', instructions: 'First.' }),
+      makeSkill({ id: 'pack/s2', instructions: 'Second.' }),
+    ];
+    expect(buildSkillPrompt(skills)).toBe('## pack/s1\nFirst.\n\n## pack/s2\nSecond.');
+  });
+});
+
+describe('fitSkillsInBudget', () => {
+  it('returns empty array when budget is 0', () => {
+    const skills = [makeSkill({ id: 'pack/s1', instructions: 'hello' })];
+    expect(fitSkillsInBudget(skills, 0)).toHaveLength(0);
+  });
+
+  it('includes skills that exactly fit the budget', () => {
+    // 'abcd' → 1 token; 'efgh' → 1 token; budget = 2
+    const skills = [
+      makeSkill({ id: 'pack/s1', instructions: 'abcd' }),
+      makeSkill({ id: 'pack/s2', instructions: 'efgh' }),
+    ];
+    const result = fitSkillsInBudget(skills, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('truncates at the first skill that overflows budget', () => {
+    // s1: 'abcd' → 1 token; s2: 'a'.repeat(400) → 100 tokens
+    const skills = [
+      makeSkill({ id: 'pack/s1', instructions: 'abcd' }),
+      makeSkill({ id: 'pack/s2', instructions: 'a'.repeat(400) }),
+      makeSkill({ id: 'pack/s3', instructions: 'xyz' }),
+    ];
+    // budget = 10: s1 fits (1), s2 overflows (100) — stops there, s3 never checked
+    const result = fitSkillsInBudget(skills, 10);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('pack/s1');
+  });
+
+  it('returns all skills when budget is large enough', () => {
+    const skills = [
+      makeSkill({ id: 'pack/s1', instructions: 'short' }),
+      makeSkill({ id: 'pack/s2', instructions: 'also short' }),
+    ];
+    expect(fitSkillsInBudget(skills, 10_000)).toHaveLength(2);
+  });
+});

--- a/packages/harness/src/__tests__/skill-resolver.test.ts
+++ b/packages/harness/src/__tests__/skill-resolver.test.ts
@@ -266,7 +266,7 @@ describe('buildSkillPrompt', () => {
 
   it('formats a single skill', () => {
     const skill = makeSkill({ id: 'pack/s1', instructions: 'Do this.' });
-    expect(buildSkillPrompt([skill])).toBe('## pack/s1\nDo this.');
+    expect(buildSkillPrompt([skill])).toBe('<skill name="pack/s1">\nDo this.\n</skill>');
   });
 
   it('joins multiple skills with double newline', () => {
@@ -274,7 +274,7 @@ describe('buildSkillPrompt', () => {
       makeSkill({ id: 'pack/s1', instructions: 'First.' }),
       makeSkill({ id: 'pack/s2', instructions: 'Second.' }),
     ];
-    expect(buildSkillPrompt(skills)).toBe('## pack/s1\nFirst.\n\n## pack/s2\nSecond.');
+    expect(buildSkillPrompt(skills)).toBe('<skill name="pack/s1">\nFirst.\n</skill>\n<skill name="pack/s2">\nSecond.\n</skill>');
   });
 });
 
@@ -285,24 +285,24 @@ describe('fitSkillsInBudget', () => {
   });
 
   it('includes skills that exactly fit the budget', () => {
-    // rendered: '## pack/s1\nabcd' = 15 chars → ceil(15/4) = 4 tokens each; budget = 8
+    // rendered: '<skill name="pack/s1">\nabcd\n</skill>' = 36 chars → ceil(36/4) = 9 tokens each; budget = 18
     const skills = [
       makeSkill({ id: 'pack/s1', instructions: 'abcd' }),
       makeSkill({ id: 'pack/s2', instructions: 'efgh' }),
     ];
-    const result = fitSkillsInBudget(skills, 8);
+    const result = fitSkillsInBudget(skills, 18);
     expect(result).toHaveLength(2);
   });
 
   it('skips oversized skills and includes subsequent skills that fit', () => {
-    // s1: rendered ~4 tokens; s2: rendered ~103 tokens; s3: rendered ~4 tokens
+    // s1 rendered: ~9 tokens; s2 rendered: ~108 tokens; s3 rendered: ~9 tokens
     const skills = [
       makeSkill({ id: 'pack/s1', instructions: 'abcd' }),
       makeSkill({ id: 'pack/s2', instructions: 'a'.repeat(400) }),
       makeSkill({ id: 'pack/s3', instructions: 'xyz' }),
     ];
-    // budget = 10: s1 fits (4), s2 overflows (103) — skipped, s3 fits (4)
-    const result = fitSkillsInBudget(skills, 10);
+    // budget = 20: s1 fits (9), s2 overflows (108) — skipped, s3 fits (9+9=18)
+    const result = fitSkillsInBudget(skills, 20);
     expect(result).toHaveLength(2);
     expect(result.map((s) => s.id)).toEqual(['pack/s1', 'pack/s3']);
   });
@@ -311,8 +311,8 @@ describe('fitSkillsInBudget', () => {
     const small1 = makeSkill({ id: 'pack/small1', instructions: 'tiny' });
     const huge = makeSkill({ id: 'pack/huge', instructions: 'x'.repeat(2000) });
     const small2 = makeSkill({ id: 'pack/small2', instructions: 'also tiny' });
-    // budget = 20 — both smalls render well under 20 tokens; huge does not
-    const result = fitSkillsInBudget([small1, huge, small2], 20);
+    // budget = 30 — both smalls render well under 30 tokens; huge does not
+    const result = fitSkillsInBudget([small1, huge, small2], 30);
     expect(result.map((s) => s.id)).toEqual(['pack/small1', 'pack/small2']);
   });
 

--- a/packages/harness/src/__tests__/skill-resolver.test.ts
+++ b/packages/harness/src/__tests__/skill-resolver.test.ts
@@ -82,6 +82,14 @@ describe('validateGlobPattern', () => {
     expect(() => validateGlobPattern(`${char}rm-rf`)).toThrow(/forbidden shell metacharacters/);
   });
 
+  it('rejects pattern longer than 256 chars', () => {
+    expect(() => validateGlobPattern('a'.repeat(257))).toThrow(/Glob pattern too long/);
+  });
+
+  it('accepts pattern of exactly 256 chars', () => {
+    expect(() => validateGlobPattern('a'.repeat(256))).not.toThrow();
+  });
+
   it('FORBIDDEN_PATTERN_RE matches dangerous chars', () => {
     expect(FORBIDDEN_PATTERN_RE.test(';echo')).toBe(true);
     expect(FORBIDDEN_PATTERN_RE.test('safe-pattern')).toBe(false);
@@ -112,7 +120,33 @@ describe('PackRegistry — glob injection at registration', () => {
   });
 });
 
-// ── Phase B: listSkills ──────────────────────────────────────────────────────
+describe('PackRegistry — frozen skills (Crit1)', () => {
+  it('skill returned by listSkills() has frozen appliesTo — mutation silently fails (non-strict) or throws (strict)', () => {
+    const registry = new PackRegistry();
+    registry.register({
+      name: 'my-pack',
+      skills: [
+        {
+          id: 'my-pack/frozen-skill',
+          name: 'frozen-skill',
+          description: 'Should be frozen',
+          version: '1.0.0',
+          instructions: 'Some instructions',
+          appliesTo: ['*'],
+          keywords: ['test'],
+          priority: 0,
+          source: { kind: 'inline' },
+        },
+      ],
+    });
+    registry.enable(['my-pack']);
+    const skill = registry.listSkills()[0];
+    // Object.freeze'd arrays throw in strict mode, silently fail otherwise
+    expect(() => {
+      (skill.appliesTo as string[]).push('*;rm -rf /');
+    }).toThrow();
+  });
+});
 
 describe('PackRegistry.listSkills', () => {
   function buildRegistry(): PackRegistry {
@@ -251,26 +285,35 @@ describe('fitSkillsInBudget', () => {
   });
 
   it('includes skills that exactly fit the budget', () => {
-    // 'abcd' → 1 token; 'efgh' → 1 token; budget = 2
+    // rendered: '## pack/s1\nabcd' = 15 chars → ceil(15/4) = 4 tokens each; budget = 8
     const skills = [
       makeSkill({ id: 'pack/s1', instructions: 'abcd' }),
       makeSkill({ id: 'pack/s2', instructions: 'efgh' }),
     ];
-    const result = fitSkillsInBudget(skills, 2);
+    const result = fitSkillsInBudget(skills, 8);
     expect(result).toHaveLength(2);
   });
 
-  it('truncates at the first skill that overflows budget', () => {
-    // s1: 'abcd' → 1 token; s2: 'a'.repeat(400) → 100 tokens
+  it('skips oversized skills and includes subsequent skills that fit', () => {
+    // s1: rendered ~4 tokens; s2: rendered ~103 tokens; s3: rendered ~4 tokens
     const skills = [
       makeSkill({ id: 'pack/s1', instructions: 'abcd' }),
       makeSkill({ id: 'pack/s2', instructions: 'a'.repeat(400) }),
       makeSkill({ id: 'pack/s3', instructions: 'xyz' }),
     ];
-    // budget = 10: s1 fits (1), s2 overflows (100) — stops there, s3 never checked
+    // budget = 10: s1 fits (4), s2 overflows (103) — skipped, s3 fits (4)
     const result = fitSkillsInBudget(skills, 10);
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('pack/s1');
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.id)).toEqual(['pack/s1', 'pack/s3']);
+  });
+
+  it('[small, huge, small] — both smalls included when huge overflows', () => {
+    const small1 = makeSkill({ id: 'pack/small1', instructions: 'tiny' });
+    const huge = makeSkill({ id: 'pack/huge', instructions: 'x'.repeat(2000) });
+    const small2 = makeSkill({ id: 'pack/small2', instructions: 'also tiny' });
+    // budget = 20 — both smalls render well under 20 tokens; huge does not
+    const result = fitSkillsInBudget([small1, huge, small2], 20);
+    expect(result.map((s) => s.id)).toEqual(['pack/small1', 'pack/small2']);
   });
 
   it('returns all skills when budget is large enough', () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -352,3 +352,8 @@ export type {
   PreparedChatA2ui,
   PrepareChatA2uiOptions,
 } from './a2ui/chat-a2ui.js';
+
+// ── Step 6: Skill Resolver ───────────────────────────────────────────────────
+export { estimateTokens, buildSkillPrompt, fitSkillsInBudget } from './runtime/token-budget.js';
+export { matchesSkill } from './runtime/skill-matcher.js';
+export { PackRegistry } from './runtime/registry.js';

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -194,7 +194,7 @@ export const githubKit: unknown = {};
 
 // ── Runtime function stubs — replaced by harness runtime in Steps 3-5 ───────
 export function buildSystemPrompt(_opts: unknown): string { return 'You are Kickstart, an AI-guided deployment assistant.'; }
-export function resolveSkills(_phase: unknown, _skills: unknown[]): unknown[] { return []; }
+// resolveSkills is now exported from ./runtime/skill-resolver (Step 6b)
 export function resolveConversationSkills(_ctx: unknown): unknown[] { return []; }
 export function processResponse(_text: string): unknown { return {}; }
 export function getPhaseDefinition(_phase: unknown): { label: string; description: string; nextPhase?: Phase } {
@@ -357,3 +357,5 @@ export type {
 export { estimateTokens, buildSkillPrompt, fitSkillsInBudget } from './runtime/token-budget.js';
 export { matchesSkill } from './runtime/skill-matcher.js';
 export { PackRegistry } from './runtime/registry.js';
+export { resolveSkills } from './runtime/skill-resolver.js';
+export type { ResolveSkillsOptions } from './runtime/skill-resolver.js';

--- a/packages/harness/src/runtime/loader-skill.ts
+++ b/packages/harness/src/runtime/loader-skill.ts
@@ -52,7 +52,7 @@ export function loadSkillFile(pack: Pack, filePath: string): Skill {
   const parsed = skillFrontmatterSchema.parse(attributes);
   const validatedName = validateSkillName(parsed.name);
 
-  return {
+  return Object.freeze({
     id: `${pack.name}/${validatedName}`,
     name: validatedName,
     description: parsed.description,
@@ -60,12 +60,12 @@ export function loadSkillFile(pack: Pack, filePath: string): Skill {
     ...(parsed.author ? { author: parsed.author } : {}),
     ...(parsed.license ? { license: parsed.license } : {}),
     instructions: body,
-    appliesTo: [...parsed['x-kickstart'].appliesTo],
-    keywords: [...parsed['x-kickstart'].keywords],
+    appliesTo: Object.freeze([...parsed['x-kickstart'].appliesTo]),
+    keywords: Object.freeze([...parsed['x-kickstart'].keywords]),
     priority: parsed['x-kickstart'].priority,
-    source: {
-      kind: 'file',
+    source: Object.freeze({
+      kind: 'file' as const,
       path: relative(resolve(baseDir), resolve(filePath)).replace(/\\/g, '/'),
-    },
-  };
+    }),
+  }) as Skill;
 }

--- a/packages/harness/src/runtime/registry.ts
+++ b/packages/harness/src/runtime/registry.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { buildCatalogSnapshot, negotiateCatalog } from './catalog.js';
 import { loadAgentFile } from './loader-agent.js';
 import { loadSkillFile, inlineSkillSchema } from './loader-skill.js';
+import { matchesSkill, validateGlobPattern } from './skill-matcher.js';
 import type { AgentContribution } from '../types/agent.js';
 import type { ComponentContribution } from '../types/component.js';
 import type { GuardrailContribution } from '../types/guardrail.js';
@@ -136,7 +137,13 @@ export class PackRegistry {
 
   getSkillsForAgent(agentName: string): Skill[] {
     this.getAgent(agentName);
-    return this.activeSkills().filter((skill) => matchesAnyPattern(agentName, skill.appliesTo));
+    return this.activeSkills().filter((skill) => matchesSkill(agentName, skill));
+  }
+
+  listSkills(agentName?: string): Skill[] {
+    const all = this.activeSkills();
+    if (!agentName) return all;
+    return all.filter((skill) => matchesSkill(agentName, skill));
   }
 
   getToolsForAgent(agentName: string): AgentCallableContribution[] {
@@ -242,6 +249,10 @@ export class PackRegistry {
         // Fix 1: zod validation — same rigor as file-backed skills
         const parsed = inlineSkillSchema.parse(raw);
         const normalized = this.normalizeInlineSkill(pack, parsed as Skill);
+        // Validate glob patterns at registration (Zapp: prevent injection)
+        for (const pattern of normalized.appliesTo ?? []) {
+          validateGlobPattern(pattern);
+        }
         // Fix 4: freeze to prevent post-registration mutation
         const frozen = Object.freeze({
           ...normalized,
@@ -249,6 +260,13 @@ export class PackRegistry {
           keywords: Object.freeze([...(normalized.keywords ?? [])]),
         }) as Skill;
         inlineSkills.push(frozen);
+      }
+    }
+
+    // Validate glob patterns for file-backed skills at registration time
+    for (const skill of fileSkills) {
+      for (const pattern of skill.appliesTo ?? []) {
+        validateGlobPattern(pattern);
       }
     }
 
@@ -534,19 +552,6 @@ export class PackRegistry {
       throw new Error(`Invalid pack name: ${name}`);
     }
   }
-}
-
-function matchesAnyPattern(value: string, patterns: readonly string[]): boolean {
-  return patterns.some((pattern) => globMatches(value, pattern));
-}
-
-function globMatches(value: string, pattern: string): boolean {
-  if (pattern === '*') {
-    return true;
-  }
-
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
-  return new RegExp(`^${escaped}$`).test(value);
 }
 
 function collectMarkdownFiles(baseDir: string, expectedSuffix: string): string[] {

--- a/packages/harness/src/runtime/registry.ts
+++ b/packages/harness/src/runtime/registry.ts
@@ -263,21 +263,26 @@ export class PackRegistry {
       }
     }
 
-    // Validate glob patterns for file-backed skills at registration time
-    for (const skill of fileSkills) {
+    // Validate glob patterns for file-backed skills at registration time, then freeze
+    const frozenFileSkills: Skill[] = fileSkills.map((skill) => {
       for (const pattern of skill.appliesTo ?? []) {
         validateGlobPattern(pattern);
       }
-    }
+      return Object.freeze({
+        ...skill,
+        appliesTo: Object.freeze([...(skill.appliesTo ?? [])]),
+        keywords: Object.freeze([...(skill.keywords ?? [])]),
+      }) as Skill;
+    });
 
     // Fix 3: detect duplicates within the merged batch before any insertion
     const seen = new Set<string>();
-    for (const id of [...fileSkills.map((s) => s.id), ...inlineSkills.map((s) => s.id)]) {
+    for (const id of [...frozenFileSkills.map((s) => s.id), ...inlineSkills.map((s) => s.id)]) {
       if (seen.has(id)) throw new Error(`Duplicate skill id "${id}" in pack "${pack.name}"`);
       seen.add(id);
     }
 
-    return [...fileSkills, ...inlineSkills];
+    return [...frozenFileSkills, ...inlineSkills];
   }
 
   private buildDependencyScope(pack: Pack): { tools: Map<string, ToolContribution>; userActions: Map<string, UserActionContribution> } {

--- a/packages/harness/src/runtime/skill-matcher.ts
+++ b/packages/harness/src/runtime/skill-matcher.ts
@@ -8,6 +8,9 @@ export const FORBIDDEN_PATTERN_RE = /[;|&$`\\]/;
  * Throws if the pattern contains shell metacharacters.
  */
 export function validateGlobPattern(pattern: string): void {
+  if (pattern.length > 256) {
+    throw new Error(`Glob pattern too long: max 256 chars`);
+  }
   if (FORBIDDEN_PATTERN_RE.test(pattern)) {
     throw new Error(
       `Glob pattern "${pattern}" contains forbidden shell metacharacters (;|&$\`\\). ` +

--- a/packages/harness/src/runtime/skill-matcher.ts
+++ b/packages/harness/src/runtime/skill-matcher.ts
@@ -1,0 +1,30 @@
+import type { Skill } from '../types/skill.js';
+
+/** Shell metacharacters that are forbidden in glob patterns. */
+export const FORBIDDEN_PATTERN_RE = /[;|&$`\\]/;
+
+/**
+ * Validate an appliesTo glob pattern at registration time.
+ * Throws if the pattern contains shell metacharacters.
+ */
+export function validateGlobPattern(pattern: string): void {
+  if (FORBIDDEN_PATTERN_RE.test(pattern)) {
+    throw new Error(
+      `Glob pattern "${pattern}" contains forbidden shell metacharacters (;|&$\`\\). ` +
+        `Reject at registration time to prevent injection.`,
+    );
+  }
+}
+
+/**
+ * Returns true if the given agentName matches the skill's appliesTo patterns.
+ * An empty or absent appliesTo list means the skill applies to all agents.
+ */
+export function matchesSkill(agentName: string, skill: Skill): boolean {
+  if (!skill.appliesTo || skill.appliesTo.length === 0) return true;
+  return skill.appliesTo.some((pattern) => {
+    if (pattern === '*') return true; // C1 short-circuit
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+    return new RegExp(`^${escaped}$`).test(agentName);
+  });
+}

--- a/packages/harness/src/runtime/skill-resolver.ts
+++ b/packages/harness/src/runtime/skill-resolver.ts
@@ -1,0 +1,41 @@
+import type { Skill } from '../types/skill.js';
+import { fitSkillsInBudget } from './token-budget.js';
+import { matchesSkill } from './skill-matcher.js';
+
+export interface ResolveSkillsOptions {
+  agentName: string;
+  userMessage: string;
+  budgetTokens: number;
+}
+
+/**
+ * Resolves the ordered, budget-trimmed list of skills for a given agent and user message.
+ *
+ * Pipeline:
+ *   1. Filter by appliesTo (matchesSkill)
+ *   2. Keyword scoring — count how many of skill.keywords[] appear in userMessage (case-insensitive)
+ *   3. Sort by score DESC, then priority ASC (lower number = higher priority)
+ *   4. Fit to token budget (fitSkillsInBudget)
+ */
+export function resolveSkills(skills: Skill[], opts: ResolveSkillsOptions): Skill[] {
+  // Stage 1: filter by appliesTo
+  const applicable = skills.filter(s => matchesSkill(opts.agentName, s));
+
+  // Stage 2: keyword scoring
+  const msg = opts.userMessage.toLowerCase();
+  const scored = applicable.map(skill => {
+    const score = (skill.keywords ?? []).filter(kw => msg.includes(kw.toLowerCase())).length;
+    return { skill, score };
+  });
+
+  // Stage 3: sort by score DESC, priority ASC
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return (a.skill.priority ?? 999) - (b.skill.priority ?? 999);
+  });
+
+  const sorted = scored.map(({ skill }) => skill);
+
+  // Stage 4: fit to budget
+  return fitSkillsInBudget(sorted, opts.budgetTokens);
+}

--- a/packages/harness/src/runtime/token-budget.ts
+++ b/packages/harness/src/runtime/token-budget.ts
@@ -8,7 +8,7 @@ export function estimateTokens(text: string | null | undefined): number {
 
 /** Build a single prompt string from a list of skills. */
 export function buildSkillPrompt(skills: Skill[]): string {
-  return skills.map((s) => `## ${s.id}\n${s.instructions}`).join('\n\n');
+  return skills.map((s) => `<skill name="${s.id}">\n${s.instructions}\n</skill>`).join('\n');
 }
 
 /**

--- a/packages/harness/src/runtime/token-budget.ts
+++ b/packages/harness/src/runtime/token-budget.ts
@@ -1,0 +1,29 @@
+import type { Skill } from '../types/skill.js';
+
+/** Approximation: ~4 characters per token. Fail-safe: returns 0 on empty/null/undefined. */
+export function estimateTokens(text: string | null | undefined): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+/** Build a single prompt string from a list of skills. */
+export function buildSkillPrompt(skills: Skill[]): string {
+  return skills.map((s) => `## ${s.id}\n${s.instructions}`).join('\n\n');
+}
+
+/**
+ * Greedily select skills that fit within the given token budget.
+ * Skills are taken in order; the first skill that would exceed the budget
+ * stops iteration.
+ */
+export function fitSkillsInBudget(skills: Skill[], budgetTokens: number): Skill[] {
+  const result: Skill[] = [];
+  let used = 0;
+  for (const skill of skills) {
+    const tokens = estimateTokens(skill.instructions);
+    if (used + tokens > budgetTokens) break;
+    result.push(skill);
+    used += tokens;
+  }
+  return result;
+}

--- a/packages/harness/src/runtime/token-budget.ts
+++ b/packages/harness/src/runtime/token-budget.ts
@@ -13,15 +13,16 @@ export function buildSkillPrompt(skills: Skill[]): string {
 
 /**
  * Greedily select skills that fit within the given token budget.
- * Skills are taken in order; the first skill that would exceed the budget
- * stops iteration.
+ * Each skill is costed as its fully-rendered block (header + instructions).
+ * Oversized skills are skipped (continue) so later smaller skills can still fit.
  */
 export function fitSkillsInBudget(skills: Skill[], budgetTokens: number): Skill[] {
   const result: Skill[] = [];
   let used = 0;
   for (const skill of skills) {
-    const tokens = estimateTokens(skill.instructions);
-    if (used + tokens > budgetTokens) break;
+    const rendered = buildSkillPrompt([skill]);
+    const tokens = estimateTokens(rendered);
+    if (used + tokens > budgetTokens) continue; // SKIP oversized, not break
     result.push(skill);
     used += tokens;
   }


### PR DESCRIPTION
Implements skill resolution, glob matching, and token budget utilities.

## Changes
- **Phase A** — `matchesSkill()` in `skill-matcher.ts` with `*` short-circuit (C1) + `validateGlobPattern()` rejecting shell metacharacters at registration (Zapp)
- **Phase B** — `listSkills(agentName?: string)` on `PackRegistry` (C2)
- **Phase C** — `estimateTokens` / `buildSkillPrompt` / `fitSkillsInBudget` in `token-budget.ts` — fail-safe on null/undefined (Zapp)
- **Phase D** — All utilities re-exported from `packages/harness/src/index.ts` (C3); `PackRegistry` also exported
- **Phase E** — 34 tests in `skill-resolver.test.ts` covering all functions, edge cases, and injection guard

Closes #480

Working as Fry (Full-Stack Dev)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>