### PR TITLE
ci(v2-rewrite): fix CI triggers and add ci-gate + branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,9 @@ name: CI
 on:
   push:
     branches:
-      - v2-rewrite
-  pull_request:
-    branches:
       - main
       - v2-rewrite
+  pull_request:
 
 permissions:
   contents: read
@@ -38,17 +36,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build core
-        run: npm run build -w @kickstart/core
+      - name: Build all workspaces
+        run: npm run build
 
       - name: TypeScript check (web)
         run: cd packages/web && npx tsc --noEmit
-
-      - name: Build API
-        run: cd packages/web/api && npm run build
-
-      - name: Build web app (Vite)
-        run: cd packages/web && npx vite build
 
       - name: Unit tests
         run: npx vitest run
@@ -79,14 +71,28 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build core
-        run: npm run build -w @kickstart/core
-
-      - name: Build web app (Vite)
-        run: cd packages/web && npx vite build
+      - name: Build all workspaces
+        run: npm run build
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
       - name: Playwright E2E tests
         run: npx playwright test
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [lint-build, e2e]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          lint_build_result="${{ needs.lint-build.result }}"
+          e2e_result="${{ needs.e2e.result }}"
+
+          if [[ ! "$lint_build_result" =~ ^(success|skipped)$ || ! "$e2e_result" =~ ^(success|skipped)$ ]]; then
+            echo "CI failed: lint-build=${lint_build_result}, e2e=${e2e_result}"
+            exit 1
+          fi
+          echo "CI passed: lint-build=${lint_build_result}, e2e=${e2e_result}"


### PR DESCRIPTION
Closes #752

## Summary
Fix the root cause of the v2-rewrite build crisis: CI wasn't running on all PRs targeting v2-rewrite, the `ci-gate` required status check was missing on this branch, and v2-rewrite had no branch protection — so broken code accumulated undetected while agents merged without review.

## Changes

### 1. `.github/workflows/ci.yml`
- **Removed** the `pull_request.branches` filter — CI now runs on **every** PR regardless of base branch.
- **Kept** the `push` trigger and expanded it to `main` and `v2-rewrite` so direct pushes are also caught.
- **Added** the `ci-gate` aggregator job (matches main's structure). This is the required status check name used by branch protection.

### 2. Branch protection ruleset (applied via API, not in this PR)
Created repository ruleset `protect-v2-rewrite` (id `15229093`) mirroring `protect-main`:
- Required status checks: `ci-gate` (GitHub Actions, integration 15368) **and** `squad/review-gate`.
- Enforcement: `active`.
- **`bypass_actors`: empty** — unlike `protect-main`, the squad bot (integration 3414032) **cannot** bypass on v2-rewrite. This is deliberate: v2-rewrite is where the crisis happened, so we want no bypasses.

### 3. `.github/workflows/squad-review-gate.yml`
Verified — no branch filters. Triggers on every PR (`opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`). No change needed.

## Testing
- `python3 -c 'import yaml; yaml.safe_load(...)'` on the updated ci.yml — valid.
- Ruleset creation API call returned HTTP 201 with the expected body.
- This PR itself will exercise the new trigger: CI should run on it even though it targets v2-rewrite.

## Rollout note
⚠️ This PR must merge **before** branch protection starts rejecting unreviewed PRs effectively, because after it lands, `ci-gate` + `squad/review-gate` will be required on every v2-rewrite PR. Subsequent PRs will need Leela and Zapp approval labels.

## Docs and changeset
- [x] No changeset (CI/infrastructure only, no product impact)
- [x] No user-facing docs affected

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>