### PR TITLE
fix(pack-core): resolve 70 A2UI component TypeScript errors (#750)

### DIFF
--- a/packages/pack-core/src/components/rich/ArchitectureDiagram.tsx
+++ b/packages/pack-core/src/components/rich/ArchitectureDiagram.tsx
@@ -14,12 +14,14 @@ import {
   tokens,
 } from '@fluentui/react-components';
 import {
-  DiagramEdge,
-  DiagramNode,
   FLUENT_DIAGRAM_PALETTE,
   loadMermaid,
   nodesToMermaid,
   renderArchitectureDiagramSvg,
+} from './architectureDiagramUtils';
+import type {
+  DiagramEdge,
+  DiagramNode,
 } from './architectureDiagramUtils';
 import {
   ARCHITECTURE_DIAGRAM_EMPTY_STATE_ICON_URL,

--- a/packages/pack-core/src/components/rich/FileEditor.tsx
+++ b/packages/pack-core/src/components/rich/FileEditor.tsx
@@ -241,7 +241,7 @@ export const FileEditor = createReactComponent(FileEditorApi, ({ props }) => {
     const artifactPath = str(activeFile.artifactPath);
     if (artifactPath) {
       const artifact = getArtifact(artifactPath);
-      return artifact ? artifact.content : null;
+      return artifact ? String(artifact.content ?? '') : null;
     }
     return str(activeFile.content) ?? null;
   }, [activeFile, getArtifact]);

--- a/packages/pack-core/src/components/rich/asset-modules.d.ts
+++ b/packages/pack-core/src/components/rich/asset-modules.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Ambient type declarations for build-time asset imports used by the rich
+ * components. Vite resolves these at bundle time; TypeScript just needs a
+ * module shape so the imports don't error.
+ */
+
+// highlight.js bundled CSS themes — imported for side effects
+declare module 'highlight.js/styles/*.css';
+
+// Monaco worker ?worker imports — Vite rewrites these to Worker constructors.
+// Typed as a Worker constructor so `new editorWorker()` type-checks.
+declare module 'monaco-editor/esm/vs/editor/editor.worker?worker' {
+  const WorkerCtor: new () => Worker;
+  export default WorkerCtor;
+}
+declare module 'monaco-editor/esm/vs/language/json/json.worker?worker' {
+  const WorkerCtor: new () => Worker;
+  export default WorkerCtor;
+}
+declare module 'monaco-editor/esm/vs/language/css/css.worker?worker' {
+  const WorkerCtor: new () => Worker;
+  export default WorkerCtor;
+}
+declare module 'monaco-editor/esm/vs/language/html/html.worker?worker' {
+  const WorkerCtor: new () => Worker;
+  export default WorkerCtor;
+}
+declare module 'monaco-editor/esm/vs/language/typescript/ts.worker?worker' {
+  const WorkerCtor: new () => Worker;
+  export default WorkerCtor;
+}

--- a/packages/pack-core/src/vendor/a2ui/schema/common-types.ts
+++ b/packages/pack-core/src/vendor/a2ui/schema/common-types.ts
@@ -29,7 +29,7 @@ export const DataBindingSchema = z
 export const FunctionCallSchema = z
   .object({
     call: z.string().describe('The name of the function to call.'),
-    args: z.record(z.any()).describe('Arguments passed to the function.'),
+    args: z.record(z.string(), z.any()).describe('Arguments passed to the function.'),
     returnType: z
       .enum(['string', 'number', 'boolean', 'array', 'object', 'any', 'void'])
       .default('boolean'),
@@ -127,7 +127,7 @@ export const ActionSchema = z
       .object({
         event: z.object({
           name: z.string(),
-          context: z.record(DynamicValueSchema).optional(),
+          context: z.record(z.string(), DynamicValueSchema).optional(),
         }),
       })
       .describe('Triggers a server-side event.'),

--- a/packages/pack-core/src/vendor/a2ui/web_core/basic_catalog/components/basic_components.ts
+++ b/packages/pack-core/src/vendor/a2ui/web_core/basic_catalog/components/basic_components.ts
@@ -26,7 +26,7 @@ import {
   AccessibilityAttributesSchema,
   CheckableSchema,
 } from '../../../schema/common-types';
-import {ComponentApi} from '../../catalog/types';
+import type {ComponentApi} from '../../catalog/types';
 
 const CommonProps = {
   accessibility: AccessibilityAttributesSchema.optional(),

--- a/packages/pack-core/src/vendor/a2ui/web_core/catalog/types.ts
+++ b/packages/pack-core/src/vendor/a2ui/web_core/catalog/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { Action, ChildList, DataBinding, FunctionCall } from '../../schema/common-types';
 
 export interface ComponentApi<Schema extends z.ZodTypeAny = z.ZodTypeAny> {
   name: string;
@@ -6,4 +7,49 @@ export interface ComponentApi<Schema extends z.ZodTypeAny = z.ZodTypeAny> {
 }
 
 export type InferredComponentApiSchemaType<T extends ComponentApi> = z.infer<T['schema']>;
-export type ResolveA2uiProps<T> = T;
+
+type DynamicTypes = DataBinding | FunctionCall;
+type IsDynamic<T> = DataBinding extends NonNullable<T> ? true : false;
+
+/**
+ * Maps a raw Zod-inferred prop type to its resolved runtime equivalent.
+ *
+ * The generic binder in `@kickstart/web` resolves dynamic values (paths,
+ * function calls) before handing props to React components, so at runtime:
+ *   - `Action` objects become callable `() => void` functions
+ *   - `ChildList` becomes the rendered subtree (typed as `any` here)
+ *   - `DynamicString`/`DynamicNumber`/... collapse to their primitive
+ *
+ * Ported from packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts
+ * so pack-core components can consume the same post-binder shape.
+ */
+export type ResolveA2uiProp<T> = [NonNullable<T>] extends [Action]
+  ? (() => void) | Extract<T, undefined>
+  : [NonNullable<T>] extends [ChildList]
+    ? any | Extract<T, undefined>
+    : Exclude<T, DynamicTypes> extends never
+      ? any
+      : Exclude<T, DynamicTypes>;
+
+/**
+ * For every dynamic prop `K`, injects a `setK(value)` setter on the resolved
+ * props object (e.g. `value: DynamicString` → `setValue(val: string)`).
+ */
+export type GenerateSetters<T> = {
+  [K in keyof T as IsDynamic<T[K]> extends true
+    ? `set${Capitalize<string & K>}`
+    : never]-?: (value: Exclude<NonNullable<T[K]>, DynamicTypes>) => void;
+};
+
+/**
+ * Fully-resolved runtime prop shape passed to the view layer. Adds the
+ * binder-injected `isValid` / `validationErrors` fields that checkable
+ * components surface.
+ */
+export type ResolveA2uiProps<T> = (T extends object
+  ? { [K in keyof T]: ResolveA2uiProp<T[K]> }
+  : T) &
+  GenerateSetters<T> & {
+    isValid?: boolean;
+    validationErrors?: string[];
+  };

--- a/packages/pack-core/tsconfig.json
+++ b/packages/pack-core/tsconfig.json
@@ -4,7 +4,13 @@
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react-jsx",
-    "moduleResolution": "bundler"
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "zod": ["../../node_modules/zod/index.d.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]


### PR DESCRIPTION
Closes #750

Working as Fry (Frontend Dev).

## Summary
All 70 TypeScript errors in `packages/pack-core/src/components/` are now clean — components can consume binder-resolved props without per-site casts, Monaco/CSS asset imports type-check, and the vendored A2UI schema works under zod v4 + `verbatimModuleSyntax`.

Built on top of #746 (pack-core tsconfig) so the underlying errors are actually visible.

## Changes
- **catalog/types.ts** — ported the full `ResolveA2uiProps<T>` type from the web pack's `generic-binder.ts`. One type-only change eliminates ~60 errors: `DynamicString`/`DynamicNumber`/... collapse to primitives, `Action` becomes `() => void`, `ChildList` becomes the rendered subtree, and `setValue` / `setChecked` / `validationErrors` / `isValid` are injected on the resolved props object. No binder runtime or Zod schema changes.
- **common-types.ts** — `z.record(...)` updated to the zod v4 two-arg form (TS2554 ×2).
- **basic_components.ts** — `import type { ComponentApi }` for `verbatimModuleSyntax` (TS1484).
- **ArchitectureDiagram.tsx** — type-only imports for `DiagramEdge`/`DiagramNode` (TS1484 ×2).
- **FileEditor.tsx** — coerce `artifact.content` (`unknown` via `@kickstart/harness`'s `Artifact = Record<string, unknown>`) to `string` before passing to Monaco / textarea / hljs (TS2322/TS2345/TS2769 ×5).
- **asset-modules.d.ts** *(new)* — ambient declarations for `highlight.js/styles/*.css` side-effect imports and Monaco `?worker` imports (TS2882 ×3, TS2307 ×5).

## Testing
- `npm run build -w @kickstart/pack-core` → **0 errors** (was 70)
- `npx vitest run packages/pack-core` → **163 passed, 159 todo, 0 failures**
- Full `npm run build` still fails in `@kickstart/api` on pre-existing `@kickstart/harness/runtime/*` esbuild path resolution errors — **unrelated to this PR**, present on `v2-rewrite` before these changes. Flagging for a separate issue.

## Docs and changeset
- [ ] Changeset added — internal-only (type/config fix, no user-visible surface change)
- [x] docs-site/docs/ updated — N/A
- [x] docs/v2-implementation-brief.md updated — N/A
- [x] docs/api-reference.md updated — N/A
- [x] Pack docs updated — N/A
- [x] Tests added or covered — existing pack-core component + guardrail tests pass
