### PR TITLE
fix(workflows): use Squad lead app token for protected branch push

### DIFF
--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -31,6 +31,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate Squad lead token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SQUAD_LEAD_APP_ID }}
+          private-key: ${{ secrets.SQUAD_LEAD_PRIVATE_KEY }}
+
       - name: Compute metrics
         id: metrics
         uses: actions/github-script@v7
@@ -150,7 +157,7 @@ jobs:
           git commit -m "chore(retro-log): #${{ steps.metrics.outputs.pr }} [scribe]" -m "Working as Scribe — see .squad/agents/scribe/charter.md"
           for attempt in 1 2 3; do
             echo "Push attempt $attempt/3 to $BASE_REF"
-            if git push origin "HEAD:$BASE_REF"; then
+            if git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git "HEAD:$BASE_REF"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then

--- a/.github/workflows/squad-release-cadence.yml
+++ b/.github/workflows/squad-release-cadence.yml
@@ -25,6 +25,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate Squad lead token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SQUAD_LEAD_APP_ID }}
+          private-key: ${{ secrets.SQUAD_LEAD_PRIVATE_KEY }}
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -81,7 +88,7 @@ jobs:
           npm run version
           git add -A
           git commit -m "chore(release): daily cadence [leela]" -m "Working as Leela — see .squad/agents/leela/charter.md"
-          git push --force-with-lease origin release/cadence
+          git push --force-with-lease https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git release/cadence
 
       - name: Open release PR (as Leela, with Scribe curating notes)
         if: steps.existing.outputs.exists == 'false'


### PR DESCRIPTION
**Working as Leela (Lead)** · see `.squad/agents/leela/charter.md`

## Problem

Both ceremony workflows (`squad-pr-retro.yml` and `squad-release-cadence.yml`) do `git push` using `GITHUB_TOKEN` (`github-actions[bot]`), which is blocked by the branch protection ruleset. `github-actions[bot]` cannot be added as a bypass actor.

## Solution

Use the `sabbour-squad-lead` GitHub App (appId: 3340358) to generate an installation token via `actions/create-github-app-token@v1`. This app can be added as a bypass actor.

## Required setup (before merging)

1. Add `sabbour-squad-lead` as a bypass actor in the branch protection ruleset
2. Add secrets to the repo:
   - `SQUAD_LEAD_APP_ID` = `3340358`
   - `SQUAD_LEAD_PRIVATE_KEY` = contents of the lead app private key

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)