### PR TITLE
docs: Step 13 — scrub Azure identifiers, delete v1 refs, update docs (#488)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,26 +10,23 @@ Kickstart helps developers go from "I have an app" to "it's running on Azure" th
 
 ## Features
 
-- **AI-guided landing page** — Track cards, framework pills, and an ✨ inspiration button that generates app ideas via AI
-- **A2UI component system** — 16 custom components + Fluent UI 2 styled vendor catalog, rendered from structured JSON returned by the LLM
-- **Component playground** — Interactive sidebar-navigated demo surface (https://kickstart.aks.azure.sabbour.me/?playground) for exploring A2UI components, scenarios, and questionnaire flows
-- **Fat A2UI components** — Azure and GitHub login cards, resource pickers, and action buttons with real API integration, in-memory token storage, and operation allowlisting
-- **LLM function calling** — Tool system enables the LLM to directly query Azure resources, GitHub repos, and web content
-- **ServiceConnector & ServicePack patterns** — Declarative auth requirements, kit lifecycle hooks, and dependency validation for seamless Azure/GitHub integration
-- **CORS proxy security** — Private IP filtering, redirect validation, and hostname allowlisting for safe cross-origin API calls
-- **Action system** — Unified button action pipeline with `/api/action` endpoint for component-driven interactions
-- **Azure Functions API** — Streaming conversation proxy, code generation (Codex), CORS proxies for ARM/GitHub/Pricing APIs
+- **Harness + packs architecture** — domain-agnostic runtime (`@kickstart/harness`) + domain packs (`pack-core`, `pack-azure`, `pack-aks-automatic`, `pack-github`)
+- **A2UI component system** — Fluent UI 2 styled components rendered from structured JSON emitted by agents via `core.emit_ui`
+- **Component playground** — Interactive demo surface for exploring A2UI components, scenarios, and questionnaire flows
+- **Azure and GitHub integration** — Login cards, resource pickers, and action buttons with real API integration via UserAction pause/resume
+- **`@openai/agents` SDK** — Agents call tools; UserActions pause the runner for browser-side interactions (MSAL popup, GitHub OAuth, etc.)
+- **Guardrails engine** — Cross-cutting checks at input, tool-call, and output stages contributed by packs
 - **MCP server** — IDE integration for VS Code Copilot and Claude Code via `@kickstart/mcp-server`
-- **Monorepo** — `packages/core` (engine), `packages/web` (React 19 + Vite 6), `packages/mcp-server` (MCP tools)
+- **Monorepo** — `packages/harness` (runtime), `packages/pack-*` (domain packs), `packages/web` (React 19 + Vite 6), `packages/mcp-server`
 
-## Two Surfaces, One Engine
+## Two Surfaces, One Harness
 
 | Surface | How it works | LLM |
 |---------|-------------|-----|
 | **Web Portal** | Azure Static Web Apps with a Copilot-style chat panel | Azure OpenAI (hosted) |
 | **IDE (MCP)** | MCP server for VS Code and Claude Code | User's own LLM |
 
-Both surfaces share `@kickstart/core` — the conversation engine, A2UI component catalog, prompt system, and code generators.
+Both surfaces use `@kickstart/harness` — the pack registry, Runner, SSE adapter, and session management.
 
 ## Quick Start
 

--- a/docs-site/docs/architecture/a2ui-integration.md
+++ b/docs-site/docs/architecture/a2ui-integration.md
@@ -123,7 +123,7 @@ Updates just the data of an existing component (without replacing it):
 
 ## Fat Components
 
-Starting in v0.3.0, Kickstart includes **fat components** — self-managing implementations of common workflows with built-in authentication, validation, and security controls. Registered as part of the `azure` and `github` IntegrationKits.
+Starting in v0.3.0, Kickstart includes **fat components** — self-managing implementations of common workflows with built-in authentication, validation, and security controls. Contributed by the `pack-azure` and `pack-github` packs.
 
 ### Azure Fat Components
 

--- a/docs-site/docs/architecture/fsm.md
+++ b/docs-site/docs/architecture/fsm.md
@@ -16,7 +16,7 @@ An earlier version of the codebase included a TypeScript state machine (`machine
 
 ### Phase Catalog
 
-Phases are defined in `packages/core/src/engine/phases.ts` as a static array:
+Phases are defined in the harness session types:
 
 ```typescript
 export interface PhaseDefinition {
@@ -50,20 +50,11 @@ This is the single source of truth. There is no separate FSM state slice, no `ph
 
 ### Phase Advancement
 
-`advancePhase()` in `converse.ts` looks up the current phase in `PHASE_DEFINITIONS` and returns `nextPhase`:
-
-```typescript
-function advancePhase(currentPhase: Phase): Phase {
-  const def = PHASE_DEFINITIONS.find((p) => p.id === currentPhase);
-  return def?.nextPhase ?? currentPhase;
-}
-```
-
-The LLM signals that a phase is complete via `phaseComplete: true` in its JSON response envelope. The `converse` handler reads this flag and calls `advancePhase()` — there is no event system or transition guard.
+`advancePhase()` looks up the current phase in `PHASE_DEFINITIONS` and returns `nextPhase`. The agent signals phase completion via the `intent: "advance"` field in `AgentOutput`.
 
 ### How the LLM Knows Its Phase
 
-The system prompt includes the current phase identifier and the `description` from its `PhaseDefinition`. This tells the LLM what to focus on and when to signal completion.
+The agent's dynamic instructions include the current phase identifier and description from its `PhaseDefinition`. This tells the LLM what to focus on and when to signal completion via `intent: "advance"` in `AgentOutput`.
 
 ---
 
@@ -81,8 +72,6 @@ The original `machine.ts` implemented a pure-function state machine with:
 
 The machine was removed because it duplicated the LLM's own phase judgment without adding correctness guarantees.
 
----
-
 ## Future Direction
 
-Phase behavior is expected to evolve significantly with the Agents SDK integration. See issue [#330](https://github.com/sabbour/kickstart/issues/330) for the planned redesign. The current plain-string approach is intentionally minimal — a clean baseline before that work begins.
+Phase behavior continues to evolve with the v2 harness + packs model. Phase transitions are now signalled via `AgentOutput.intent = "advance"` rather than a JSON envelope flag. See [Architecture Overview](./overview.md) for the current v2 request flow.

--- a/docs-site/docs/architecture/overview.md
+++ b/docs-site/docs/architecture/overview.md
@@ -4,115 +4,93 @@ sidebar_position: 1
 
 # Architecture Overview
 
-Kickstart is a monorepo with three packages — a shared core engine, a React SPA, and an MCP server for IDE integration. The web surface runs on Azure Static Web Apps with a managed functions backend.
+Kickstart v2 is a **harness + packs** system. The harness is domain-agnostic; packs carry all product knowledge.
 
 ## Monorepo Structure
 
 ```
 kickstart/
 ├── packages/
-│   ├── core/          @kickstart/core — shared TypeScript engine
-│   │   ├── engine/        phase catalog (phases.ts), skill resolver (skill-resolver.ts)
-│   │   ├── kits/          IntegrationKit interface + defaultKitRegistry
-│   │   ├── prompts/       buildSystemPrompt(), phase templates, component catalog
-│   │   ├── services/      resolveConversationSkills (per-turn injection)
-│   │   └── tools/         ToolRegistry + built-in LLM-callable tools
-│   ├── web/           @kickstart/web — React SPA + Azure Functions API
-│   │   ├── api/           Azure Functions (converse, health, proxies)
-│   │   │   └── src/lib/   session-store, openai-client, model-router, rate-limiter
+│   ├── harness/           @kickstart/harness — runtime engine
 │   │   └── src/
-│   │       ├── catalog/   A2UI component implementations (22 custom — asserted in `custom-component-count.test.ts`; base catalog has 33 entries — asserted in `component-catalog.test.ts`)
-│   │       ├── components/ Chat UI, FileEditor sidebar, Landing
-│   │       └── services/  virtual-fs.ts (browser-side virtual file store with IndexedDB persistence)
-│   └── mcp-server/    @kickstart/mcp-server — optional IDE adapter
-└── infra/             Bicep templates for Azure provisioning
+│   │       ├── runtime/       Runner, session, SSE adapter
+│   │       ├── a2ui/          A2UI v0.9 message types and helpers
+│   │       ├── mcp/           MCP adapter utilities
+│   │       └── types/         Shared Zod schemas (AgentOutput, etc.)
+│   ├── pack-core/         @kickstart/pack-core — base agents, skills, tools, components
+│   ├── pack-azure/        @kickstart/pack-azure — Azure agents, tools, user actions
+│   ├── pack-aks-automatic/ @kickstart/pack-aks-automatic — AKS Automatic deployment pack
+│   ├── pack-github/       @kickstart/pack-github — GitHub agents, tools, user actions
+│   ├── web/               @kickstart/web — React SPA + Azure Functions API
+│   │   ├── api/               Azure Functions (converse, resume, packs manifest)
+│   │   └── src/               React app, A2UI renderer, catalog components
+│   └── mcp-server/        @kickstart/mcp-server — MCP adapter for IDE clients
+└── infra/                 Bicep templates for Azure provisioning
 ```
+
+## The Five Primitives
+
+Every harness interaction is built from five primitive types that packs contribute:
+
+| Primitive | Sigil | Example |
+|-----------|-------|---------|
+| **Agent** | `.` | `core.triage`, `azure.architect` |
+| **Tool** | `.` | `azure.arm_get`, `core.write_file` |
+| **UserAction** | `:` | `azure:login`, `github:oauth` |
+| **Component** | `/` | `pack-core/Button`, `azure/Login` |
+| **Guardrail** | — | `core/token-budget`, `azure/no-hardcoded-creds` |
 
 ## Request Flow
 
 ```
-POST /api/converse { sessionId, message, messages? }
-  1. Rate limit + content safety checks
-  2. Session lookup or creation (rehydrate from client messages[] on cold start)
-  3. resolveSkills(phase, kits)         ← kit prompts for system prompt (Mechanism A)
-  4. resolveConverseModelRoute()        ← trust-based model selection
-  5. buildSystemPrompt({ phase, kitPrompts, artifactSummary })
-  6. resolveConversationSkills(msg)     ← per-turn domain injection (Mechanism B)
-  7. Call Azure OpenAI
-  8. Parse JSON → if phaseComplete: true → advancePhase()
-  9. Extract FileEditor artifacts → session store
- 10. Stream SSE events to client
+POST /api/converse { sessionId, message }
+  1. Rate limit + guardrail input check
+  2. Session lookup or creation
+  3. Runner selects active Agent (session.activeAgent, default core.triage)
+  4. Dynamic instructions = agent body + resolvedSkills(agent, ctx) + catalog
+  5. Agent streams text, emits A2UI via core.emit_ui tool calls
+  6. Agent may call Tools or UserActions
+     └─ UserAction: pause → emit user_action_required SSE → browser acts → POST /api/converse/resume
+  7. Guardrails run at input, tool-call, and output stages
+  8. AgentOutput { message, intent } returned
+  9. Handoff → next Agent picks up future turns
+ 10. Stream typed SSE events to client: chunk | a2ui | tool | handoff | intent | done | error
 ```
 
-See [Prompt Pipeline](./prompt-pipeline.md) for the full assembly order with code references.
+See [Prompt Pipeline](./prompt-pipeline.md) for the per-turn assembly details.
 
 ## Server-Side vs Client-Side State
 
 | What | Where | Lifetime |
 |------|-------|----------|
-| Conversation messages | Server (memory) | 1 hour |
-| Phase string (`currentPhase`) | Server session | 1 hour |
-| Generated artifact metadata | Server (memory) | 1 hour |
-| Full generated file content | Client message history | Browser session |
-| Virtual FS (file content for sidebar) | Client memory + optional IndexedDB (`kickstart-vfs`) | No TTL |
-| `routingPhaseTrusted` flag | Server session | Reset on rehydration |
+| Conversation messages | Server session (memory) | 1 hour |
+| Active agent name | Server session | Per turn |
+| Generated artifact metadata | Server session | 1 hour |
+| Virtual FS (file content) | Client memory + IndexedDB (`kickstart-vfs`) | No TTL |
 
-**Cold start:** Server session expires → client resends up to 50 messages for rehydration. All messages content-safety checked. `routingPhaseTrusted` reset to `false` — client cannot self-elevate to generate-tier model.
-
-## AI Engine
-
-- **Azure OpenAI GPT-5.4-mini** for all conversation phases (`AZURE_OPENAI_CHAT_DEPLOYMENT`)
-- **Azure OpenAI GPT-5.4** for Generate phase when server-trusted (`AZURE_OPENAI_CODEX_DEPLOYMENT`)
-- Model selection is trust-based, not phase-based — see [Prompt Pipeline: Model Routing](./prompt-pipeline.md#model-routing)
-- Two skill injection mechanisms run every turn — see [Skill Injection](./skill-injection.md)
-- Phase tracking: `session.state.currentPhase` (plain string) — see [Phase System](./fsm.md)
-
-## A2UI Component Catalog
-
-Two FileEditor concepts, both backed by `services/virtual-fs.ts`:
-
-Both use `services/virtual-fs.ts` as the browser-side virtual file store: data lives in client memory and may also be persisted in IndexedDB for reuse across sessions. This module does not implement a 1-hour TTL eviction policy.
-
-- **A2UI FileEditor** (`catalog/components/FileEditor.tsx`) — ephemeral, per-turn in-chat component. LLM controls content.
-- **Sidebar FileEditor** (`components/FileEditor/`) — persistent panel with FileTree + Monaco. Shows all generated files across the session.
-
-Base catalog: `packages/core/src/prompts/component-catalog.ts`. Kit-contributed components merged at `buildSystemPrompt()` time.
-
-## Code Health Notes
-
-:::note Exported but uncalled APIs removed
-`resolveSkillsAsync()` and `resolveSkillsFromList()` were exported from `@kickstart/core` but never called in any production handler. They were removed in PR #402. Only `resolveSkills()` remains as the public entry point.
-:::
-
-:::info Both skill paths are active
-**`azure-kit.ts` uses the typed `kit.skills[]` path** (Path 1) — it registers `skills: azureIacSkills` (see `azure-kit.ts:573`). **`github-kit.ts` uses the legacy `kit.prompts[]` / `kit.phasePrompts{}` path** (Path 2). Both paths are valid for kit authors. Consolidation of the two paths into a single mechanism is tracked as future work.
-:::
-
-:::note Two keyword systems with no shared vocabulary
-Mechanism A (kit prompt classification) and Mechanism B (user message classification) both key on words like `"dockerfile"`, `"manifest"`, `"pipeline"` — but in separate files with separate formats. They will drift independently.
-:::
+**Cold start:** Server session expires → client resends message history. Session is restored from the conversation log.
 
 ## Session Lifecycle
 
 ```
 Client POST (no sessionId)
-  → createSession()  OR  hydrateSession(messages[])
-  → Session ID returned in response
+  → createSession() → Session ID returned
 
 Client POST (with sessionId, session alive)
   → getSession(sessionId) → found → continue
 
 Client POST (with sessionId, session expired)
-  → getSession(sessionId) → null
-  → body.messages[] present → hydrateSession() → new session, same conversation
-  → body.messages[] absent → createSession() → fresh start
+  → createSession() → fresh session
 
 Garbage collection
   → Every 10 minutes: delete sessions older than 1 hour
 ```
 
-## What Should Be Cleaned Up
+## A2UI Component Catalog
 
-1. ~~**`resolveSkillsAsync` / `resolveSkillsFromList`**~~ — **Done in #402.** Both removed from public exports.
-2. **Typed `Skill` path in `skill-resolver.ts`** — consolidate to one canonical resolution path. `azure-kit.ts` uses the typed `kit.skills[]` path; `github-kit.ts` uses the legacy `kit.prompts[]` / `kit.phasePrompts{}` path. Both paths are active and valid, but the dual-path design adds Agent SDK integration complexity.
-3. **Keyword vocabulary** — extract a shared constants module referenced by both mechanisms.
+Components are registered per pack at startup. The harness seals the registry before the first request. The negotiated catalog is served via `GET /api/packs`.
+
+- **In-chat components** — emitted via `core.emit_ui` tool calls during agent turns.
+- **Sidebar FileEditor** (`components/FileEditor/`) — persistent panel backed by `services/virtual-fs.ts`.
+
+See [A2UI Integration](./a2ui-integration.md) for the full component model.

--- a/docs-site/docs/architecture/prompt-pipeline.md
+++ b/docs-site/docs/architecture/prompt-pipeline.md
@@ -4,231 +4,78 @@ sidebar_position: 2
 
 # Prompt Pipeline
 
-Every conversation turn assembles a fresh prompt from multiple sources before calling Azure OpenAI. This page describes the exact order and the code behind each step.
+Every conversation turn dynamically assembles agent instructions before calling the LLM via the `@openai/agents` SDK. This page describes how the harness builds per-turn context.
 
 > **Source files:**
-> - `packages/core/src/engine/skill-resolver.ts` — Mechanism A
-> - `packages/core/src/services/resolveConversationSkills.ts` — Mechanism B (live in main as of PR #382)
-> - `packages/core/src/prompts/system-prompt.ts` — `buildSystemPrompt()`
-> - `packages/web/api/src/functions/converse.ts` — assembly harness (~lines 210–300)
-> - `packages/web/api/src/lib/converse-model-router.ts` — model routing
-
-## Two Skill Mechanisms
-
-There are two independent skill injection mechanisms running every turn. They target different message positions and serve different purposes.
-
-| | Mechanism A | Mechanism B |
-|-|-------------|-------------|
-| **File** | `engine/skill-resolver.ts` | `services/resolveConversationSkills.ts` |
-| **Trigger** | Current FSM phase | Keywords in user message |
-| **Source** | Registered IntegrationKits | Hardcoded domain patterns |
-| **Injection point** | System prompt (`## Available Capabilities`) | User message turn before real message |
-| **Also injects** | — | `[Current session context]` appended to real user message |
+> - `packages/harness/src/runtime/skill-resolver.ts` — per-turn skill resolution
+> - `packages/harness/src/runtime/runner.ts` — turn orchestration
+> - `packages/web/api/src/functions/converse.ts` — HTTP handler
 
 ## Assembly Order
 
 ```
 POST /api/converse arrives
     │
-    ├─ 1. Session lookup / rehydration
-    ├─ 2. currentPhase = getSafeCurrentPhase(engineState)
+    ├─ 1. Session lookup or creation
+    ├─ 2. Guardrail input check (core/token-budget, etc.)
     │
-    ├─ 3. [MECHANISM A] resolveSkills(currentPhase, defaultKitRegistry.getAll())
-    │      returns resolvedSkills.prompts[]
+    ├─ 3. Runner selects active Agent
+    │      session.activeAgent ?? "core.triage"
     │
-    ├─ 4. resolveConverseModelRoute(currentPhase, { trustedPhase })
-    │      returns { deployment, model, pricingGroup }
+    ├─ 4. Dynamic instructions assembled per turn
+    │      = agent.body (base .agent.md text)
+    │      + resolvedSkills(agent.name, recentTurns)  ← skill resolver
+    │      + catalog snapshot (component type list)
     │
-    ├─ 5. buildArtifactSummary(session.generatedArtifacts)
-    │      returns markdown summary of files generated so far
+    ├─ 5. Agent streams via SDK — text chunks + tool calls
+    │      core.emit_ui → a2ui SSE events
+    │      core.write_file, azure.arm_get, etc.
     │
-    ├─ 6. buildSystemPrompt({ phase, appDefinition, kitPrompts, artifactSummary })
-    │      ┌──────────────────────────────────────────┐
-    │      │ KICKSTART_SYSTEM_PROMPT (persona + rules) │
-    │      │ ## Current Phase: {label}                 │
-    │      │ {phase description}                       │
-    │      │ {phase promptTemplate with {{vars}}}      │
-    │      │ {artifactSummary — if any}                │
-    │      │ ## Available Capabilities                 │  ← Mechanism A here
-    │      │ {kit prompts}                             │
-    │      └──────────────────────────────────────────┘
+    ├─ 6. UserAction encountered?
+    │      → pause, emit user_action_required SSE
+    │      → browser acts (MSAL popup, GitHub OAuth, etc.)
+    │      → POST /api/converse/resume with typed result
+    │      → Runner resumes
     │
-    ├─ 7. Build messages[] from session history
-    │      messages[0] = { role: "system", content: freshSystemPrompt }
+    ├─ 7. Guardrail output check
     │
-    ├─ 8. [MECHANISM B] resolveConversationSkills(message, phase, sessionContext)
-    │      ├─ domainKnowledge != null:
-    │      │    messages.splice(messages.length - 1, 0, { role: "user", content: domainKnowledge })  // ↑ inserted immediately before the real user message
-    │      └─ Append currentState to messages[last].content
-    │
-    └─ 9. chatCompletion(messages, { deployment, responseFormat: "json_object" })
+    └─ 8. AgentOutput { message, intent } → SSE done
 ```
 
-## Mechanism A — Kit Skill Resolver
+## Skill Resolution
 
-**File:** `packages/core/src/engine/skill-resolver.ts`
+`resolveSkills(agentName, context)` in `packages/harness/src/runtime/skill-resolver.ts`:
 
-```typescript
-// converse.ts ~line 210
-const resolvedSkills = resolveSkills(currentPhase, defaultKitRegistry.getAll());
+1. **Match `appliesTo`** — glob each skill's `appliesTo` field against the current agent name.
+2. **Keyword scoring** — score matched skills against the recent conversation turns.
+3. **Priority ordering** — sort by `priority` (higher first), apply token budget cap (2000 tokens default).
+4. **Inject** — append skill text to the agent's dynamic instructions.
 
-const freshSystemPrompt = buildSystemPrompt({
-  phase: currentPhase,
-  appDefinition: state.appDefinition,
-  kitPrompts: resolvedSkills.prompts,  // ← appended as ## Available Capabilities
-  artifactSummary: artifactSummary || undefined,
-});
-```
+Skills are authored as `SKILL.md` files inside packs. They are pure text — no code, no execution.
 
-**3-stage resolution:**
-1. **Typed skill resolution first** — resolve `kit.skills[]` entries matching the current phase; apply keyword activation rules and priority sorting.
-2. **Legacy prompt fallback** — if no typed skills, fall back to `kit.phasePrompts[phase]` (explicit per-phase), then flat `kit.prompts[]` classified by keyword groups.
-3. **Phase-specific tool handling** — `resolveLegacySkills()` synthesizes a tool-listing prompt in **Discover** only; in Design it collects `availableTools` but does **not** inject that prompt.
-
-**To add a skill:** Implement `IntegrationKit` and register with `defaultKitRegistry`. No config files.
-
-## Mechanism B — Per-Turn Domain Injection
-
-**File:** `packages/core/src/services/resolveConversationSkills.ts`  
-**Status:** Live in main (merged PR #382). Called in `converse.ts` lines ~278–299.
-
-```typescript
-// converse.ts ~line 278
-const { domainKnowledge, currentState } = resolveConversationSkills(
-  body.message,
-  currentPhase,
-  { phase: currentPhase, appDefinition: state.appDefinition, filesGenerated },
-);
-if (domainKnowledge) {
-  messages.splice(messages.length - 1, 0, { role: "user", content: domainKnowledge });  // ↑ inserted immediately before the real user message
-}
-const last = messages[messages.length - 1];
-messages[messages.length - 1] = {
-  ...last,
-  content: `${last.content}\n\n${currentState}`,
-};
-```
-
-**Detected domains:** `stack-node`, `stack-python`, `stack-dotnet`, `stack-java`, `stack-go`, `infra-docker`, `infra-aks`, `infra-cicd`, `auth`, `data-relational`, `data-nosql`, `data-cache`, `data-queue`, `component-form`, `component-table`, `component-chart`
-
-**Example:** User says `"generate the Dockerfile for my Node app"`:
-- Matched: `infra-docker`, `stack-node`
-- Injected user turn: `[Domain knowledge: Docker + Node.js]`
-- Real message becomes: `"generate the Dockerfile...\n\n[Current session context]\nPhase: generate\n..."`
-
-:::note Phase-conditional override in Mechanism B
-`resolveConversationSkills.ts` contains a hard-coded guard: when `phase === "generate"`, it unconditionally adds `infra-aks` and `infra-docker` domains regardless of the user message content. This ensures AKS/Docker knowledge is always present in Generate phase — the same goal Mechanism A achieves by routing kit prompts containing `"dockerfile"`/`"manifest"` to Generate phase. **This is overlapping coverage.** See Conflict Analysis below.
-:::
-
-## Conflict Analysis — Do the Two Mechanisms Overlap?
-
-**Different targets, shared vocabulary.** Mechanism A classifies *kit prompt text*; Mechanism B classifies *user message text*. They inject to different positions in `messages[]`. The design intent is layered, not redundant.
-
-**However, there is concrete overlap in the Generate phase:**
-
-| What fires | Condition | Content |
-|------------|-----------|---------|
-| Mechanism A | Kit prompts containing "dockerfile"/"manifest" classified to Generate | Kit generation-phase prompts in system prompt |
-| Mechanism B (unconditional) | `phase === "generate"` — always | `infra-aks` + `infra-docker` domain knowledge as user turn |
-
-Both mechanisms activate in Generate phase, both inject AKS/Docker context, through different channels. The channels are different (system prompt vs user turn) but the knowledge overlaps.
-
-**Keyword sets evolved independently.** Mechanism A uses string substring matching; Mechanism B uses regex patterns. No shared file. Overlapping terms: `"dockerfile"`, `"manifest"`, `"pipeline"`, `"deploy"`.
-
-**Recommendation for cleanup:** The unconditional Generate phase injection in Mechanism B should either be made conditional on user message content (matching B's general pattern), or removed and covered by kit prompts alone. The current state works but is not intentionally designed.
-
-## System Prompt Structure
-
-`buildSystemPrompt()` builds:
+## Agent Instructions Structure
 
 ```
-{KICKSTART_SYSTEM_PROMPT}
-  - Persona + COLLABORATOR VOICE
-  - K8s terminology rules by phase
-  - GUARDRAILS (DS001–DS013)
+{agent.body}                     ← base .agent.md text (persona + rules)
 
-## Current Phase: {label}
-{phase description}
-{phase promptTemplate}
-
-{artifactSummary — omitted if empty}
-
-## Available Capabilities
-{kit prompts — omitted if none}
-```
-
-Phase exit conditions in `phases.ts` are human-readable strings. Not code-enforced. See [FSM](./fsm.md).
-
-## Model Routing
-
-Trust-based, not phase-based:
-
-```typescript
-// packages/web/api/src/lib/converse-model-router.ts
-export function resolveConverseModelRoute(
-  phase: string | null | undefined,
-  options: { trustedPhase?: boolean } = {},
-): ConverseModelRoute {
-  if (options.trustedPhase && normalizeConversePhase(phase) === Phase.Generate) {
-    return { deployment: getGenerateDeploymentName(), pricingGroup: "generate" };
-    // Reads AZURE_OPENAI_CODEX_DEPLOYMENT — e.g. "gpt-5.4"
-  }
-  return { deployment: getChatDeploymentName(), pricingGroup: "chat" };
-  // Reads AZURE_OPENAI_CHAT_DEPLOYMENT — e.g. "gpt-5.4-mini"
-}
-```
-
-| Condition | Model | Env var |
-|-----------|-------|---------|
-| Generate + server-trusted | GPT-5.4 | `AZURE_OPENAI_CODEX_DEPLOYMENT` |
-| Any other phase | GPT-5.4-mini | `AZURE_OPENAI_CHAT_DEPLOYMENT` |
-| Client-rehydrated session | GPT-5.4-mini | `AZURE_OPENAI_CHAT_DEPLOYMENT` |
-
-## Code Health Notes
-
-:::note Exported but uncalled variants removed
-`resolveSkillsAsync()` and `resolveSkillsFromList()` were exported from `@kickstart/core` but never called in production. They were removed in PR #402. Only `resolveSkills()` is now the public entry point.
-:::
-
-:::note Typed Skill path is active in production
-`skill-resolver.ts` has two resolution paths: typed `kit.skills[]` and legacy `kit.prompts[]`. **`azure-kit.ts` uses the typed path** — it registers `skills: azureIacSkills`. `github-kit.ts` uses the legacy path. Both paths are active in production; consolidation to a single canonical path is tracked as future work.
-:::
-
-:::warning Keyword drift risk
-Two independent keyword systems. Changes in one are invisible to the other. A new kit whose prompts contain `"manifest"` will activate in AKS-related user turns through Mechanism A, but Mechanism B's `infra-aks` domain block will also activate if the user message contains `/\bmanifest\b/i`. No test exercises the combined behavior.
-:::
-
-## What Should Be Cleaned Up
-
-1. ~~**Remove `resolveSkillsAsync` / `resolveSkillsFromList` from public exports**~~ — **Done in #402.**
-2. **Resolve Generate-phase overlap** — remove the unconditional `infra-aks`/`infra-docker` injection from Mechanism B or document why the system prompt coverage is insufficient.
-3. **Consolidate typed `Skill` vs legacy path** — `azure-kit.ts` uses the typed path; `github-kit.ts` uses legacy. Pick one canonical resolution path before Agent SDK adapters are built.
-4. **Create a shared vocabulary file** for terms that must stay in sync between the two mechanisms.
-
+## Active Skills
+{skill1 text}
 ---
+{skill2 text}
 
-## Impact of FSM Removal
-
-:::warning phases.ts is being deleted
-`phases.ts` phase templates are confirmed for deletion. `buildSystemPrompt()` will no longer select a template by phase. See [FSM](./fsm.md).
-:::
-
-### What Changes
-
-`buildSystemPrompt()` replaces phase-template selection with a single full-sequence prompt using numbered blocks:
-
-```
-═══ 1. BEFORE YOU START ═══  [always present]
-═══ 2. GATHER REQUIREMENTS ═══  [always present]
-═══ 3. GENERATE ═══  [always present]
+## Component Catalog
+{registered component list with schemas}
 ```
 
-Model routing reads `session.state.currentPhase` (plain string) instead of `session.engineState.currentPhase` (FSM enum).
+## Guardrails
 
-### What Does NOT Change
+Guardrails contributed by packs run at three stages:
 
-Both skill injection mechanisms are unaffected:
-- `resolveSkills(phase, kits)` — same signature, same behavior
-- `resolveConversationSkills(message, phase, context)` — same signature; `if (phase === "generate")` guard works as plain string comparison
+| Stage | When |
+|-------|------|
+| `input` | Before the agent receives the user message |
+| `tool` | Before each tool call result is returned to the agent |
+| `output` | After `AgentOutput` is produced |
 
-The 6-part per-turn assembly order is unchanged.
+Built-in guardrails: `core/token-budget`, `core/content-safety`. Pack guardrails: `azure/no-hardcoded-creds`, `aks/no-privileged-containers`, etc.
+

--- a/docs-site/docs/architecture/skill-injection.md
+++ b/docs-site/docs/architecture/skill-injection.md
@@ -2,223 +2,57 @@
 sidebar_position: 4
 ---
 
-# Skill Injection Deep-Dive
+# Skill Injection
 
-Two independent skill injection mechanisms run every turn. This page explains both side-by-side, their conflict zones, and how to extend each.
+Per-turn skill injection is how packs deliver domain knowledge to agents without bloating every turn with all possible context.
 
-> **Sources:**
-> - Mechanism A: `packages/core/src/engine/skill-resolver.ts`
-> - Mechanism B: `packages/core/src/services/resolveConversationSkills.ts`
-> - Wired in: `packages/web/api/src/functions/converse.ts`
+> **Source:** `packages/harness/src/runtime/skill-resolver.ts`
 
-## Side-by-Side Comparison
+## How It Works
 
-| | Mechanism A | Mechanism B |
-|-|-------------|-------------|
-| **File** | `engine/skill-resolver.ts` | `services/resolveConversationSkills.ts` |
-| **Added** | Original codebase | PR #382 |
-| **Fires** | Every turn | Every turn |
-| **Selection trigger** | Current FSM phase | Keywords in user message |
-| **Knowledge source** | Registered IntegrationKits | Hardcoded domain blocks |
-| **Injection point** | System prompt — `## Available Capabilities` | User message turn, before real message |
-| **Also injects** | — | `[Current session context]` appended to real message |
-| **Extensible via** | New `IntegrationKit` TypeScript class | Edit `resolveConversationSkills.ts` |
+Every turn, `resolveSkills(agentName, context)` runs against all registered skills from all enabled packs:
 
-## Why Two Mechanisms?
+1. **`appliesTo` glob match** — each `SKILL.md` declares which agents it applies to via the `appliesTo` frontmatter field (e.g., `"azure.*"`, `"core.triage"`).
+2. **Keyword scoring** — matched skills are scored against the recent conversation turns. Skills whose keywords appear in recent messages rank higher.
+3. **Priority ordering** — ties broken by the `priority` field in skill frontmatter (higher = first).
+4. **Token budget** — the resolver caps total injected skill text at 2000 tokens by default. Lower-priority skills are dropped when the budget is exhausted.
 
-**Mechanism A** solves: the LLM needs to know what tools and capabilities are registered, and this varies by phase. This is permanent per-phase context — correct to put in the system prompt.
+Selected skills are appended to the agent's dynamic instructions for that turn only. They are not stored in the session and not part of the conversation history.
 
-**Mechanism B** solves: when the user asks about Node.js, the LLM needs Node.js deployment knowledge *for this turn*, but always-on system prompt injection bloats every turn with all possible domain knowledge. Injecting as a user turn makes it one-shot — present now, not repeated in history. Design goal: save 500–1000 tokens per subsequent turn.
+## Skill Authoring
 
-## Mechanism A — How It Works
+Skills live in `SKILL.md` files inside pack `skills/` directories:
 
-```typescript
-// converse.ts
-const resolvedSkills = resolveSkills(currentPhase, defaultKitRegistry.getAll());
-const freshSystemPrompt = buildSystemPrompt({
-  phase: currentPhase,
-  kitPrompts: resolvedSkills.prompts,  // ← becomes ## Available Capabilities
-  // ...
-});
+```markdown
+---
+name: AKS Node Pool Sizing
+appliesTo: "aks.*"
+keywords:
+  - node pool
+  - vm size
+  - cluster scaling
+priority: 80
+---
+
+When recommending node pool sizes for AKS Automatic, prefer ...
 ```
 
-### Resolution Paths
+| Frontmatter field | Required | Description |
+|---|---|---|
+| `name` | ✅ | Human-readable skill name |
+| `appliesTo` | ✅ | Agent name glob — which agents receive this skill |
+| `keywords` | ✅ | Terms that boost this skill's score against conversation turns |
+| `priority` | optional | Ordering within budget (default: 50) |
 
-`resolveSkills()` uses a **3-stage resolution** for each kit:
+## Where Skills Live
 
-1. **Typed skill resolution first** — resolve `kit.skills[]` entries matching the current phase; apply keyword activation rules and priority sorting.
-2. **Legacy prompt fallback** — if no typed skills, fall back to `kit.phasePrompts[phase]` (explicit per-phase), then flat `kit.prompts[]` classified by keyword groups.
-3. **Phase-specific tool handling** — `resolveLegacySkills()` synthesizes a tool-listing prompt in **Discover** only; in Design it collects `availableTools` but does **not** inject that prompt.
+| Pack | Skills directory |
+|------|-----------------|
+| `pack-core` | `packages/pack-core/src/skills/` |
+| `pack-azure` | `packages/pack-azure/src/skills/` |
+| `pack-aks-automatic` | `packages/pack-aks-automatic/src/skills/` |
+| `pack-github` | `packages/pack-github/src/skills/` |
 
-This is backed by **two resolution paths** — a typed `Skill` object path and a legacy `prompts[]` path:
+Skills are loaded at pack registration time by the `SKILL.md` loader in `packages/harness/src/runtime/loader-skill.ts`.
 
-```typescript
-// Path 1 — typed Skill objects (kit.skills[])
-interface Skill {
-  id: string;
-  phases: Phase[];       // explicit phase assignment
-  keywords?: string[];   // optional keyword boost
-  content: string;       // text injected into system prompt
-}
 
-// Path 2 — legacy flat prompts (kit.prompts[] / kit.phasePrompts{})
-// IntegrationKit (full interface — see packages/core/src/kits/types.ts)
-interface IntegrationKit {
-  name: string;
-  description: string;
-  tools: Tool<any>[];
-  connectors: APIConnector[];
-  prompts?: string[];                              // classified by keyword heuristic
-  phasePrompts?: Partial<Record<Phase, string[]>>; // explicit per-phase prompts
-  skills?: Skill[];                                // typed skill definitions (Path 1)
-}
-```
-
-:::info Both skill paths are active
-**`azure-kit.ts` uses the typed `kit.skills[]` path** (Path 1) — it registers `skills: azureIacSkills` (see `azure-kit.ts:573`). **`github-kit.ts` uses the legacy `kit.prompts[]` / `kit.phasePrompts{}` path** (Path 2). Both paths are valid for kit authors. Consolidation of the two paths into a single mechanism is tracked as future work.
-:::
-
-### Public API
-
-The only supported public entry point for Mechanism A is:
-
-```typescript
-resolveSkills(phase: Phase, kits: IntegrationKit[], conversationHistory?: string[]): ResolvedSkills
-```
-
-All other resolver functions (`resolveSkillsAsync`, `resolveSkillsFromList`, `formatSkillsSection`, `registerSkillMiddleware`) have been removed — they had zero non-test production callers and the entire resolver surface is being redesigned in the Agents SDK migration (#330).
-
-### Keyword Classification (Legacy Path)
-
-```typescript
-const GENERATE_KEYWORDS = ["generat", "workflow", "dockerfile", "manifest", "artifact", "ci/cd", ...];
-const DEPLOYMENT_KEYWORDS = ["deploy", "safeguard", "validation", "cost", "estimate", ...];
-```
-
-Each kit prompt string is lowercased and checked for substring membership. A match routes the prompt to the corresponding phase(s).
-
-### Adding a New Skill via Mechanism A
-
-1. Implement `IntegrationKit` (`packages/core/src/kits/types.ts`)
-2. Add your prompts to `phasePrompts[Phase.X]` (preferred) or `prompts[]` (heuristic-classified)
-3. Register: `defaultKitRegistry.register(myKit)`
-
-No config files. TypeScript only.
-
-## Mechanism B — How It Works
-
-```typescript
-// converse.ts ~line 278
-const { domainKnowledge, currentState } = resolveConversationSkills(
-  body.message,
-  currentPhase,
-  { phase: currentPhase, appDefinition: state.appDefinition, filesGenerated },
-);
-if (domainKnowledge) {
-  messages.splice(messages.length - 1, 0, { role: "user", content: domainKnowledge });  // ↑ inserted immediately before the real user message
-}
-messages[last] = { ...messages[last], content: `${messages[last].content}\n\n${currentState}` };
-```
-
-### Domain Detection
-
-```typescript
-const DOMAIN_PATTERNS = [
-  { domain: "stack-node",   patterns: [/\bnode(\.?js)?\b/i, /\btypescript\b/i, /\bexpress\b/i, ...] },
-  { domain: "infra-docker", patterns: [/\bdocker(file)?\b/i, /\bcontainer\b/i, ...] },
-  { domain: "infra-aks",    patterns: [/\baks\b/i, /\bkubernetes\b/i, /\bmanifest\b/i, ...] },
-  // ... 16 domains total
-];
-```
-
-All matched domains are combined into one `domainKnowledge` string.
-
-### Phase Override (the Problematic Part)
-
-```typescript
-// resolveConversationSkills.ts — hard-coded phase guard
-if (phase === "generate") {
-  matchedDomains.add("infra-aks");
-  matchedDomains.add("infra-docker");
-}
-```
-
-When `phase === "generate"`, AKS and Docker knowledge is injected regardless of user message content. This is not keyword-driven — it's unconditional. See Conflict Analysis below.
-
-### Session Context Block
-
-`currentState` is always built and appended:
-```
-[Current session context]
-Phase: generate
-App: my-express-api (node)
-Database: postgres
-Files generated: Dockerfile, deployment.yaml, github-workflow.yml
-```
-
-### Adding a New Domain via Mechanism B
-
-Edit `packages/core/src/services/resolveConversationSkills.ts`:
-1. Add to `Domain` union type
-2. Add `{ domain, patterns }` to `DOMAIN_PATTERNS`
-3. Add knowledge block to the assembly section
-
-No config file. Code change required.
-
-## Conflict Analysis
-
-### Are they redundant?
-
-In general, **no**. They inject different content to different positions:
-- A → system prompt (permanent per-phase context)
-- B → user turn before real message (ephemeral per-request context)
-
-### But Generate phase has concrete overlap
-
-When `phase === "generate"`:
-
-| Mechanism | What fires | What it injects | Where |
-|-----------|------------|-----------------|-------|
-| A | Kit prompts containing "dockerfile"/"manifest" classified to Generate | Kit-defined generation prompts | System prompt `## Available Capabilities` |
-| B (unconditional) | Always when `phase === "generate"` | AKS Automatic deployment knowledge + Docker best practices | User message turn |
-
-Both inject AKS/Docker context. The content differs (A provides kit prompts, B provides hardcoded domain knowledge), but the coverage goal is the same: ensure the LLM has AKS/Docker context in Generate phase.
-
-### Keyword overlap table
-
-| Trigger word | A activates | B activates |
-|--------------|-------------|-------------|
-| "dockerfile" | Generate phase (GENERATE_KEYWORDS) | `infra-docker` domain |
-| "manifest" | Generate phase (GENERATE_KEYWORDS) | `infra-aks` domain |
-| "pipeline" | Generate phase (GENERATE_KEYWORDS) | `infra-cicd` domain |
-| "deploy" | Deployment phases (DEPLOYMENT_KEYWORDS) | `infra-aks` or `infra-cicd` domain |
-
-### The maintenance risk
-
-Changes to either keyword set are invisible to the other. A new kit whose prompts trigger on `"manifest"` will activate in Generate phase (A), but if the user message also contains `"manifest"`, Mechanism B's `infra-aks` block fires too. The combined injection is not tested end-to-end.
-
-## Code Health Notes
-
-:::danger Two independent keyword systems with no shared vocabulary
-`GENERATE_KEYWORDS` in `skill-resolver.ts` and `DOMAIN_PATTERNS` in `resolveConversationSkills.ts` cover overlapping semantic territory with no shared file. Drift is inevitable and invisible.
-:::
-
-:::warning Unconditional Generate-phase injection in Mechanism B
-The `if (phase === "generate")` guard in `resolveConversationSkills.ts` is not consistent with the rest of Mechanism B's design (keyword-driven detection). It hard-codes a specific phase's behavior rather than detecting intent from message content. This is the most likely source of future confusion.
-:::
-
-:::warning Dead Skill API in Mechanism A
-`resolveSkillsAsync()` and `resolveSkillsFromList()` were exported but never called in production. They have been removed in #402. Only `resolveSkills()` remains as the public entry point.
-:::
-
-## What Should Be Cleaned Up
-
-1. **Resolve the Generate-phase unconditional injection** — make it keyword-driven (consistent with B's design) or remove it and rely on Mechanism A's kit prompts for AKS/Docker coverage in Generate. The current implementation mixes two patterns in one function.
-
-2. **Create a shared vocabulary module** — a single `src/engine/domain-vocab.ts` (or similar) exporting the keyword/domain taxonomy used by both mechanisms. This prevents divergence and makes the combined behavior testable.
-
-3. **Consolidate the typed `Skill` vs legacy path in Mechanism A** — pick one canonical resolution API. `azure-kit.ts` uses the typed `kit.skills[]` path; `github-kit.ts` uses the legacy path. Both are active in production, but the dual-path design is the highest-risk surface area for Agent SDK integration confusion.
-
-4. ~~**Remove `resolveSkillsAsync` / `resolveSkillsFromList` from public exports**~~ — **Done in #402.** Only `resolveSkills()` is now exported.
-
-5. **After FSM removal** — both `resolveSkills(phase, kits)` and `resolveConversationSkills(message, phase, context)` accept a phase string. Neither needs code changes when the FSM is removed. The `if (phase === "generate")` guard in Mechanism B continues to work as a plain string comparison. The source of the phase string changes (was `engineState.currentPhase`, becomes `session.state.currentPhase`) but the function signatures and behavior are identical.

--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -10,36 +10,35 @@ Kickstart is built using the [Squad framework](./../) for AI-guided development.
 
 To add a component to the Kickstart catalog:
 
-1. Define the component type and data model in `packages/core/src/catalog/`
-2. Implement the React renderer in `packages/web/src/catalog/components/`
-3. Register the component in the catalog registry
-4. Update the system prompt to teach the AI when and how to use the new component
-5. Add documentation to `docs-site/docs/components/`
+1. Define the component type and data model in the appropriate pack's `src/components/`
+2. Implement the React renderer (basic or rich) in the pack
+3. Register the component contribution in the pack's index
+4. Add documentation to `docs-site/docs/components/`
 
 ## Adding New Conversation Phases
 
-The conversation flow is defined in `packages/core/src/engine/phases.ts`. To add a phase:
+See [Conversation Phases](./extending/conversation-phases.md) for the full walkthrough.
 
-1. Add a new phase entry to `PHASE_DEFINITIONS` in `packages/core/src/engine/phases.ts`
-2. Add transition rules from adjacent phases
-3. Update the system prompt with phase-specific instructions
-4. Add any phase-specific A2UI components
-5. Test the flow end-to-end
+In brief:
+1. Add a new phase to the `Phase` enum in `packages/harness/src/types/`
+2. Add a `PhaseDefinition` entry with `nextPhase` chaining
+3. Add phase-specific skills to relevant packs
+4. Test the flow end-to-end
 
-## Extending the System Prompt
+## Extending Agent Instructions
 
-The system prompt lives in `packages/core/src/prompts/`. Key guidelines:
+Agent instructions live in `.agent.md` files inside each pack's `src/agents/` directory. Skills are `SKILL.md` files in `src/skills/`. Key guidelines:
 
-- Keep phase instructions focused and concise
-- Use structured output format (JSON envelope) consistently
+- Keep agent base instructions concise — skills add the domain detail
+- Use `appliesTo` globs to scope skills to the right agents
 - Hide Kubernetes jargon in early phases (Discover, Design)
-- Include A2UI component examples for each phase
 
 ## Testing
 
 | Package | Tool | Command |
 |---------|------|---------|
-| `packages/core` | Vitest | `npm run test` (from root) |
+| `packages/harness` | Vitest | `npm run test` (from root) |
+| `packages/pack-*` | Vitest | `npm run test` (from root) |
 | `packages/web` | Vite build | `cd packages/web && npm run build` |
 
 Run all tests from the repo root:

--- a/docs-site/docs/extending/api-endpoints.md
+++ b/docs-site/docs/extending/api-endpoints.md
@@ -183,14 +183,10 @@ Endpoints share a set of utility modules in `packages/web/api/src/lib/`:
 
 | Module | Exports | Purpose |
 |---|---|---|
-| `openai-client.ts` | `chatCompletion()`, `chatCompletionWithTools()`, `chatCompletionStream()`, `codexCompletion()` | Azure OpenAI client with JSON mode and tool support |
-| `session-store.ts` | `getSession()`, `createSession()`, `hydrateSession()`, `addMessage()` | In-memory session management with 1-hour TTL |
+| `runner.ts` | `Runner` | Orchestrates agent turns, guardrails, tool dispatch, and UserAction pause/resume |
+| `session-store.ts` | `getSession()`, `createSession()`, `addMessage()` | In-memory session management with 1-hour TTL |
 | `error-response.ts` | `safeErrorResponse()`, `safeStreamError()` | Generic error responses — logs details server-side, returns safe messages to clients |
 | `rate-limiter.ts` | `checkRateLimit()`, `rateLimitResponse()` | Sliding-window rate limiting (30 req/min per client, 300 req/min global backstop) |
-| `response-processor.ts` | `processResponse()` | Parse LLM JSON envelope into message + A2UI components |
-| `content-safety.ts` | `checkContentSafety()` | Content safety pre-flight check on user messages |
-| `auto-continue.ts` | `chatCompletionWithAutoContinue()`, `isTruncated()` | Auto-continuation for truncated LLM responses |
-| `sanitize-tool-output.ts` | `sanitizeToolOutput()` | Sanitize tool results before feeding back to the LLM |
 
 ---
 

--- a/docs-site/docs/extending/conversation-phases.md
+++ b/docs-site/docs/extending/conversation-phases.md
@@ -10,7 +10,7 @@ Kickstart guides users through six phases — Discover, Design, Generate, Review
 
 ### The Phase Enum
 
-Every phase is a string constant defined in `packages/core/src/engine/types.ts`:
+Every phase is a string constant defined in `packages/harness/src/types/phases.ts`:
 
 ```typescript
 export enum Phase {
@@ -25,7 +25,7 @@ export enum Phase {
 
 ### Phase Definitions
 
-Each phase has a `PhaseDefinition` in `packages/core/src/engine/phases.ts`:
+Each phase has a `PhaseDefinition` in `packages/harness/src/types/phases.ts`:
 
 ```typescript
 export interface PhaseDefinition {
@@ -61,7 +61,7 @@ if (llmResponse.phaseComplete) {
 
 `advancePhase()` looks up the current phase in `PHASE_DEFINITIONS` and returns `nextPhase`. There is no event system or transition guard — the LLM's signal is the only trigger.
 
-A2UI actions with `complete:` or `continue:` prefixes (handled in `packages/core/src/engine/auto-continue.ts`) can trigger phase transitions from button clicks in the UI. After stripping the `complete:`/`continue:` prefix, if the resulting action name starts with `navigate:` or `nav:`, it is treated as a phase-navigation signal — for example, the full action name is `complete:navigate:design`.
+A2UI actions with `complete:` or `continue:` prefixes (handled in `packages/harness/src/runtime/runner.ts`) can trigger phase transitions from button clicks in the UI. After stripping the `complete:`/`continue:` prefix, if the resulting action name starts with `navigate:` or `nav:`, it is treated as a phase-navigation signal — for example, the full action name is `complete:navigate:design`.
 
 ### How the LLM Navigates Phases
 
@@ -69,26 +69,22 @@ The system prompt includes the current phase identifier and the `description` fr
 
 ### Skill Resolution
 
-Skills are filtered by phase. `packages/core/src/engine/skill-resolver.ts` exports a single `resolveSkills()` function that:
+Skills are filtered per agent turn. `packages/harness/src/runtime/skill-resolver.ts` exports `resolveSkills()` which:
 
-1. Filters typed `Skill` objects to those whose `phases` array includes `currentPhase`
-2. Keyword-activates additional skills from conversation history that weren't initially phase-matched
+1. Matches skills by `appliesTo` glob against the current agent name
+2. Keyword-activates additional skills from recent conversation turns
 3. Sorts the combined set by `priority` (higher first)
-4. Merges in legacy `phasePrompts` and heuristically-classified flat prompts for backward compatibility
-
-Skill phase membership is declared on the `Skill` object itself via the `phases` array property.
+4. Caps at the token budget (2000 tokens default)
 
 ### System Prompt Architecture
 
-The system prompt builder (`packages/core/src/prompts/system-prompt.ts`) assembles context per turn:
+The system prompt is assembled per turn by the harness:
 
 | Layer | Content |
 |---|---|
-| Active skills | Resolved for current phase (Mechanism A) |
-| Copilot extension instructions | Static per-turn context |
-| Per-turn domain injection | Resolved from user message (Mechanism B) |
-
-Phase context (current phase + description) is included in the prompt so the LLM knows where it is in the conversation.
+| Active skills | Resolved for current agent by `resolveSkills()` |
+| Agent base instructions | Static `.agent.md` body |
+| Component catalog | Registered component type list |
 
 ---
 
@@ -96,7 +92,7 @@ Phase context (current phase + description) is included in the prompt so the LLM
 
 ### Step 1 — Add the enum value
 
-Open `packages/core/src/engine/types.ts` and add your new phase to the `Phase` enum:
+Open `packages/harness/src/types/phases.ts` and add your new phase to the `Phase` enum:
 
 ```typescript
 export enum Phase {
@@ -112,7 +108,7 @@ export enum Phase {
 
 ### Step 2 — Add the phase definition
 
-Open `packages/core/src/engine/phases.ts` and insert a `PhaseDefinition` at the correct position in `PHASE_DEFINITIONS`. Update the `nextPhase` of the preceding entry to point to your new phase:
+Open `packages/harness/src/types/phases.ts` and insert a `PhaseDefinition` at the correct position in `PHASE_DEFINITIONS`. Update the `nextPhase` of the preceding entry to point to your new phase:
 
 ```typescript
 {
@@ -130,42 +126,33 @@ Also update the `Design` entry so its `nextPhase` is `Phase.Validate`.
 Add `Phase.Validate` to the `phases` array of any skills that should activate during this phase:
 
 ```typescript
+// In your pack's SKILL.md frontmatter:
+// appliesTo: "aks.*"
+// keywords:
+//   - validate
+//   - architecture check
+```
+
+Or in a typed skill registration:
+
+```typescript
 const mySkill: Skill = {
   id: "my-skill",
   name: "My Skill",
-  phases: [Phase.Validate],
-  keywords: [...],
-  content: "...",
+  appliesTo: "aks.*",
+  keywords: ["validate", "architecture check"],
+  content: "When validating architecture, ...",
 };
 ```
 
-### Step 4 — Add phase-specific prompts to kits (optional)
+### Step 4 — Write tests
 
-If an `IntegrationKit` needs to inject extra context during your phase, use `phasePrompts`:
-
-```typescript
-const myKit: IntegrationKit = {
-  // ...
-  phasePrompts: {
-    [Phase.Validate]: [
-      "When validating architecture, always check for missing health check configurations.",
-    ],
-  },
-};
-```
-
-### Step 5 — Write tests
-
-Add test cases to `packages/core/src/__tests__/skill-resolver.test.ts` to verify your phase's skill filtering behavior. Also confirm that `PHASE_DEFINITIONS` in `packages/core/src/engine/phases.ts` correctly chains `nextPhase` through all phases.
-
----
+Add test cases to the harness skill resolver tests to verify your phase's skill activation behavior. Also confirm that `PHASE_DEFINITIONS` correctly chains `nextPhase` through all phases.
 
 ## Key Files
 
 | File | Purpose |
 |---|---|
-| `packages/core/src/engine/types.ts` | `Phase` enum and `PhaseDefinition` interface |
-| `packages/core/src/engine/phases.ts` | `PHASE_DEFINITIONS` — phase catalog and order |
-| `packages/core/src/engine/skill-resolver.ts` | Phase-aware skill filtering and phase group constants |
-| `packages/core/src/engine/auto-continue.ts` | A2UI action → phase transition wiring |
-| `packages/core/src/prompts/system-prompt.ts` | System prompt assembly including phase context |
+| `packages/harness/src/runtime/session.ts` | Session state including `currentPhase` |
+| `packages/harness/src/runtime/skill-resolver.ts` | Per-turn skill filtering |
+| `packages/pack-core/src/agents/` | Base agent definitions (`.agent.md`) |

--- a/docs-site/docs/extending/integration-kits.md
+++ b/docs-site/docs/extending/integration-kits.md
@@ -2,346 +2,97 @@
 sidebar_position: 4
 ---
 
-# Integration Kits
+# Packs
 
-An IntegrationKit is the canonical unit for extending Kickstart with a new integration surface. It bundles tools, API connectors, system-prompt augmentations, UI component registrations, and lifecycle hooks into a single composable package. When you register a kit, everything gets wired up automatically — tools go into the ToolRegistry, connectors into the APIConnectorRegistry, and prompts into the skill resolver.
+A **Pack** is the unit of extensibility in Kickstart v2. It bundles agents, skills, tools, user actions, components, and guardrails into a single deployable unit. The harness is domain-agnostic; packs carry all product knowledge.
 
-This guide covers the kit interface, the registry, built-in kits, and how to create your own.
+## Pack Interface
 
-## How Kits Work
-
-### The IntegrationKit Interface
-
-Every kit implements the `IntegrationKit` interface defined in `packages/core/src/kits/types.ts`:
+Every pack implements the `Pack` interface registered via the `PackRegistry`:
 
 ```typescript
-export interface IntegrationKit {
-  name: string;
+interface Pack {
+  name: string;          // e.g. "azure", "aks-automatic", "github"
   description: string;
-  tools: Tool<any>[];
-  connectors: APIConnector[];
-  prompts?: string[];
-  phasePrompts?: Partial<Record<Phase, string[]>>;
-  skills?: Skill[];
-  components?: ComponentRegistration[];
-  auth?: KitAuthRequirement[];
-  dependencies?: string[];
-  onActivate?: () => Promise<void>;
-  onDeactivate?: () => Promise<void>;
+  dependencies?: string[];  // other pack names that must be registered first
+
+  agents?: AgentContribution[];
+  skills?: SkillContribution[];
+  tools?: ToolContribution[];
+  userActions?: UserActionContribution[];
+  components?: ComponentContribution[];
+  guardrails?: GuardrailContribution[];
+
+  onRegister?: () => Promise<void>;
 }
 ```
 
-| Property | Type | Description |
-|---|---|---|
-| `name` | `string` | Unique kit identifier (e.g. `"azure"`, `"github"`) |
-| `description` | `string` | Human-readable summary of what the kit provides |
-| `tools` | `Tool<any>[]` | LLM-callable functions — auto-registered into `ToolRegistry` |
-| `connectors` | `APIConnector[]` | Authenticated API clients — auto-registered into `APIConnectorRegistry` |
-| `prompts` | `string[]?` | Flat system-prompt augmentations injected for all phases (or filtered by keyword heuristics) |
-| `phasePrompts` | `Partial<Record<Phase, string[]>>?` | Per-phase prompt augmentations — takes priority over flat `prompts` for a given phase |
-| `skills` | `Skill[]?` | Typed domain knowledge injected per-phase with keyword activation and priority ordering |
-| `components` | `ComponentRegistration[]?` | A2UI component type registrations (frontend binding is in `packages/web`) |
-| `auth` | `KitAuthRequirement[]?` | Declarative auth requirements — the web layer uses these to wire providers |
-| `dependencies` | `string[]?` | Names of kits that must be registered before this one |
-| `onActivate` | `() => Promise<void>?` | Lifecycle hook called after registration and dependency validation |
-| `onDeactivate` | `() => Promise<void>?` | Lifecycle hook called before the kit is removed from the registry |
+## Primitive Naming Conventions
 
-### Supporting Types
+| Primitive | Name format | Example |
+|-----------|------------|---------|
+| Agent | `pack.agent_name` | `azure.architect`, `core.triage` |
+| Tool | `pack.verb_noun` | `azure.arm_get`, `core.write_file` |
+| UserAction | `pack:verb_noun` | `azure:login`, `github:oauth` |
+| Component | `pack/PascalName` | `azure/Login`, `pack-core/Button` |
+| Guardrail | `pack/kebab-name` | `core/token-budget`, `aks/no-privileged-containers` |
 
-#### ComponentRegistration
+## Registering a Pack
 
 ```typescript
-interface ComponentRegistration {
-  type: string;           // A2UI component type identifier, e.g. 'azureLoginCard'
-  description: string;    // Human-readable description
-  promptMeta?: {
-    category: ComponentCategory;  // Grouping for the prompt catalog
-    example: string;              // JSON example shown to the LLM
-    notes?: string;               // Optional notes after the example
-  };
+import { packRegistry } from "@kickstart/harness";
+import { azurePack } from "@kickstart/pack-azure";
+
+packRegistry.register(azurePack);
+packRegistry.seal();  // called once at server startup; no new registrations after this
+```
+
+## Creating a Pack
+
+1. Create a new package under `packages/pack-{name}/`
+2. Implement the `Pack` interface in `src/index.ts`
+3. Add agents in `src/agents/*.agent.md`
+4. Add skills in `src/skills/*.SKILL.md`
+5. Add tools in `src/tools/*.ts`
+6. Add user actions in `src/user-actions/*.ts` (for browser interactions)
+7. Add components in `src/components/` (React renderers)
+8. Register the pack in `packages/web/api/src/app.ts`
+
+## Built-in Packs
+
+| Pack | What it contributes |
+|------|---------------------|
+| `pack-core` | Base agents (triage, codesmith, reviewer), cross-cutting skills, core tools, full A2UI component catalog |
+| `pack-azure` | Azure agents, ARM tools, MSAL user actions, Azure UI components |
+| `pack-aks-automatic` | AKS deployment agents, manifest generation skills, safeguards |
+| `pack-github` | GitHub agent, repo tools, OAuth user actions, GitHub UI components |
+
+## UserActions vs Tools
+
+| | Tool | UserAction |
+|--|------|-----------|
+| Requires browser? | No | Yes |
+| Name sigil | `.` | `:` |
+| Runner behavior | Inline result | Pause → browser → resume |
+| Example | `azure.arm_get` | `azure:login` |
+
+When a UserAction is called:
+1. Runner pauses and emits `user_action_required` SSE event
+2. Browser receives the event and renders the appropriate component (MSAL popup, OAuth flow, etc.)
+3. Browser POSTs the typed result to `/api/converse/resume`
+4. Runner resumes with the result
+
+## Guardrails
+
+Guardrails contributed by packs run at three stages in the Runner lifecycle:
+
+```typescript
+interface GuardrailContribution {
+  id: string;   // e.g. "core/token-budget"
+  stages: ("input" | "output" | "tool")[];
+  evaluate(input: GuardrailInput): GuardrailResult;
 }
 ```
 
-#### KitAuthRequirement
+Core guardrails run first and fail-closed. Pack guardrails run after core guardrails.
 
-```typescript
-interface KitAuthRequirement {
-  provider: string;    // Auth provider identifier, e.g. 'azure-msal', 'github-oauth'
-  scopes: string[];    // OAuth scopes or permission strings
-  optional?: boolean;  // If true, the kit can function (degraded) without this auth
-}
-```
-
-### The Kit Registry
-
-`packages/core/src/kits/registry.ts` exports an `IntegrationKitRegistry` class and a `defaultKitRegistry` singleton:
-
-```typescript
-import { registerKit, defaultKitRegistry } from "@kickstart/core";
-
-// Register at app startup (dependencies first)
-await registerKit(githubKit);
-await registerKit(azureKit);
-
-// Query registered kits
-defaultKitRegistry.get("azure");
-defaultKitRegistry.getAll();
-defaultKitRegistry.names();
-defaultKitRegistry.has("github");
-```
-
-#### What happens when you register a kit
-
-1. **Auth validation** — verifies `provider` is non-empty and `scopes` is a non-empty string array
-2. **Dependency validation** — all declared deps must be registered first
-3. **Cycle detection** — DFS walk detects circular dependency chains (e.g. A → B → A)
-4. **Collision detection** — tool and connector names must be unique across kits
-5. **Tool auto-wiring** — all `tools` are registered into the `ToolRegistry`
-6. **Connector auto-wiring** — all `connectors` are registered into the `APIConnectorRegistry`
-7. **Lifecycle hook** — `onActivate()` is called if provided
-8. **Transactional rollback** — if `onActivate()` throws, all changes are rolled back (tools unregistered, connectors removed, kit deleted)
-
-#### Unregistration
-
-```typescript
-await defaultKitRegistry.unregister("my-kit");
-```
-
-Unregistration blocks if other kits declare this kit as a dependency. `onDeactivate()` is called before removal — if it throws, the kit stays registered.
-
-### Prompt Resolution
-
-Kits contribute to the system prompt at three levels (highest priority first):
-
-1. **`skills`** — typed `Skill` objects filtered by phase and activated by keyword matching in conversation history. Skills have explicit `priority` ordering.
-2. **`phasePrompts[phase]`** — explicit per-phase augmentations. When present for a given phase, these take priority over the flat `prompts` array.
-3. **`prompts`** — flat augmentations filtered by keyword heuristics in the skill resolver for backward compatibility.
-
-The skill resolver (`packages/core/src/engine/skill-resolver.ts`) runs a middleware chain: phaseFilter → keywordActivation → priorityOrder. See [Conversation Phases](./conversation-phases.md) for details on how skills are resolved per phase.
-
-### Trust Model
-
-Kits are **trusted first-party code**. No sandboxing is applied — lifecycle hooks (`onActivate`, `onDeactivate`) and tool `execute` functions run with full process privileges. If third-party kits are needed in the future, implement capability restrictions and sandboxing before allowing untrusted code to register as a kit.
-
----
-
-## Built-in Kits
-
-### GitHub Kit
-
-**File:** `packages/core/src/kits/github-kit.ts`
-
-| | Details |
-|---|---|
-| **Tools** | `github_repo_info`, `github_repo_tree`, `github_repo_file_read` |
-| **Connectors** | `GitHubConnector` (OAuth Device Flow + PAT auth) |
-| **Components** | `AuthCard` (GitHub sign-in), `githubRepoPicker` (repo search and selection) |
-| **Auth** | `github-oauth` with scopes `repo`, `read:user` |
-| **Phase prompts** | Discover (repo analysis protocol), Design (CI/CD extension), Generate (deploy.yml with OIDC), Handoff (push + secrets setup), Deploy (Actions monitoring) |
-
-### Azure Kit
-
-**File:** `packages/core/src/kits/azure-kit.ts`
-
-| | Details |
-|---|---|
-| **Tools** | `azure_resource_list`, `azure_resource_get`, `estimate_cost` |
-| **Connectors** | `AzureARMConnector` (Azure Resource Manager), `PricingConnector` (no auth) |
-| **Components** | `AuthCard` (Azure MSAL), `azureResourcePicker`, `azureResourceForm`, `azureAction` |
-| **Auth** | `azure-msal` with scope `https://management.azure.com/.default` |
-| **Skills** | `iac-bicep-modules` (Bicep conventions), `iac-secure-decorators` (@secure() usage), and more |
-
----
-
-## How to Create an Integration Kit
-
-### Step 1 — Plan your kit surface
-
-Decide what your kit provides:
-
-- **Tools** — what LLM-callable functions does your integration need? (see [LLM Tools](./llm-tools.md))
-- **Connectors** — does it call an external API that needs authentication?
-- **Prompts** — should the AI behave differently during certain phases when your kit is active?
-- **Components** — does it register A2UI component types for the frontend?
-
-### Step 2 — Implement the tools
-
-Create tool files in `packages/core/src/tools/` following the `Tool<TArgs>` interface. See [LLM Tools](./llm-tools.md) for the complete walkthrough.
-
-```typescript
-// packages/core/src/tools/my-service-query.ts
-import type { Tool, ToolContext } from "./types.js";
-
-interface MyServiceQueryArgs {
-  query: string;
-}
-
-export const myServiceQuery: Tool<MyServiceQueryArgs> = {
-  name: "my_service_query",
-  description: "Query the My Service API for relevant resources.",
-  parameters: {
-    type: "object",
-    properties: {
-      query: { type: "string", description: "Search query" },
-    },
-    required: ["query"],
-  },
-  async execute(args, context) {
-    // Implementation
-    return { results: [] };
-  },
-};
-```
-
-### Step 3 — Implement the connector (if needed)
-
-Create a connector implementing the `APIConnector` interface from `packages/core/src/connectors/types.ts`:
-
-```typescript
-import type { APIConnector, HttpMethod, APIConnectorRequestOptions } from "./types.js";
-
-export class MyServiceConnector implements APIConnector {
-  readonly name = "my-service";
-  readonly baseUrl = "https://api.myservice.com/v1";
-
-  async authenticate(): Promise<void> {
-    // Acquire or refresh tokens
-  }
-
-  isAuthenticated(): boolean {
-    return false;
-  }
-
-  async request(
-    method: HttpMethod,
-    path: string,
-    body?: unknown,
-    options?: APIConnectorRequestOptions,
-  ): Promise<Response> {
-    return fetch(`${this.baseUrl}${path}`, {
-      method,
-      headers: { ...options?.headers },
-      body: body ? JSON.stringify(body) : undefined,
-      signal: options?.signal,
-    });
-  }
-}
-```
-
-### Step 4 — Define the kit
-
-Create your kit file in `packages/core/src/kits/`:
-
-```typescript
-// packages/core/src/kits/my-service-kit.ts
-import type { IntegrationKit } from "./types.js";
-import { Phase } from "../engine/types.js";
-import { myServiceQuery } from "../tools/my-service-query.js";
-import { MyServiceConnector } from "../connectors/MyServiceConnector.js";
-
-export const myServiceKit: IntegrationKit = {
-  name: "my-service",
-  description: "My Service integration — query resources and manage deployments.",
-
-  tools: [myServiceQuery],
-  connectors: [new MyServiceConnector()],
-
-  phasePrompts: {
-    [Phase.Discover]: [
-      "When the user mentions My Service, call my_service_query to discover " +
-      "their existing resources before making recommendations.",
-    ],
-  },
-
-  components: [
-    {
-      type: "myServicePicker",
-      description: "Resource picker for My Service resources.",
-    },
-  ],
-
-  auth: [
-    {
-      provider: "my-service-oauth",
-      scopes: ["read", "write"],
-      optional: false,
-    },
-  ],
-
-  // If this kit depends on the GitHub kit being registered first:
-  // dependencies: ["github"],
-
-  async onActivate() {
-    // Runs after registration — initialize caches, warm connections, etc.
-  },
-
-  async onDeactivate() {
-    // Runs before removal — clean up resources
-  },
-};
-```
-
-### Step 5 — Register at app startup
-
-Import and register your kit where the app bootstraps. Register dependencies first:
-
-```typescript
-import { registerKit } from "@kickstart/core";
-import { myServiceKit } from "@kickstart/core/kits/my-service-kit";
-
-// After existing kits are registered
-await registerKit(myServiceKit);
-```
-
-### Step 6 — Write tests
-
-Add test cases to `packages/core/src/__tests__/integration-kit.test.ts` (or create a new test file):
-
-```typescript
-import { IntegrationKitRegistry } from "../kits/registry.js";
-import { ToolRegistry } from "../tools/registry.js";
-import { APIConnectorRegistry } from "../connectors/registry.js";
-import { myServiceKit } from "../kits/my-service-kit.js";
-
-describe("myServiceKit", () => {
-  it("registers without errors", async () => {
-    const toolReg = new ToolRegistry();
-    const connReg = new APIConnectorRegistry();
-    const kitReg = new IntegrationKitRegistry(toolReg, connReg);
-
-    await kitReg.register(myServiceKit);
-
-    expect(kitReg.has("my-service")).toBe(true);
-    expect(toolReg.get("my_service_query")).toBeDefined();
-    expect(connReg.get("my-service")).toBeDefined();
-  });
-
-  it("rejects self-dependency", async () => {
-    const badKit = { ...myServiceKit, dependencies: ["my-service"] };
-    const kitReg = new IntegrationKitRegistry();
-    await expect(kitReg.register(badKit)).rejects.toThrow("dependency on itself");
-  });
-});
-```
-
-### Step 7 — Build and verify
-
-```bash
-npm run build -w @kickstart/core
-npm run test -w @kickstart/core
-```
-
----
-
-## Key Files
-
-| File | Purpose |
-|---|---|
-| `packages/core/src/kits/types.ts` | `IntegrationKit`, `ComponentRegistration`, `KitAuthRequirement` interfaces |
-| `packages/core/src/kits/registry.ts` | `IntegrationKitRegistry` class, `defaultKitRegistry` singleton, `registerKit()` |
-| `packages/core/src/kits/github-kit.ts` | GitHub integration kit (tools, connectors, phase prompts) |
-| `packages/core/src/kits/azure-kit.ts` | Azure integration kit (tools, connectors, skills, components) |
-| `packages/core/src/connectors/types.ts` | `APIConnector` interface and auth strategy types |
-| `packages/core/src/tools/types.ts` | `Tool<TArgs>` interface (see [LLM Tools](./llm-tools.md)) |
-| `packages/core/src/engine/skill-resolver.ts` | Prompt resolution middleware chain |
-| `packages/core/src/__tests__/integration-kit.test.ts` | Kit registration, dependency, and lifecycle tests |

--- a/docs-site/docs/extending/llm-tools.md
+++ b/docs-site/docs/extending/llm-tools.md
@@ -12,7 +12,7 @@ This guide covers the tool interface, the registry, and how to add a new tool.
 
 ### Tool Interface
 
-Every tool implements the `Tool<TArgs>` interface defined in `packages/core/src/tools/types.ts`:
+Every tool implements the `Tool<TArgs>` interface defined in `packages/pack-core/src/tools/types.ts`:
 
 ```typescript
 export interface Tool<TArgs = Record<string, unknown>> {
@@ -48,7 +48,7 @@ The `ToolContext` gives your tool access to:
 
 ### Tool Registry
 
-`packages/core/src/tools/registry.ts` exports a `ToolRegistry` class and a `defaultRegistry` singleton:
+`packages/pack-core/src/tools/registry.ts` exports a `ToolRegistry` class and a `defaultRegistry` singleton:
 
 ```typescript
 const registry = new ToolRegistry();
@@ -98,10 +98,10 @@ Tool call events are streamed to the client as SSE events of type `tool_call` an
 
 ### Step 1 — Create the tool file
 
-Create a new file in `packages/core/src/tools/`. Name it after your tool using kebab-case:
+Create a new file in `packages/pack-core/src/tools/`. Name it after your tool using kebab-case:
 
 ```
-packages/core/src/tools/my-tool.ts
+packages/pack-core/src/tools/my-tool.ts
 ```
 
 Implement the `Tool<TArgs>` interface:
@@ -155,7 +155,7 @@ The LLM decides when to call your tool based entirely on the `description`. Be e
 
 ### Step 2 — Add SSRF and input validation
 
-If your tool makes outbound HTTP requests, validate inputs to prevent SSRF attacks. See `packages/core/src/tools/fetch-webpage.ts` for the reference implementation — it validates the URL scheme, blocks private IP ranges, and restricts to HTTP/HTTPS:
+If your tool makes outbound HTTP requests, validate inputs to prevent SSRF attacks. See `packages/pack-core/src/tools/fetch-webpage.ts` for the reference implementation — it validates the URL scheme, blocks private IP ranges, and restricts to HTTP/HTTPS:
 
 ```typescript
 async execute(args, context) {
@@ -169,7 +169,7 @@ async execute(args, context) {
 
 ### Step 3 — Register the tool
 
-Open `packages/core/src/tools/index.ts` and add your tool to the registration block:
+Open `packages/pack-core/src/tools/index.ts` and add your tool to the registration block:
 
 ```typescript
 import { myTool } from "./my-tool.js";
@@ -181,7 +181,7 @@ defaultRegistry.registerAll([
 ]);
 ```
 
-Alternatively, if your tool belongs to an integration, add it to your `IntegrationKit`'s `tools` array instead. See [Integration Kits](./integration-kits.md) for details.
+Alternatively, if your tool belongs to an integration, add it to your pack's tool contributions instead. See [Packs](./integration-kits.md) for details.
 
 ### Step 4 — Write tests
 
@@ -226,8 +226,8 @@ Start the dev server and open a conversation. Ask the AI to do something that sh
 
 | File | Purpose |
 |---|---|
-| `packages/core/src/tools/types.ts` | `Tool<TArgs>` and `ToolContext` interfaces |
-| `packages/core/src/tools/registry.ts` | `ToolRegistry` class and `defaultRegistry` singleton |
-| `packages/core/src/tools/index.ts` | Tool registration entry point |
-| `packages/core/src/tools/fetch-webpage.ts` | Reference implementation with SSRF protection |
+| `packages/pack-core/src/tools/types.ts` | `Tool<TArgs>` and `ToolContext` interfaces |
+| `packages/pack-core/src/tools/registry.ts` | `ToolRegistry` class and `defaultRegistry` singleton |
+| `packages/pack-core/src/tools/index.ts` | Tool registration entry point |
+| `packages/pack-core/src/tools/fetch-webpage.ts` | Reference implementation with SSRF protection |
 | `packages/web/api/src/functions/converse.ts` | LLM wiring: `toOpenAIFormat()`, `execute()`, multi-round loop |

--- a/docs-site/docs/extending/overview.md
+++ b/docs-site/docs/extending/overview.md
@@ -4,49 +4,51 @@ sidebar_position: 1
 
 # Extending Kickstart
 
-Kickstart is built to be extended. Every major system surface has a defined extension point — no forking required. Whether you want to add a new guided conversation phase, expose a new function to the LLM, or bundle an entire third-party integration, there's a clean contract for doing it.
+Kickstart v2 is built on the **harness + packs** model. All domain knowledge lives in packs; the harness is domain-agnostic. Extension means authoring a new pack or contributing to an existing one.
 
 ## Extension Points
 
-| Extension Point | What You're Adding | Where It Lives |
+| What you want to add | Primitive | Where it lives |
 |---|---|---|
-| [Conversation Phases](./conversation-phases.md) | A new guided step in the AI flow | `packages/core/src/engine/` |
-| [LLM Tools](./llm-tools.md) | A new function the AI can call | `packages/core/src/tools/` |
-| [Integration Kits](./integration-kits.md) | A composable bundle of tools, connectors, prompts, and skills | `packages/core/src/kits/` |
-| [API Endpoints](./api-endpoints.md) | A new Azure Functions endpoint (optionally SSE-streaming) | `packages/web/api/src/functions/` |
-| [MCP Tools](./mcp-tools.md) | A new tool for VS Code Copilot / Claude Code IDE integration | `packages/mcp-server/src/tools/` |
+| A new AI persona | **Agent** (`.agent.md`) | `packages/pack-*/src/agents/` |
+| Domain knowledge for agents | **Skill** (`SKILL.md`) | `packages/pack-*/src/skills/` |
+| A server-side function the LLM can call | **Tool** | `packages/pack-*/src/tools/` |
+| A browser interaction (auth, consent, etc.) | **UserAction** | `packages/pack-*/src/user-actions/` |
+| A new A2UI component type | **Component** | `packages/pack-*/src/components/` |
+| A cross-cutting check | **Guardrail** | `packages/pack-*/src/guardrails/` |
+| A new HTTP endpoint | **Azure Function** | `packages/web/api/src/functions/` |
+| IDE tool exposure | **MCP tool** | `packages/mcp-server/src/` |
 
 ## Architecture Overview
 
-Kickstart's extensibility is layered. Most changes flow through the **core package** (`packages/core`), which is shared by both the web API and the MCP server.
-
 ```
 packages/
-├── core/                    ← Shared engine: phases, tools, kits, prompts
-│   └── src/
-│       ├── engine/          ← Phase state machine, skill resolver
-│       ├── tools/           ← LLM tool registry
-│       ├── kits/            ← Integration kit registry
-│       └── prompts/         ← System prompt builder
-├── web/
-│   └── api/src/functions/   ← Azure Functions HTTP endpoints
-└── mcp-server/src/          ← MCP server for IDE clients
+├── harness/              ← Runtime: pack registry, Runner, SSE, session
+│   └── src/runtime/      ← Skill resolver, guardrail engine, catalog
+├── pack-core/            ← Base agents, skills, tools, components
+├── pack-azure/           ← Azure domain
+├── pack-aks-automatic/   ← AKS Automatic domain
+├── pack-github/          ← GitHub domain
+├── web/api/              ← Azure Functions HTTP layer
+└── mcp-server/           ← MCP adapter
 ```
 
 ## Where to Start
 
-- **Adding a new AI capability?** → [LLM Tools](./llm-tools.md) is the fastest path. Create one file, register it, done.
-- **Adding an end-to-end integration** (e.g., a new cloud provider)? → [Integration Kits](./integration-kits.md) lets you bundle tools + connectors + prompts into one unit.
-- **Adding a new guided workflow step?** → [Conversation Phases](./conversation-phases.md) walks you through the phase state machine.
-- **Exposing a new HTTP surface?** → [API Endpoints](./api-endpoints.md) covers the Azure Functions v4 pattern with SSE streaming.
-- **Extending IDE integration?** → [MCP Tools](./mcp-tools.md) covers the MCP server pattern for VS Code Copilot and Claude Code.
+- **New LLM capability (no browser interaction)?** → Author a **Tool** in the relevant pack. One file, register in the pack's index, done.
+- **Browser popup / credential flow?** → Author a **UserAction**. The harness handles pause/resume automatically.
+- **New AI persona?** → Author an `.agent.md` file. Declare its allowed tools and handoff targets in frontmatter.
+- **Domain knowledge injection?** → Author a `SKILL.md` file with an `appliesTo` glob targeting the relevant agents.
+- **New integration domain** (e.g., a new cloud provider)? → Create a new pack that contributes agents + skills + tools + user actions together.
+- **New HTTP surface?** → [API Endpoints](./api-endpoints.md) covers the Azure Functions v4 pattern with SSE streaming.
+- **IDE integration?** → [MCP Tools](./mcp-tools.md) covers MCP tool authoring for VS Code Copilot and Claude Code.
 
 ## Design Principles
 
-**First-party only.** There is no plugin sandbox or dynamic loading — all extensions are compiled into the package. This keeps the trust model simple: anything registered is trusted code.
+**Packs are the unit of extensibility.** A pack is a sealed bundle registered at startup. The harness is domain-agnostic — it does not know about Azure, AKS, GitHub, or any product domain.
 
-**Composition over inheritance.** Integration Kits wire into the ToolRegistry, ConnectorRegistry, and SkillResolver automatically. You define the what; the system handles the wiring.
+**First-party only.** No plugin sandbox or dynamic loading — all packs are compiled into the monorepo. Everything registered is trusted code.
 
-**Phase-aware.** Skills and prompts can be scoped to specific phases. An LLM tool registered for the `generate` phase doesn't appear in `discover` phase conversations.
+**Tools have no side effects on their own.** Agents call tools; tools return typed results. Browser interactions go through UserActions, which pause the runner and wait for a browser POST.
 
-**SSE-first.** Long-running AI operations use Server-Sent Events. New endpoints that call the LLM should follow the same streaming pattern as `converse` and `generate`.
+**Skills are pure text.** No code, no execution. If you need execution, write a tool.

--- a/docs-site/docs/getting-started/local-setup.md
+++ b/docs-site/docs/getting-started/local-setup.md
@@ -24,7 +24,7 @@ cd kickstart
 npm install
 ```
 
-The root `npm install` installs dependencies for all workspace packages (`packages/core` and `packages/web`).
+The root `npm install` installs dependencies for all workspace packages (`packages/harness` and `packages/web`).
 
 ### 2. Configure environment variables
 

--- a/docs-site/docs/getting-started/project-structure.md
+++ b/docs-site/docs/getting-started/project-structure.md
@@ -9,73 +9,67 @@ Kickstart is organized as an npm workspaces monorepo.
 ```
 kickstart/
 ├── packages/
-│   ├── core/              # AI engine — phases, prompts, catalog, tools
-│   │   ├── src/
-│   │   │   ├── engine/    # Phase definitions, state, skill resolver
-│   │   │   │   └── phases.ts  # Conversation phase definitions
-│   │   │   ├── prompts/   # System prompt templates
-│   │   │   ├── catalog/   # A2UI component catalog definitions
-│   │   │   ├── tools/     # LLM tool definitions
-│   │   │   └── index.ts   # Package entry point
-│   │   └── package.json
+│   ├── harness/           # @kickstart/harness — runtime engine
+│   │   └── src/
+│   │       ├── runtime/   # Runner, session, skill resolver, SSE adapter
+│   │       ├── a2ui/      # A2UI v0.9 message types and helpers
+│   │       ├── mcp/       # MCP adapter utilities
+│   │       └── types/     # Zod schemas (AgentOutput, pack primitives)
 │   │
-│   ├── web/               # React frontend + Azure Functions API
-│   │   ├── src/            # React app source
-│   │   │   ├── vendor/     # Vendored A2UI renderer
-│   │   │   ├── catalog/    # A2UI catalog component implementations
-│   │   │   │   └── components/  # Rendered A2UI components (CodeBlock, AuthCard, …)
+│   ├── pack-core/         # @kickstart/pack-core — base agents, skills, tools, components
+│   │   └── src/
+│   │       ├── agents/    # .agent.md files for triage, codesmith, reviewer
+│   │       ├── skills/    # SKILL.md files
+│   │       ├── tools/     # core.emit_ui, core.write_file, etc.
+│   │       └── components/ # Basic + rich A2UI component renderers
+│   │
+│   ├── pack-azure/        # @kickstart/pack-azure — Azure agents, tools, user actions
+│   ├── pack-aks-automatic/ # @kickstart/pack-aks-automatic — AKS Automatic deployment pack
+│   ├── pack-github/       # @kickstart/pack-github — GitHub agents, tools, user actions
+│   │
+│   ├── web/               # @kickstart/web — React frontend + Azure Functions API
+│   │   ├── src/           # React app source
+│   │   │   ├── vendor/    # Vendored A2UI renderer
 │   │   │   ├── components/ # App-shell components (Layout, Sidebar, Topbar, …)
-│   │   │   ├── pages/      # Route-level pages (Chat, Playground, Landing, …)
-│   │   │   ├── hooks/      # React hooks (useStreaming, useNavigation, …)
-│   │   │   └── App.tsx     # Root component
-│   │   ├── api/            # Azure Functions (SWA managed)
-│   │   │   └── src/
-│   │   │       └── functions/  # Individual function handlers
-│   │   │           └── converse.ts  # /api/converse endpoint
-│   │   ├── public/         # Static assets (icons, favicon)
-│   │   ├── dist/           # Vite build output
+│   │   │   ├── pages/     # Route-level pages (Chat, Playground, Landing, …)
+│   │   │   └── hooks/     # React hooks (useStreaming, useActionDispatch, …)
+│   │   ├── api/           # Azure Functions (SWA managed)
+│   │   │   └── src/functions/  # converse.ts, resume.ts, packs.ts
 │   │   └── package.json
 │   │
-│   └── mcp-server/        # MCP server — exposes Kickstart tools via Model Context Protocol
-│       ├── src/
-│       │   ├── app/        # Server bootstrap and protocol handler
-│       │   ├── tools/      # MCP tool implementations
-│       │   └── index.ts    # Package entry point
-│       └── package.json
+│   └── mcp-server/        # @kickstart/mcp-server — MCP adapter wrapping the Runner
+│       └── src/
+│           └── index.ts   # MCP server entry point
 │
-├── docs-site/              # This documentation site (Docusaurus)
-├── infra/                  # Azure infrastructure (Bicep)
-├── .squad/                 # AI team configuration (Squad framework)
-├── package.json            # Root workspace config
-├── tsconfig.json           # Shared TypeScript config
-└── vitest.config.ts        # Test configuration
+├── docs-site/             # This documentation site (Docusaurus)
+├── infra/                 # Azure infrastructure (Bicep)
+├── .squad/                # AI team configuration (Squad framework)
+├── package.json           # Root workspace config
+├── tsconfig.json          # Shared TypeScript config
+└── vitest.config.ts       # Test configuration
 ```
 
 ## Package Details
 
-### `packages/core`
+### `packages/harness`
 
-The AI engine package. Contains:
+The domain-agnostic runtime. Manages pack registration, runs agents via the `@openai/agents` SDK, streams typed SSE events, mediates A2UI, enforces guardrails. Does not know about Azure, AKS, or GitHub — packs carry all product knowledge.
 
-- **Phase definitions** — the 6-phase conversation flow (Discover → Design → Generate → Review → Handoff → Deploy), defined in `src/engine/phases.ts`
-- **System prompts** — templates that instruct the LLM on response format, tone, and behavior
-- **A2UI catalog** — component type definitions for the custom Kickstart catalog
-- **LLM tools** — tool definitions used by the AI engine
+### `packages/pack-core`
 
-This package has no UI dependencies and can be used independently.
+The base pack. Contributes the core agents (triage, codesmith, reviewer), cross-cutting skills (file generation, code review), basic tools (`core.emit_ui`, `core.write_file`, `core.read_file`, etc.), and the full A2UI component catalog.
+
+### `packages/pack-azure` / `pack-aks-automatic` / `pack-github`
+
+Domain packs. Each contributes agents, skills, tools, user actions, and components for its domain.
 
 ### `packages/web`
 
-The frontend application and API layer. Contains:
-
-- **React SPA** — the main user interface, built with React 19 and Vite 6
-- **A2UI renderer** — vendored renderer in `src/vendor/`
-- **Catalog components** — A2UI component implementations in `src/catalog/components/`
-- **Azure Functions** — the `/api/converse` endpoint in `api/src/functions/converse.ts`
+The frontend application and API layer. React 19 + Vite 6 SPA with Azure Functions backend. The web client reads the negotiated catalog from `GET /api/packs` at startup and dispatches user actions through `useActionDispatch`.
 
 ### `packages/mcp-server`
 
-The Model Context Protocol (MCP) server. Exposes Kickstart's AI tools to MCP-compatible clients (e.g. GitHub Copilot, Claude Desktop). Lives alongside `core` and `web` in the monorepo.
+MCP adapter wrapping the Runner. Exposes Kickstart turns to MCP-compatible clients (VS Code Copilot, Claude Code). A2UI surfaces emitted as MCP embedded resources with `mimeType: "application/json+a2ui"`.
 
 ### `docs-site`
 

--- a/docs/v2-implementation-brief.md
+++ b/docs/v2-implementation-brief.md
@@ -1,7 +1,7 @@
 # Kickstart v2 — Implementation Brief
 
 **Audience:** the implementing agent.
-**Status:** design locked. Ready to execute.
+**Status:** ✅ All 13 steps merged into `v2-rewrite`. Implementation complete.
 **Scope:** greenfield rewrite on `main`. v1 does not need to keep working. Delete aggressively. No user state to preserve.
 
 ---
@@ -1066,33 +1066,33 @@ export async function initPacks(): Promise<void> {
 
 Each step compiles, tests green, before moving on. Land as sequential PRs on `main`.
 
-**Step 1 — nuke v1.** Delete v1 paths listed in §4. Rename `packages/core` → `packages/harness`. Preserve: Azure OpenAI client, `@kickstart/mcp-server` shell, web shell (`components/`, `contexts/`, auditable `hooks/`), Playground page files, `catalog/components/` + `catalog/fluent-components/` + `catalog/icons/` (to be redistributed), `services/api-client.ts`, `services/virtual-fs.ts`, frontmatter parser. Repo compiles; no runtime yet.
+**✅ Step 1 — nuke v1.** Delete v1 paths listed in §4. Rename `packages/core` → `packages/harness`. Preserve: Azure OpenAI client, `@kickstart/mcp-server` shell, web shell (`components/`, `contexts/`, auditable `hooks/`), Playground page files, `catalog/components/` + `catalog/fluent-components/` + `catalog/icons/` (to be redistributed), `services/api-client.ts`, `services/virtual-fs.ts`, frontmatter parser. Repo compiles; no runtime yet.
 
-**Step 2 — harness types.** Add every file under `packages/harness/src/types/`. Zod schemas for `AgentOutput` and A2UI v0.9 messages. Move `utils/chat-a2ui.ts` into harness. No runtime yet.
+**✅ Step 2 — harness types.** Add every file under `packages/harness/src/types/`. Zod schemas for `AgentOutput` and A2UI v0.9 messages. Move `utils/chat-a2ui.ts` into harness. No runtime yet.
 
-**Step 3 — registry + loaders.** `PackRegistry` (register/enable/seal). `.agent.md` loader. `SKILL.md` loader. Unit tests covering frontmatter parsing, tool-reference resolution, collision detection, dependency ordering.
+**✅ Step 3 — registry + loaders.** `PackRegistry` (register/enable/seal). `.agent.md` loader. `SKILL.md` loader. Unit tests covering frontmatter parsing, tool-reference resolution, collision detection, dependency ordering.
 
-**Step 4 — pack-core.** Author the three `.agent.md` files. Author the five `SKILL.md` files. Implement `core.emit_ui`, `core.write_file`, `core.read_file`, `core.list_files`, `core.validate_artifacts`, `core.fetch_webpage`. Port 27 basic Fluent renderers + 12 rich components from `catalog/` into `pack-core/src/components/{basic,rich}/`.
+**✅ Step 4 — pack-core.** Author the three `.agent.md` files. Author the five `SKILL.md` files. Implement `core.emit_ui`, `core.write_file`, `core.read_file`, `core.list_files`, `core.validate_artifacts`, `core.fetch_webpage`. Port 27 basic Fluent renderers + 12 rich components from `catalog/` into `pack-core/src/components/{basic,rich}/`.
 
-**Step 4a — playground on registry.** Rewrite `Playground.tsx` / `PlaygroundWorkspace.tsx` to read from the registry. Port a handful of core-domain scenarios into `pack-core/playground/`. Useful validation of the registry shape before domain packs land.
+**✅ Step 4a — playground on registry.** Rewrite `Playground.tsx` / `PlaygroundWorkspace.tsx` to read from the registry. Port a handful of core-domain scenarios into `pack-core/playground/`. Useful validation of the registry shape before domain packs land.
 
-**Step 5 — runner + SSE.** Converse handler. Resume handler. `/api/packs` manifest. Rewrite `hooks/useStreaming.ts` for typed SSE. Rewrite `hooks/useActionDispatch.ts` as the UserAction dispatcher. Integration test: triage → codesmith with a mocked model, asserting SSE event order (`chunk`, `a2ui`, `handoff`, `intent`, `done`).
+**✅ Step 5 — runner + SSE.** Converse handler. Resume handler. `/api/packs` manifest. Rewrite `hooks/useStreaming.ts` for typed SSE. Rewrite `hooks/useActionDispatch.ts` as the UserAction dispatcher. Integration test: triage → codesmith with a mocked model, asserting SSE event order (`chunk`, `a2ui`, `handoff`, `intent`, `done`).
 
-**Step 6 — skill resolver.** Per-turn selection by `appliesTo` glob + keyword scoring + priority + token budget (2000 tokens default). Unit tests.
+**✅ Step 6 — skill resolver.** Per-turn selection by `appliesTo` glob + keyword scoring + priority + token budget (2000 tokens default). Unit tests.
 
-**Step 7 — pack-azure.** Port 2 agents, 9 skills. Port 5 tools. Port 6 user actions (using ported `services/azure-auth.ts`, `services/azure-deployments.ts`). Port 8 components including `AzureLoginCard`→`Login`, `AzureResourcePicker`→`SubscriptionPicker`/`RegionPicker`/`ResourceGroupPicker`, `AzureResourceForm`→`ResourceForm`, `AzureAction`→`Action`, `CostEstimate`→`CostSummary`. Port Azure icon assets. Author playground scenarios + stubs.
+**✅ Step 7 — pack-azure.** Port 2 agents, 9 skills. Port 5 tools. Port 6 user actions (using ported `services/azure-auth.ts`, `services/azure-deployments.ts`). Port 8 components including `AzureLoginCard`→`Login`, `AzureResourcePicker`→`SubscriptionPicker`/`RegionPicker`/`ResourceGroupPicker`, `AzureResourceForm`→`ResourceForm`, `AzureAction`→`Action`, `CostEstimate`→`CostSummary`. Port Azure icon assets. Author playground scenarios + stubs.
 
-**Step 8 — pack-aks-automatic.** Port 3 agents, 7 skills, `safeguards.json`. 2 tools. 1 user action. Port `ArchitectureDiagram.tsx` + `architectureDiagramIconRegistry.ts` + `architectureDiagramUtils.ts` (with tests) + k8s icons. 3 new components. 3 guardrails. Playground scenarios.
+**✅ Step 8 — pack-aks-automatic.** Port 3 agents, 7 skills, `safeguards.json`. 2 tools. 1 user action. Port `ArchitectureDiagram.tsx` + `architectureDiagramIconRegistry.ts` + `architectureDiagramUtils.ts` (with tests) + k8s icons. 3 new components. 3 guardrails. Playground scenarios.
 
-**Step 9 — pack-github.** 1 agent, 3 skills. 1 tool. 6 user actions (port from adaptive-ui-github-pack logic and `services/github-handoff.ts`). Port `GitHubLoginCard`→`Login`, `GitHubRepoPicker`→`RepoPicker`, `GitHubCommit`→`CreatePRFlow`, `GitHubAction`→`Action`. Playground scenarios + stubs.
+**✅ Step 9 — pack-github.** 1 agent, 3 skills. 1 tool. 6 user actions (port from adaptive-ui-github-pack logic and `services/github-handoff.ts`). Port `GitHubLoginCard`→`Login`, `GitHubRepoPicker`→`RepoPicker`, `GitHubCommit`→`CreatePRFlow`, `GitHubAction`→`Action`. Playground scenarios + stubs.
 
-**Step 10 — web client.** Rewrite `components/A2UI/` to consume the negotiated catalog from the registry. `useActionDispatch` routes `user_action_required` → pack handlers (real or stub). Queue policy (cancellation opt-in per action).
+**✅ Step 10 — web client.** Rewrite `components/A2UI/` to consume the negotiated catalog from the registry. `useActionDispatch` routes `user_action_required` → pack handlers (real or stub). Queue policy (cancellation opt-in per action).
 
-**Step 11 — guardrails engine.** Wire stages into Runner lifecycle. Port existing ad-hoc checks (today's regex scattered across v1) into `GuardrailContribution`s.
+**✅ Step 11 — guardrails engine.** Wire stages into Runner lifecycle. Port existing ad-hoc checks (today's regex scattered across v1) into `GuardrailContribution`s.
 
-**Step 12 — MCP.** Rewrite `@kickstart/mcp-server` shell to wrap Runner turns. Emit A2UI as MCP embedded resources with `mimeType: "application/json+a2ui"` and `audience: ["user"]`. UserActions surfaced as MCP `action` tool calls.
+**✅ Step 12 — MCP.** Rewrite `@kickstart/mcp-server` shell to wrap Runner turns. Emit A2UI as MCP embedded resources with `mimeType: "application/json+a2ui"` and `audience: ["user"]`. UserActions surfaced as MCP `action` tool calls.
 
-**Step 13 — docs + cleanup.** Rewrite `docs/` and `docs-site/` around harness + packs. Delete every reference to phases, stepwise, v1 flags, `IntegrationKit`, `converse-model-router`, `response-processor`.
+**✅ Step 13 — docs + cleanup.** Rewrite `docs/` and `docs-site/` around harness + packs. Delete every reference to phases, stepwise, v1 flags, `IntegrationKit`, `converse-model-router`, `response-processor`.
 
 ---
 
@@ -1119,4 +1119,4 @@ Each step compiles, tests green, before moving on. Land as sequential PRs on `ma
 
 ---
 
-**End of brief.** Hand to the implementing agent. Start with Step 1.
+**End of brief.** All 13 steps are merged. The v2 rewrite is complete.


### PR DESCRIPTION
Closes #488

Working as Bender (Automation/Tooling)

## Changes

### `docs/v2-implementation-brief.md`
- Status updated to ✅ All 13 steps merged
- All step entries marked ✅ complete
- Final line updated: "All 13 steps are merged. The v2 rewrite is complete."

### `docs-site/` — v1 architecture scrubbed, replaced with v2
- **`architecture/overview.md`** — complete rewrite: harness+packs, 5 primitives, v2 request flow, session lifecycle
- **`architecture/prompt-pipeline.md`** — rewrite: Runner-based assembly, skill resolution, guardrails
- **`architecture/skill-injection.md`** — rewrite: SKILL.md-based resolver (appliesTo glob + keyword scoring + token budget)
- **`architecture/fsm.md`** — update: remove `packages/core` path, update phase advancement to `intent: "advance"`
- **`architecture/a2ui-integration.md`** — `IntegrationKits` → packs
- **`extending/overview.md`** — rewrite: packs-first extension model
- **`extending/integration-kits.md`** — replaced: now documents v2 Pack interface, UserActions, guardrails
- **`extending/conversation-phases.md`** — remove `phasePrompts`/`IntegrationKit` Step 4, update skill resolver refs
- **`extending/llm-tools.md`** — `packages/core/src/tools/` → `packages/pack-core/src/tools/`
- **`extending/api-endpoints.md`** — remove `response-processor.ts` stale entry
- **`contributing.md`** — update `packages/core` → harness/pack paths
- **`getting-started/project-structure.md`** — complete rewrite for v2 packages
- **`getting-started/local-setup.md`** — fix `packages/core` ref

### `README.md`
- Features section updated for harness+packs architecture
- "Two Surfaces, One Engine" → "Two Surfaces, One Harness"

### Worktree cleanup
- Removed stale worktrees for merged steps: 485, 486, 487

## No code changes — docs/cleanup only