### PR TITLE
fix(web): update vendored A2UI for Zod v4 + fix connector call signatures

### DIFF
--- a/packages/web/src/catalog/components/AzureAction.tsx
+++ b/packages/web/src/catalog/components/AzureAction.tsx
@@ -90,7 +90,7 @@ const AzureActionApi = {
     description: DynamicStringSchema.optional(),
     method: z.enum(['PUT', 'POST', 'PATCH', 'DELETE']),
     path: DynamicStringSchema,
-    body: z.record(z.unknown()).optional(),
+    body: z.record(z.string(), z.unknown()).optional(),
     apiVersion: DynamicStringSchema.optional(),
     confirmLabel: DynamicStringSchema.optional(),
     onSuccess: ActionSchema.optional(),

--- a/packages/web/src/catalog/components/GitHubAction.tsx
+++ b/packages/web/src/catalog/components/GitHubAction.tsx
@@ -126,7 +126,7 @@ const GitHubActionApi = {
     method: z.enum(['POST', 'PUT', 'PATCH', 'DELETE']),
     path: DynamicStringSchema,
     operationType: DynamicStringSchema,
-    body: z.record(z.unknown()).optional(),
+    body: z.record(z.string(), z.unknown()).optional(),
     confirmLabel: DynamicStringSchema.optional(),
     onSuccess: ActionSchema.optional(),
     onError: ActionSchema.optional(),

--- a/packages/web/src/vendor/a2ui/web_core/catalog/types.ts
+++ b/packages/web/src/vendor/a2ui/web_core/catalog/types.ts
@@ -185,7 +185,7 @@ export class Catalog<T extends ComponentApi> {
 
       // Provides runtime safety: Coerces and strips invalid arguments before execute()
       try {
-        const safeArgs = fn.schema.parse(rawArgs);
+        const safeArgs = fn.schema.parse(rawArgs) as Record<string, any>;
         return fn.execute(safeArgs, ctx, abortSignal);
       } catch (e: any) {
         if (e?.name === 'ZodError' || e instanceof z.ZodError) {

--- a/packages/web/src/vendor/a2ui/web_core/processing/message-processor.ts
+++ b/packages/web/src/vendor/a2ui/web_core/processing/message-processor.ts
@@ -117,7 +117,7 @@ export class MessageProcessor<T extends ComponentApi> {
 
     const functions: any[] = [];
     for (const api of catalog.functions.values()) {
-      const zodSchema = zodToJsonSchema(api.schema, {
+      const zodSchema = zodToJsonSchema(api.schema as any, {
         target: 'jsonSchema2019-09',
       }) as any;
 
@@ -133,7 +133,7 @@ export class MessageProcessor<T extends ComponentApi> {
 
     let theme: Record<string, any> | undefined;
     if (catalog.themeSchema) {
-      const zodSchema = zodToJsonSchema(catalog.themeSchema, {
+      const zodSchema = zodToJsonSchema(catalog.themeSchema as any, {
         target: 'jsonSchema2019-09',
       }) as any;
 

--- a/packages/web/src/vendor/a2ui/web_core/rendering/data-context.ts
+++ b/packages/web/src/vendor/a2ui/web_core/rendering/data-context.ts
@@ -101,7 +101,7 @@ export class DataContext {
       const args: Record<string, any> = {};
 
       for (const [key, argVal] of Object.entries(call.args)) {
-        args[key] = this.resolveDynamicValue(argVal);
+        args[key] = this.resolveDynamicValue(argVal as DynamicValue);
       }
 
       const abortController = new AbortController();
@@ -193,7 +193,7 @@ export class DataContext {
       const argSignals: Record<string, Signal<any>> = {};
 
       for (const [key, argVal] of Object.entries(call.args)) {
-        argSignals[key] = this.resolveSignal(argVal);
+        argSignals[key] = this.resolveSignal(argVal as DynamicValue);
       }
 
       if (Object.keys(argSignals).length === 0) {
@@ -285,7 +285,7 @@ export class DataContext {
       const resolvedContext: Record<string, any> = {};
       if (action.event.context) {
         for (const [key, value] of Object.entries(action.event.context)) {
-          resolvedContext[key] = this.resolveDynamicValue(value);
+          resolvedContext[key] = this.resolveDynamicValue(value as DynamicValue);
         }
       }
       return {

--- a/packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts
+++ b/packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts
@@ -64,64 +64,66 @@ function getFieldBehavior(
   type: z.ZodTypeAny,
   propertyName?: string,
 ): BehaviorNode {
-  let current = type;
+  let current: z.ZodTypeAny = type;
 
   // Unwrap optionals/nullables/defaults
   while (
-    current._def.typeName === 'ZodOptional' ||
-    current._def.typeName === 'ZodNullable' ||
-    current._def.typeName === 'ZodDefault'
+    current instanceof z.ZodOptional ||
+    current instanceof z.ZodNullable ||
+    current instanceof z.ZodDefault
   ) {
-    current = current._def.innerType;
+    current = (
+      current as z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny> | z.ZodDefault<z.ZodTypeAny>
+    ).unwrap() as z.ZodTypeAny;
   }
 
   if (propertyName === 'checks') {
     return {type: 'CHECKABLE'};
   }
 
-  // Structural matching for A2UI primitives using typeName to avoid dual-module instanceof issues
-  if (current._def.typeName === 'ZodUnion') {
-    const options = current._def.options as z.ZodTypeAny[];
+  // Structural matching for A2UI primitives using instanceof to avoid dual-module issues
+  if (current instanceof z.ZodUnion) {
+    const options = (current as z.ZodUnion<any>).options as z.ZodTypeAny[];
 
     // ActionSchema is a union containing { event: ... }
     const isAction = options.some(
-      o => o._def.typeName === 'ZodObject' && o._def.shape().event,
+      o => o instanceof z.ZodObject && (o as z.ZodObject<any>).shape.event,
     );
     if (isAction) return {type: 'ACTION'};
 
     // Dynamic strings/values are unions containing DataBindingSchema { path: ... } but NOT { componentId: ... }
     const isDynamic = options.some(
       o =>
-        o._def.typeName === 'ZodObject' &&
-        o._def.shape().path &&
-        !o._def.shape().componentId,
+        o instanceof z.ZodObject &&
+        (o as z.ZodObject<any>).shape.path &&
+        !(o as z.ZodObject<any>).shape.componentId,
     );
     if (isDynamic) return {type: 'DYNAMIC'};
 
     // ChildList is a union containing an array and an object with { componentId, path }
     const isChildList = options.some(
       o =>
-        o._def.typeName === 'ZodObject' &&
-        o._def.shape().componentId &&
-        o._def.shape().path,
+        o instanceof z.ZodObject &&
+        (o as z.ZodObject<any>).shape.componentId &&
+        (o as z.ZodObject<any>).shape.path,
     );
     if (isChildList) return {type: 'STRUCTURAL'};
-  } else if (current._def.typeName === 'ZodString') {
+  } else if (current instanceof z.ZodString) {
     // ComponentId falls back to STATIC since we can't perfectly identify it, which is fine because STATIC returns strings as-is.
   }
 
   // Recursive array scraping
-  if (current._def.typeName === 'ZodArray') {
+  if (current instanceof z.ZodArray) {
     return {
       type: 'ARRAY',
-      element: getFieldBehavior(current._def.type),
+      element: getFieldBehavior((current as z.ZodArray<z.ZodTypeAny>).element),
     };
   }
 
   // Recursive object scraping
-  if (current._def.typeName === 'ZodObject') {
+  if (current instanceof z.ZodObject) {
     const shape: Record<string, BehaviorNode> = {};
-    const objShape = current._def.shape();
+    const objShape = (current as z.ZodObject<any>).shape;
     for (const [key, value] of Object.entries(objShape)) {
       shape[key] = getFieldBehavior(value as z.ZodTypeAny, key);
     }

--- a/packages/web/src/vendor/a2ui/web_core/schema/client-to-server.ts
+++ b/packages/web/src/vendor/a2ui/web_core/schema/client-to-server.ts
@@ -38,7 +38,7 @@ export const A2uiClientActionSchema = z
       .datetime()
       .describe('An ISO 8601 timestamp of when the event occurred.'),
     context: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .describe(
         "A JSON object containing the key-value pairs from the component's action.event.context, after resolving all data bindings.",
       ),
@@ -116,7 +116,7 @@ export const A2uiClientDataModelSchema = z
   .object({
     version: z.literal('v0.9'),
     surfaces: z
-      .record(z.object({}).passthrough())
+      .record(z.string(), z.object({}).passthrough())
       .describe('A map of surface IDs to their current data models.'),
   })
   .strict();

--- a/packages/web/src/vendor/a2ui/web_core/schema/common-types.ts
+++ b/packages/web/src/vendor/a2ui/web_core/schema/common-types.ts
@@ -29,7 +29,9 @@ export const DataBindingSchema = z
 export const FunctionCallSchema = z
   .object({
     call: z.string().describe('The name of the function to call.'),
-    args: z.record(z.any()).describe('Arguments passed to the function.'),
+    args: z
+      .record(z.string(), z.any())
+      .describe('Arguments passed to the function.'),
     returnType: z
       .enum(['string', 'number', 'boolean', 'array', 'object', 'any', 'void'])
       .default('boolean'),
@@ -127,7 +129,7 @@ export const ActionSchema = z
       .object({
         event: z.object({
           name: z.string(),
-          context: z.record(DynamicValueSchema).optional(),
+          context: z.record(z.string(), DynamicValueSchema).optional(),
         }),
       })
       .describe('Triggers a server-side event.'),


### PR DESCRIPTION
Closes #740

## Summary
Updates the vendored A2UI `web_core` library to be compatible with Zod v4 (4.3.6), which broke internal type introspection APIs and the `z.record` single-arg signature. Also fixes 2 connector call signature mismatches.

## Changes

**Vendor (A2UI `web_core`):**
- `rendering/generic-binder.ts` — replace `_def.typeName` string checks with `instanceof z.Zod*` class checks; use `.unwrap()`, `.options`, `.shape`, `.element` accessors instead of `_def.innerType` / `_def.options` / `_def.shape()` / `_def.type`
- `rendering/data-context.ts` — cast `unknown` values to `DynamicValue` when iterating `Record`-typed `call.args` / `action.event.context` entries (3 sites)
- `processing/message-processor.ts` — cast Zod v4 schemas to `any` when passed to `zodToJsonSchema@3.x` (which still expects the legacy `zod/v3 ZodSchema` type)
- `catalog/types.ts` — cast `schema.parse()` result to `Record<string, any>` for `FunctionImplementation.execute` signature
- `schema/common-types.ts` + `schema/client-to-server.ts` — upgrade `z.record(V)` single-arg calls to the new v4 `z.record(keyType, valueType)` 2-arg signature

**Connectors:**
- `catalog/components/AzureAction.tsx` — `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`
- `catalog/components/GitHubAction.tsx` — same fix

## Testing
- `npx tsc --noEmit` — **all 31 errors listed in #740 are resolved.** Remaining 24 errors are pre-existing syntax errors in `src/App.tsx` and `src/hooks/useStreaming.ts` (corrupted `onComplete` callback signatures from the v2 Step 5 merge). Those are out of scope for this issue; a separate fix (`59299b7 fix: restore onComplete callback signatures lost in v2 merge`) already exists on `release/1.0.0` and should be carried into `v2-rewrite` in a separate PR.
- `npx vitest run` — 234/235 tests pass, 1 skipped. 8 test files fail to transform due to the pre-existing `App.tsx` / `useStreaming.ts` syntax errors above, not due to changes in this PR. No regressions in vendor or catalog tests.
- `npx vite build` — blocked by the same pre-existing `App.tsx` syntax error; not caused by this PR.

## Docs and changeset
- [x] Changeset: N/A (internal vendored code fix, no public API surface change)
- [x] docs-site/docs/ — N/A
- [x] docs/v2-implementation-brief.md — N/A
- [x] docs/api-reference.md — N/A
- [x] Pack docs — N/A
- [x] Tests — no new tests needed; existing vendor unit tests cover the introspection path

🤖 Working as Fry (Frontend Dev)