### PR TITLE
fix(web): restore onComplete callback signatures in App.tsx (#747)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -487,6 +487,12 @@ export function App() {
     if (mockEnabled) {
       mockStreaming.send(text, sessionId, {
         onChunk: () => {},
+        onA2UI: handleIncomingA2UI,
+        onSetupEvent: handleIncomingSetupEvent,
+        onPhase: (phase) => setConversationPhase(phase),
+        onComplete: (fullText, model) => {
+          if (finalizeStepwiseAssistantTurn({
+            assistantMessageId,
             sessionId: sessionId!,
             model,
           })) {
@@ -549,6 +555,10 @@ export function App() {
       
       streaming.send(text, backendSessionId, {
         onChunk: () => {},
+        onA2UI: handleIncomingA2UI,
+        onSetupEvent: handleIncomingSetupEvent,
+        onPhase: (phase) => setConversationPhase(phase),
+        onComplete: (fullText, model, receivedSessionId, debugInfo, usage) => {
           const phase = currentPhaseRef.current || undefined;
           // Store the backend session ID on first response
           if (receivedSessionId && !activeSession?.backendSessionId) {

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -228,7 +228,7 @@ export function useStreaming() {
                 const delta = (parsed.delta as string) ?? '';
                 accumulated += delta;
                 updateRevealTarget(accumulated);
-                callbacks.onChunk(accumulated); {
+                callbacks.onChunk(accumulated);
                 if (isRawA2uiItem(parsed)) {
                   if (debugMode) debugA2uiMessages.push(parsed as A2uiPayloadItem);
                   callbacks.onA2UI([parsed as A2uiPayloadItem]);


### PR DESCRIPTION
Closes #747

Working as Fry (Frontend Dev).

## Summary
`packages/web/src/App.tsx` was failing `vite build` with `Expected a semicolon or an implicit semicolon after a statement` at line 492. The v2 Step 5 merge dropped the `onA2UI`, `onSetupEvent`, `onPhase`, and `onComplete` callback signatures from both `mockStreaming.send` and `streaming.send` call sites, leaving orphaned callback bodies dangling inside the options object. Restored, adapted from commit `59299b7` on `release/1.0.0`.

## Changes
- `packages/web/src/App.tsx`: restored callback signatures for both streaming branches.
  - Mock branch: `onComplete: (fullText, model) => { … }`
  - Real branch: `onComplete: (fullText, model, receivedSessionId, debugInfo, usage) => { … }`
- `packages/web/src/hooks/useStreaming.ts`: removed a stray `{` after `callbacks.onChunk(accumulated)` inside the `chunk` case that opened an unclosed block and broke the `case 'tool_start'` label. Same class of v2 merge corruption.

## Scope notes
- Mock mode was already neutralised in Step 1: `useMockStreaming.ts` and `services/mock-streaming.ts` do not exist on `v2-rewrite`; `mockEnabled = false` and `playgroundEnabled = false` are hard-coded, and `mockStreaming` is stubbed as a no-op. This PR only restores the callback shapes so the module parses and typechecks. The mock branch stays dead code until Step 5 cleanup formally deletes it.
- No change to imports — no `useMockStreaming`, `isMockMode`, or `isPlaygroundMode` imports exist on this branch to remove.

## Testing
- `npx vite build` (packages/web): ✅ builds cleanly
- `npx tsc --noEmit` (packages/web): no App.tsx errors. Remaining errors are pre-existing missing type exports from `../types` on v2-rewrite (`ChatMessage`, `A2uiPayloadItem`, `DebugMetadata`, `SetupGenerationEvent`, `TokenUsageSummary`, etc.) — out of scope for this fix.
- `npx vitest run` (packages/web): 224 pass / 15 fail. All failures are pre-existing Fluent UI `useContext` issues in `CostEstimate` and related catalog tests, unrelated to streaming callbacks.

## Docs and changeset
- [ ] Changeset added (or marked internal-only with reason) — internal-only: build-unblock during v2 rewrite, no user-visible behaviour change
- [ ] docs-site/docs/ updated (or N/A) — N/A
- [ ] docs/v2-implementation-brief.md updated (or N/A) — N/A
- [ ] docs/api-reference.md updated (or N/A) — N/A
- [ ] Pack docs updated (or N/A) — N/A
- [ ] Tests added or covered — covered by existing vite build / tsc smoke

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>