### PR TITLE
fix(workflows): fix YAML syntax errors in squad ceremony workflows

### DIFF
--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -53,7 +53,7 @@ jobs:
             } else {
               pr = context.payload.pull_request;
             }
-            if (pr.state === 'open' || (pr.closed_at == null && pr.merged_at == null)) {
+            if (pr.state === 'open') {
               throw new Error(
                 `PR #${pr.number} is not closed yet (state: ${pr.state}). Retro metrics can only be generated for closed or merged pull requests.`
               );

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -17,6 +17,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: squad-pr-retro-log
+  cancel-in-progress: false
+
 jobs:
   retro:
     runs-on: ubuntu-latest
@@ -102,12 +106,16 @@ jobs:
 
             core.setOutput('line', line);
             core.setOutput('pr', String(pr.number));
+            core.setOutput('base_ref', pr.base?.ref ?? context.payload.repository?.default_branch ?? 'main');
 
       - name: Append to retro log (as Scribe)
         env:
+          BASE_REF: ${{ steps.metrics.outputs.base_ref }}
           LINE: ${{ steps.metrics.outputs.line }}
         run: |
           set -e
+          git fetch origin "$BASE_REF"
+          git checkout -B "$BASE_REF" "origin/$BASE_REF"
           mkdir -p .squad
           touch .squad/retro-log.md
           # Insert the new line directly after the entries marker
@@ -130,7 +138,16 @@ jobs:
             exit 0
           fi
           git commit -m "chore(retro-log): #${{ steps.metrics.outputs.pr }} [scribe]" -m "Working as Scribe — see .squad/agents/scribe/charter.md"
-          git push
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:$BASE_REF"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Push failed after 3 attempts."
+              exit 1
+            fi
+            git pull --rebase origin "$BASE_REF"
+          done
 
       - name: Mirror line as PR comment
         uses: actions/github-script@v7
@@ -150,6 +167,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: parseInt('${{ steps.metrics.outputs.pr }}'),
+              issue_number: parseInt('${{ steps.metrics.outputs.pr }}', 10),
               body,
             });

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -53,6 +53,11 @@ jobs:
             } else {
               pr = context.payload.pull_request;
             }
+            if (pr.state !== 'closed' || (pr.closed_at == null && pr.merged_at == null)) {
+              throw new Error(
+                `PR #${pr.number} is not closed yet (state: ${pr.state}). Retro metrics can only be generated for closed or merged pull requests.`
+              );
+            }
             const title = (pr.title || '').replace(/"/g, "'");
             const author = pr.user?.login ?? 'unknown';
             const changed = (pr.additions ?? 0) + (pr.deletions ?? 0);

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -34,10 +34,15 @@ jobs:
           script: |
             let pr;
             if (context.eventName === 'workflow_dispatch') {
+              const prNumberInput = context.payload.inputs.pr_number;
+              const prNumber = parseInt(prNumberInput, 10);
+              if (Number.isNaN(prNumber)) {
+                throw new Error(`Invalid workflow_dispatch input "pr_number": "${prNumberInput}". Expected a numeric pull request number.`);
+              }
               const { data } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: parseInt(context.payload.inputs.pr_number),
+                pull_number: prNumber,
               });
               pr = data;
               pr.merged = pr.merged_at != null;

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -53,7 +53,7 @@ jobs:
             } else {
               pr = context.payload.pull_request;
             }
-            if (pr.state !== 'closed' || (pr.closed_at == null && pr.merged_at == null)) {
+            if (pr.state === 'open' || (pr.closed_at == null && pr.merged_at == null)) {
               throw new Error(
                 `PR #${pr.number} is not closed yet (state: ${pr.state}). Retro metrics can only be generated for closed or merged pull requests.`
               );

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -6,14 +6,16 @@ name: Squad · PR Retro
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to backfill retro entry for'
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
-
-concurrency:
-  group: squad-pr-retro-${{ github.repository }}-${{ github.event.pull_request.base.ref }}
-  cancel-in-progress: false
 
 jobs:
   retro:
@@ -24,14 +26,24 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Compute metrics
         id: metrics
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request;
+            let pr;
+            if (context.eventName === 'workflow_dispatch') {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parseInt(context.payload.inputs.pr_number),
+              });
+              pr = data;
+              pr.merged = pr.merged_at != null;
+            } else {
+              pr = context.payload.pull_request;
+            }
             const title = (pr.title || '').replace(/"/g, "'");
             const author = pr.user?.login ?? 'unknown';
             const changed = (pr.additions ?? 0) + (pr.deletions ?? 0);
@@ -112,26 +124,8 @@ jobs:
             echo "No retro-log changes to commit (duplicate event?)"
             exit 0
           fi
-          git commit -m "chore(retro-log): #${{ steps.metrics.outputs.pr }} [scribe]
-
-Working as Scribe — see .squad/agents/scribe/charter.md"
-          max_attempts=3
-          for attempt in $(seq 1 "$max_attempts"); do
-            if git push; then
-              break
-            fi
-            if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "git push failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "git push failed (attempt ${attempt}); rebasing latest base branch before retry"
-            if ! git pull --rebase origin "${{ github.event.pull_request.base.ref }}"; then
-              echo "git pull --rebase failed while preparing retry push"
-              exit 1
-            fi
-            sleep_seconds=$((2 ** attempt))
-            sleep "$sleep_seconds"
-          done
+          git commit -m "chore(retro-log): #${{ steps.metrics.outputs.pr }} [scribe]" -m "Working as Scribe — see .squad/agents/scribe/charter.md"
+          git push
 
       - name: Mirror line as PR comment
         uses: actions/github-script@v7
@@ -151,6 +145,6 @@ Working as Scribe — see .squad/agents/scribe/charter.md"
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: parseInt('${{ steps.metrics.outputs.pr }}'),
               body,
             });

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -115,7 +115,12 @@ jobs:
         run: |
           set -e
           git fetch origin "$BASE_REF"
-          git checkout -B "$BASE_REF" "origin/$BASE_REF"
+          if git show-ref --verify --quiet "refs/heads/$BASE_REF"; then
+            git checkout "$BASE_REF"
+            git reset --hard "origin/$BASE_REF"
+          else
+            git checkout -b "$BASE_REF" "origin/$BASE_REF"
+          fi
           mkdir -p .squad
           touch .squad/retro-log.md
           # Insert the new line directly after the entries marker
@@ -139,6 +144,7 @@ jobs:
           fi
           git commit -m "chore(retro-log): #${{ steps.metrics.outputs.pr }} [scribe]" -m "Working as Scribe — see .squad/agents/scribe/charter.md"
           for attempt in 1 2 3; do
+            echo "Push attempt $attempt/3 to $BASE_REF"
             if git push origin "HEAD:$BASE_REF"; then
               break
             fi
@@ -147,6 +153,7 @@ jobs:
               exit 1
             fi
             git pull --rebase origin "$BASE_REF"
+            sleep 2
           done
 
       - name: Mirror line as PR comment

--- a/.github/workflows/squad-release-cadence.yml
+++ b/.github/workflows/squad-release-cadence.yml
@@ -80,9 +80,7 @@ jobs:
           git checkout -B release/cadence
           npm run version
           git add -A
-          git commit -m "chore(release): daily cadence [leela]
-
-Working as Leela — see .squad/agents/leela/charter.md"
+          git commit -m "chore(release): daily cadence [leela]" -m "Working as Leela — see .squad/agents/leela/charter.md"
           git push --force-with-lease origin release/cadence
 
       - name: Open release PR (as Leela, with Scribe curating notes)


### PR DESCRIPTION
## What

Fixes YAML syntax errors in both squad ceremony workflows that prevented them from ever running.

## Why

Multi-line `git commit -m` body (blank line + continuation at column 0) terminated the YAML `run: |` block early, making GitHub reject both files as invalid YAML on parse.

## Changes

- `squad-pr-retro.yml`: fix multi-line commit message; add `workflow_dispatch` input (`pr_number`) so missed retros can be backfilled
- `squad-release-cadence.yml`: fix multi-line commit message

## After merge

Run backfill for the 10 missed PRs (#471 #481 #543–#550) and trigger the release cadence check.