### PR TITLE
ci: add v2-rewrite branch to CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - v2-rewrite
   pull_request:
     branches:
       - main
+      - v2-rewrite
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #741

## Summary
CI previously only ran on PRs targeting `main`, which allowed v2-rewrite to accumulate build failures undetected.

## Changes
- `.github/workflows/ci.yml`: added `push` trigger for `v2-rewrite` and added `v2-rewrite` to `pull_request.branches`.

## Testing
- YAML validated with `python3 -c 'import yaml; yaml.safe_load(...)'`.

🤖 Working as Bender (Backend Dev)