### PR TITLE
fix(mcp-server): unblock build — narrow pendingInterrupt for TS spread

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -199,11 +199,20 @@ server.tool(
       content.push(...buildA2UIContent(a2uiMessages, isVsCode));
 
       // UserAction interrupt: always structured JSON, never human-readable text
-      if (pendingInterrupt) {
+      if (pendingInterrupt !== null) {
+        const interrupt = pendingInterrupt as {
+          actionId: string;
+          actionName: string;
+          confirmComponent?: { component: string; props?: Record<string, unknown> };
+          resultSchema: Record<string, unknown>;
+        };
         content.push(
           buildInterruptContent({
             type: 'interrupt',
-            ...pendingInterrupt,
+            actionId: interrupt.actionId,
+            actionName: interrupt.actionName,
+            confirmComponent: interrupt.confirmComponent,
+            resultSchema: interrupt.resultSchema,
           }),
         );
       }


### PR DESCRIPTION
Closes #738

## Summary
The MCP server failed to build on `v2-rewrite`. The issue enumerated 15 TS errors across 7 files (`ConversationPhaseComponent`, `CodeBlockComponent`, `TextComponent` shape drift, `deleteEngineState` missing, etc.), but the real root cause was a single problem: **`packages/harness` had not been built**. Every `TS6305` / `any` warning disappeared after `npm run build -w @kickstart/harness`, leaving exactly one genuine type error in `packages/mcp-server/src/index.ts`.

That one real error: `pendingInterrupt` is captured in a closure (`sseWrite`) passed to `runner.run()`, so TypeScript refuses to narrow it at the outer `if (pendingInterrupt)` branch and rejects the subsequent `...pendingInterrupt` spread.

## Changes
- `packages/mcp-server/src/index.ts`: replace the unnarrowable spread with an explicit property copy via a locally-typed alias, constructing the v2 `McpInterruptBlock` shape cleanly.

No v1 types were resurrected. No component-shape workarounds were added; the current harness exports already match what the MCP server imports.

## Testing
- `npm run build -w @kickstart/harness` ✅
- `npm run build -w @kickstart/mcp-server` ✅
- `npx vitest run packages/mcp-server/src/__tests__/mcp-adapter.test.ts` ✅ (22/22 — covers the `buildInterruptContent` path touched here)

### Pre-existing failures out of scope
A repo-wide `npx vitest run` surfaces 9 pre-existing failures unrelated to this PR:
- `packages/harness/src/__tests__/registry.test.ts` — 2 failures
- `packages/mcp-server/src/__tests__/action.test.ts` / `action-endpoint.test.ts` — tests still reference `Phase.Design` but `Assess` now sits between Discover and Design
- `packages/web/src/__tests__/app-file-surface.test.ts`, `streaming-406-fallback.test.ts` — jsdom not installed

These also reproduce on untouched `origin/v2-rewrite` and should be tracked separately.

🤖 Working as Bender (Backend Dev)