### PR TITLE
fix(api): resolve @kickstart/harness subpath imports in esbuild

### DIFF
--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -13,11 +13,27 @@ import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const HARNESS_SRC = resolve(__dirname, "../../harness/src");
 
 const entryPoints = readdirSync("src/functions")
   .filter((f) => f.endsWith(".ts"))
   .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"))
   .map((f) => join("src/functions", f));
+
+// esbuild's `alias` option does not handle subpath exports like
+// `@kickstart/harness/runtime/sse`. A resolver plugin rewrites both the
+// root specifier and any subpath to the corresponding `.ts` source file.
+const harnessResolver = {
+  name: "kickstart-harness-resolver",
+  setup(build) {
+    build.onResolve({ filter: /^@kickstart\/harness(\/.*)?$/ }, (args) => {
+      const sub = args.path === "@kickstart/harness"
+        ? "index"
+        : args.path.slice("@kickstart/harness/".length);
+      return { path: resolve(HARNESS_SRC, `${sub}.ts`) };
+    });
+  },
+};
 
 await esbuild.build({
   entryPoints,
@@ -28,9 +44,7 @@ await esbuild.build({
   target: "node20",
   external: ["@azure/functions", "bicep-node"],
   sourcemap: true,
-  alias: {
-    "@kickstart/harness": resolve(__dirname, "../../harness/src/index.ts"),
-  },
+  plugins: [harnessResolver],
 });
 
 console.log(`✅ Bundled ${entryPoints.length} function(s) to dist/functions/`);


### PR DESCRIPTION
Closes #739

## Summary
`packages/web/api` failed to bundle with esbuild because subpath imports (`@kickstart/harness/runtime/sse`, `.../runtime/session`, `.../runtime/runner`, `.../runtime/resume`, `.../runtime/registry`) were rewritten by the simple string alias to `packages/harness/src/index.ts/runtime/sse` — a file path that does not exist. The `isPhase` symptom in the original issue was a downstream side effect of that same resolver failure.

## Changes
- `packages/web/api/esbuild.config.mjs`: replaced the single-target `alias` with a resolver plugin (`kickstart-harness-resolver`) that maps `@kickstart/harness` → `packages/harness/src/index.ts` and `@kickstart/harness/<sub>` → `packages/harness/src/<sub>.ts`. No v1 code resurrected; the v2 harness source layout is the source of truth.

## Testing
- `npm run build -w @kickstart/harness` ✅
- `npm run build -w @kickstart/api` ✅ (20 functions bundled)

🤖 Working as Bender (Backend Dev)