### PR TITLE
fix(pack-core): clear 6 lint errors

### DIFF
--- a/packages/pack-core/src/guardrails/no_pii_in_logs.ts
+++ b/packages/pack-core/src/guardrails/no_pii_in_logs.ts
@@ -6,7 +6,7 @@ import type { GuardrailContribution, GuardrailInput, GuardrailResult } from '@ki
  */
 const PII_PATTERNS: Array<{ name: string; pattern: RegExp; replacement: string }> = [
   // Email addresses
-  { name: 'email', pattern: /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, replacement: '[REDACTED-EMAIL]' },
+  { name: 'email', pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, replacement: '[REDACTED-EMAIL]' },
   // Social Security Number: 123-45-6789
   { name: 'SSN', pattern: /\b\d{3}-\d{2}-\d{4}\b/g, replacement: '[REDACTED-SSN]' },
   // US phone numbers: (123) 456-7890, 123-456-7890, +1-123-456-7890

--- a/packages/pack-core/src/tools/emit_ui.ts
+++ b/packages/pack-core/src/tools/emit_ui.ts
@@ -39,7 +39,7 @@ export const emitUiTool: ToolContribution = {
         parsed = A2UIMessageSchema.parse(input.message) as A2UIMessageV09;
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`emit_ui: invalid A2UI message — ${msg}`);
+        throw new Error(`emit_ui: invalid A2UI message — ${msg}`, { cause: err });
       }
 
       if (session) {

--- a/packages/pack-core/src/tools/read_file.ts
+++ b/packages/pack-core/src/tools/read_file.ts
@@ -60,7 +60,7 @@ export const readFileTool: ToolContribution = {
         content = readFileSync(fullPath, { encoding: 'utf-8' });
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`read_file: cannot read "${input.path}": ${msg}`);
+        throw new Error(`read_file: cannot read "${input.path}": ${msg}`, { cause: err });
       }
 
       return content;

--- a/packages/pack-core/src/tools/write_file.ts
+++ b/packages/pack-core/src/tools/write_file.ts
@@ -26,7 +26,7 @@ function resolveConfinedPath(workspaceRoot: string, relativePath: string): strin
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
       const parent = dirname(checkDir);
-      if (parent === checkDir) throw new Error(`write_file: path escapes workspace root: ${relativePath}`);
+      if (parent === checkDir) throw new Error(`write_file: path escapes workspace root: ${relativePath}`, { cause: err });
       checkDir = parent;
     }
   }
@@ -80,7 +80,7 @@ export const writeFileTool: ToolContribution = {
         writeFileSync(fullPath, input.content, { encoding: 'utf-8' });
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`write_file: cannot write "${input.path}": ${msg}`);
+        throw new Error(`write_file: cannot write "${input.path}": ${msg}`, { cause: err });
       }
 
       return `Written: ${input.path} (${input.content.length} bytes)`;


### PR DESCRIPTION
Closes #754

## Summary
`npm run lint` now exits 0 for pack-core (was 6 errors).

## Changes
- `guardrails/no_pii_in_logs.ts`: remove useless `\-` escapes inside email regex character classes (×2).
- `tools/emit_ui.ts`, `tools/read_file.ts`, `tools/write_file.ts`: pass `{ cause: err }` when rethrowing caught errors to satisfy `preserve-caught-error` (×4).

## Testing
- `npm run lint` → 0 errors (38 pre-existing warnings unchanged).
- `npm run build` → green.
- `npx vitest run` → same baseline as v2-rewrite (unrelated failures in web/chat-ui, streaming-fallback, CostEstimate, and harness/mcp-server tracked in #755 and #759).

## Docs and changeset
- [x] No user-visible change (internal lint hygiene); no changeset needed.
- [x] N/A docs-site
- [x] N/A api-reference
- [x] N/A pack docs
- [x] No new tests (lint-only refactor)