### PR TITLE
fix(pack-core): resolve tsconfig moduleResolution incompatibility

### DIFF
--- a/packages/pack-core/tsconfig.json
+++ b/packages/pack-core/tsconfig.json
@@ -4,7 +4,13 @@
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react-jsx",
-    "moduleResolution": "bundler"
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "zod": ["../../node_modules/zod/index.d.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]


### PR DESCRIPTION
Closes #746

## Summary
`packages/pack-core/` failed to build with TS5095/TS5109: its tsconfig overrode `moduleResolution: "bundler"` while inheriting `module: "Node16"` from the root — an invalid combination.

## Root cause
- Root `tsconfig.json` sets `module: Node16` + `moduleResolution: Node16`.
- `packages/harness/tsconfig.json` also uses `Node16/Node16` (standalone, does not extend root).
- `packages/pack-azure`, `packages/pack-aks-automatic`, `packages/pack-github` extend root and do **not** override module/moduleResolution — they inherit `Node16/Node16`. ✅ already consistent.
- `packages/pack-core` overrode only `moduleResolution: bundler` — the broken pack. It needs `bundler` resolution because its vendored a2ui source uses extensionless relative imports.

## Fix
- `packages/pack-core/tsconfig.json`: override `module: "preserve"` so it pairs with `moduleResolution: "bundler"` validly, and add the same `paths` / `baseUrl` / `ignoreDeprecations` zod workaround the other packs already use so harness's zod v4 types align with pack-core's resolved zod.
- No changes to the other four tsconfigs — they were already consistent with harness.

## Testing
- `npm run build -w @kickstart/harness` ✅
- `npm run build -w @kickstart/pack-azure` ✅
- `npm run build -w @kickstart/pack-aks-automatic` ✅
- `npm run build -w @kickstart/pack-github` ✅
- `npm run build -w @kickstart/pack-core`: TS5095/TS5109 gone. Remaining errors are **pre-existing, unrelated bugs** in pack-core source (monaco worker module declarations, FileEditor prop types, a2ui zod v3→v4 API calls, one `verbatimModuleSyntax` type-only import in vendored a2ui). These were previously masked because tsc errored out at config-load time; they need separate follow-up issues to address the pack-core source.
- `npx vitest run` on pack/harness scope: 416 pass; 2 pre-existing harness registry test failures unrelated to tsconfig.

## Docs and changeset
- [ ] Changeset — internal build-config fix, no runtime/API surface change, marking as internal-only
- [x] N/A — docs-site
- [x] N/A — implementation brief / api-reference / pack docs
- [x] Tests — existing tests exercise these packages; no new ones needed for a tsconfig fix
