### PR TITLE
test(web): fix CostEstimate test Fluent context wiring

### DIFF
--- a/packages/web/src/catalog/components/CostEstimate.test.ts
+++ b/packages/web/src/catalog/components/CostEstimate.test.ts
@@ -3,8 +3,47 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import type { ComponentContext } from '../../vendor/a2ui/web_core/index';
 import { ConversationSessionProvider } from '../../contexts/ConversationSessionContext';
-import { CostEstimateView } from './CostEstimate';
 import type { CostEstimateInput } from '../../utils/cost-estimate';
+
+// Fluent v9 components pull in a chain of internal context hooks
+// (useTextDirection, useFluent, useCardBase_unstable, etc.) that resolve
+// `react` via commonjs and trip the "Cannot read properties of null"
+// dispatcher error when rendered from node with renderToStaticMarkup.
+// For this markup-only contract test we stub out just the surface used by
+// CostEstimate with pass-through <div>s and a no-op makeStyles.
+vi.mock('@fluentui/react-components', async () => {
+  const actual = await vi.importActual<typeof import('@fluentui/react-components')>(
+    '@fluentui/react-components',
+  );
+  const passthrough = (tag: string) =>
+    ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+      React.createElement(tag, rest as Record<string, unknown>, children);
+  return {
+    ...actual,
+    makeStyles: (styles: Record<string, unknown>) => () =>
+      Object.fromEntries(Object.keys(styles).map((k) => [k, k])) as Record<string, string>,
+    tokens: new Proxy({}, { get: () => '' }) as unknown as typeof actual.tokens,
+    Badge: passthrough('span'),
+    Body2: passthrough('p'),
+    Button: passthrough('button'),
+    Caption1: passthrough('span'),
+    Card: passthrough('section'),
+    Label: passthrough('label'),
+    MessageBar: passthrough('div'),
+    MessageBarBody: passthrough('div'),
+    Select: passthrough('select'),
+    Slider: passthrough('input'),
+    Spinner: passthrough('span'),
+    Subtitle1: passthrough('h3'),
+  };
+});
+
+vi.mock('@fluentui/react-icons', () => ({
+  MoneyRegular: () => React.createElement('span', { 'data-icon': 'money' }),
+}));
+
+// Import after mocks so CostEstimate.tsx binds to the stubs.
+const { CostEstimateView } = await import('./CostEstimate');
 
 const componentContext = {
   dispatchAction: vi.fn(),


### PR DESCRIPTION
Closes #760

## Summary
The 5 cases in `CostEstimate.test.ts` were failing with `TypeError: Cannot read properties of null (reading 'useContext')` coming out of Fluent's `useTextDirection` / `useFluent` chain inside `makeStyles` and `useCardBase_unstable`. Wrapping the SUT in `FluentProvider` does not fix it under vitest's node-env SSR (the Fluent packages resolve react via commonjs and the dispatcher isn't wired for those copies).

## Changes
- Stub `@fluentui/react-components` with passthrough HTML elements (`Card` → `<section>`, `Subtitle1` → `<h3>`, etc.), a no-op `makeStyles`, and a `tokens` Proxy.
- Stub the `MoneyRegular` icon from `@fluentui/react-icons`.
- Import `CostEstimateView` after the mocks so it binds to the stubs.

All 5 assertions are on surrounding text/markup (loading copy, citations, "Estimated fallback", usage disclaimers, legacy `items`/`total` fallback) so the passthrough stubs keep coverage intact.

## Testing
- `npx vitest run packages/web/src/catalog/components/CostEstimate.test.ts` → 5/5 pass
- `npm run build` → green

## Docs and changeset
- [ ] N/A — test-only change

Working as Fry (Frontend).