### PR TITLE
fix(retro): always target main for retro-log PRs

### DIFF
--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -111,7 +111,7 @@ jobs:
 
             core.setOutput('line', line);
             core.setOutput('pr', String(pr.number));
-            core.setOutput('base_ref', pr.base?.ref ?? context.payload.repository?.default_branch ?? 'main');
+            core.setOutput('base_ref', 'main');
 
       - name: Append to retro log (as Scribe)
         env:

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   retro:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'retro-log') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/squad-pr-retro.yml
+++ b/.github/workflows/squad-pr-retro.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   retro:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'retro-log') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'retro-log') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -158,7 +158,6 @@ jobs:
 
           PR_COUNT="$(gh pr list \
             --state open \
-            --base "$BASE_REF" \
             --head "${SIDE_BRANCH}" \
             --json number \
             --jq 'length')"
@@ -170,7 +169,6 @@ jobs:
 
           PR_URL="$(gh pr list \
             --state open \
-            --base "$BASE_REF" \
             --head "${SIDE_BRANCH}" \
             --json url \
             --jq '.[0].url')"


### PR DESCRIPTION
Fixes retro-log PRs targeting feature branches instead of main.\n\nThe `base_ref` output in the metrics step previously used the original PR's base branch. This changes it to always use `main`, so the retro log is always canonical on main regardless of which branch the source PR merged into.\n\nCloses no issue — user directive.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>