### PR TITLE
fix(harness): align Phase enum with brief canonical (drop Assess, add Handoff)

### DIFF
--- a/packages/harness/src/__tests__/chat-a2ui.test.ts
+++ b/packages/harness/src/__tests__/chat-a2ui.test.ts
@@ -7,32 +7,32 @@ import {
 } from '../a2ui/chat-a2ui.js';
 
 describe('chat-a2ui phase normalization', () => {
-  it('accepts the current harness assess phase', () => {
-    expect(normalizeConversationPhase('assess')).toBe('assess');
+  it('accepts the canonical handoff phase', () => {
+    expect(normalizeConversationPhase('handoff')).toBe('handoff');
   });
 
-  it('maps legacy handoff to assess', () => {
-    expect(normalizeConversationPhase('handoff')).toBe('assess');
+  it('maps legacy assess to handoff', () => {
+    expect(normalizeConversationPhase('assess')).toBe('handoff');
   });
 
-  it('uses the current harness phase order', () => {
+  it('uses the canonical brief phase order', () => {
     expect(CONVERSATION_PHASE_ORDER).toEqual([
       'discover',
-      'assess',
       'design',
       'generate',
       'review',
+      'handoff',
       'deploy',
     ]);
   });
 
-  it('extracts assess from ConversationPhase components', () => {
+  it('extracts handoff from ConversationPhase components', () => {
     expect(extractConversationPhase([
       {
         component: 'ConversationPhase',
-        currentPhase: 'assess',
+        currentPhase: 'handoff',
       },
-    ])).toBe('assess');
+    ])).toBe('handoff');
   });
 
   it('rejects legacy-only phases', () => {

--- a/packages/harness/src/__tests__/harness-exports.test.ts
+++ b/packages/harness/src/__tests__/harness-exports.test.ts
@@ -3,8 +3,8 @@
  *
  * Verifies that the @kickstart/harness stub:
  *   1. exports compile and the module loads without throwing
- *   2. Phase enum matches the current harness order with Assess
- *   3. PHASE_DEFINITIONS flows correctly (Discover → Assess → … → Deploy)
+ *   2. Phase enum matches the canonical brief order (Discover → … → Deploy)
+ *   3. PHASE_DEFINITIONS flows correctly per the brief
  *   4. SETUP_GENERATION_STEP_ORDER is a non-empty, well-typed constant
  *   5. DEPLOYMENT_SAFEGUARDS contains the mandatory DS011–DS013 rules
  *   6. Runtime function stubs return the expected stub shapes
@@ -59,17 +59,17 @@ describe('harness module', () => {
 // ── 2. Phase enum ────────────────────────────────────────────────────────────
 
 describe('Phase enum', () => {
-  it('contains exactly the current harness phases', () => {
+  it('contains exactly the canonical brief phases', () => {
     const phases = Object.values(Phase);
-    expect(phases).toEqual(['discover', 'assess', 'design', 'generate', 'review', 'deploy']);
+    expect(phases).toEqual(['discover', 'design', 'generate', 'review', 'handoff', 'deploy']);
   });
 
-  it('does not contain the legacy "handoff" phase', () => {
-    expect(Object.values(Phase)).not.toContain('handoff');
+  it('does not contain the legacy "assess" phase', () => {
+    expect(Object.values(Phase)).not.toContain('assess');
   });
 
-  it('contains the Assess phase', () => {
-    expect(Phase.Assess).toBe('assess');
+  it('contains the Handoff phase', () => {
+    expect(Phase.Handoff).toBe('handoff');
   });
 });
 
@@ -81,21 +81,25 @@ describe('PHASE_DEFINITIONS', () => {
     expect(PHASE_DEFINITIONS).toHaveLength(phaseCount);
   });
 
-  it('Discover advances to Assess', () => {
+  it('Discover advances to Design', () => {
     const result = advancePhase(Phase.Discover);
-    expect(result).toBe(Phase.Assess);
-  });
-
-  it('Assess advances to Design', () => {
-    expect(advancePhase(Phase.Assess)).toBe(Phase.Design);
+    expect(result).toBe(Phase.Design);
   });
 
   it('Design advances to Generate', () => {
     expect(advancePhase(Phase.Design)).toBe(Phase.Generate);
   });
 
-  it('Review advances to Deploy', () => {
-    expect(advancePhase(Phase.Review)).toBe(Phase.Deploy);
+  it('Generate advances to Review', () => {
+    expect(advancePhase(Phase.Generate)).toBe(Phase.Review);
+  });
+
+  it('Review advances to Handoff', () => {
+    expect(advancePhase(Phase.Review)).toBe(Phase.Handoff);
+  });
+
+  it('Handoff advances to Deploy', () => {
+    expect(advancePhase(Phase.Handoff)).toBe(Phase.Deploy);
   });
 
   it('Deploy does not advance (terminal phase)', () => {
@@ -179,8 +183,8 @@ describe('runtime function stubs', () => {
 
   it('isPhase correctly identifies valid phases', () => {
     expect(isPhase('discover')).toBe(true);
-    expect(isPhase('assess')).toBe(true);
-    expect(isPhase('handoff')).toBe(false);
+    expect(isPhase('handoff')).toBe(true);
+    expect(isPhase('assess')).toBe(false);
     expect(isPhase('not-a-phase')).toBe(false);
   });
 

--- a/packages/harness/src/a2ui/chat-a2ui.ts
+++ b/packages/harness/src/a2ui/chat-a2ui.ts
@@ -21,14 +21,14 @@ const SURFACE_SCOPE_SEPARATOR = '::';
 
 const PHASE_ALIASES = {
   discover: 'discover',
-  assess: 'assess',
   plan: 'design',
   design: 'design',
   build: 'generate',
   generate: 'generate',
   review: 'review',
   validate: 'review',
-  handoff: 'assess',
+  handoff: 'handoff',
+  assess: 'handoff',
   deploy: 'deploy',
 } as const;
 
@@ -59,23 +59,23 @@ const FILE_NAME_LANGUAGES: Record<string, string> = {
   '.env.template': 'dotenv',
 };
 
-export type ConversationPhaseId = 'discover' | 'assess' | 'design' | 'generate' | 'review' | 'deploy';
+export type ConversationPhaseId = 'discover' | 'design' | 'generate' | 'review' | 'handoff' | 'deploy';
 
 export const CONVERSATION_PHASE_ORDER = [
   'discover',
-  'assess',
   'design',
   'generate',
   'review',
+  'handoff',
   'deploy',
 ] as const satisfies readonly ConversationPhaseId[];
 
 export const CONVERSATION_PHASE_LABELS: Record<ConversationPhaseId, string> = {
   discover: 'Discover',
-  assess: 'Assess',
   design: 'Design',
   generate: 'Generate',
   review: 'Review',
+  handoff: 'Handoff',
   deploy: 'Deploy',
 };
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -2,13 +2,14 @@
 // This file temporarily satisfies legacy @kickstart/core imports during the v2 migration.
 
 // ── Phase (was an enum in v1) ────────────────────────────────────────────────
-// Order matches the current harness contract: Discover → Assess → Design → Generate → Review → Deploy
+// Canonical order per docs/v2-implementation-brief.md §2:
+// Discover → Design → Generate → Review → Handoff → Deploy
 export const Phase = {
   Discover: 'discover',
-  Assess: 'assess',
   Design: 'design',
   Generate: 'generate',
   Review: 'review',
+  Handoff: 'handoff',
   Deploy: 'deploy',
 } as const;
 export type Phase = (typeof Phase)[keyof typeof Phase];
@@ -221,11 +222,11 @@ export const defaultRegistry: {
 export const PHASE_DEFINITIONS: Array<{
   id: Phase; label: string; description: string; nextPhase?: Phase;
 }> = [
-  { id: Phase.Discover, label: 'Discover', description: 'What are you building?', nextPhase: Phase.Assess },
-  { id: Phase.Assess, label: 'Assess', description: 'Assess requirements and handoff context.', nextPhase: Phase.Design },
+  { id: Phase.Discover, label: 'Discover', description: 'What are you building?', nextPhase: Phase.Design },
   { id: Phase.Design, label: 'Design', description: 'Here is the recommended architecture.', nextPhase: Phase.Generate },
   { id: Phase.Generate, label: 'Generate', description: 'Generating your deployment files.', nextPhase: Phase.Review },
-  { id: Phase.Review, label: 'Review', description: 'Review and validate your artifacts.', nextPhase: Phase.Deploy },
+  { id: Phase.Review, label: 'Review', description: 'Review and validate your artifacts.', nextPhase: Phase.Handoff },
+  { id: Phase.Handoff, label: 'Handoff', description: 'Hand off to the target platform.', nextPhase: Phase.Deploy },
   { id: Phase.Deploy, label: 'Deploy', description: 'Deploy to AKS.' },
 ];
 


### PR DESCRIPTION
Closes #755

## Summary
The MCP action tests (7 failures) expected `advancePhase(Discover) === Design` but the runtime had a legacy `assess` phase in between. The fix aligns `@kickstart/harness` with the canonical phase order from `docs/v2-implementation-brief.md` §2: **Discover → Design → Generate → Review → Handoff → Deploy**.

## Changes
- `packages/harness/src/index.ts` — `Phase` enum + `PHASE_DEFINITIONS` updated to canonical. `Phase.Assess` is removed; `Phase.Handoff` is added between Review and Deploy.
- `packages/harness/src/a2ui/chat-a2ui.ts` — `PHASE_ALIASES`, `ConversationPhaseId`, `CONVERSATION_PHASE_ORDER`, `CONVERSATION_PHASE_LABELS` updated. Legacy `'assess'` inputs still accepted and normalized to `'handoff'` (reverse of the old handoff→assess mapping).
- `packages/harness/src/__tests__/harness-exports.test.ts` — asserts canonical enum, advancement flow, `isPhase` validity.
- `packages/harness/src/__tests__/chat-a2ui.test.ts` — asserts `handoff` is canonical and `assess` normalizes to `handoff`.

## Testing
- `npx vitest run packages/mcp-server/src/__tests__/action.test.ts packages/mcp-server/src/__tests__/action-endpoint.test.ts` → **33 passed / 0 failed** (was 7 failing).
- `npx vitest run packages/harness/src/__tests__/harness-exports.test.ts packages/harness/src/__tests__/chat-a2ui.test.ts` → all green.
- `npm run build` → green.
- Full `npx vitest run` → 17 unrelated pre-existing failures remain (web/chat-ui, streaming-406-fallback, CostEstimate, harness/registry — the registry ones are tracked in #759).

## Docs and changeset
- [ ] Changeset: not required (internal-only seam alignment, no user-visible API change).
- [ ] docs-site / api-reference: N/A
- [ ] v2-implementation-brief: already documents this order; code is catching up.
- [x] Tests updated to cover canonical order

⚠️ Legacy persisted sessions storing `currentPhase: 'assess'` will normalize to `'handoff'` on next read via the chat-a2ui alias map. Net-new sessions will never see `'assess'`.