### PR TITLE
fix(web): chat-ui regression test wiring

### DIFF
--- a/packages/web/src/__tests__/chat-ui.test.ts
+++ b/packages/web/src/__tests__/chat-ui.test.ts
@@ -1,9 +1,51 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
-import { ChatMessage as ChatMessageView } from '../components/Chat/ChatMessage';
-import { ChatShell } from '../components/Chat/ChatShell';
-import { DebugPanel } from '../components/Chat/DebugPanel';
+
+// Fluent v9 components + icons go through internal context hooks that resolve
+// `react` via commonjs and trip the "Cannot read properties of null" /
+// "Invalid hook call" SSR errors under vitest's node env. Mock the surfaces
+// used by the chat regression tests with passthrough HTML stubs; the
+// assertions only care about surrounding markup and data-testids.
+vi.mock('@fluentui/react-components', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@fluentui/react-components');
+  const passthrough = (tag: string) =>
+    ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+      React.createElement(tag, rest as Record<string, unknown>, children);
+  const stubs: Record<string, unknown> = { ...actual };
+  // Override components/hooks that exercise Fluent context internals.
+  // Fluent components are React.forwardRef (object) or functions — stub both
+  // when the export name starts with a capital letter.
+  for (const key of Object.keys(actual)) {
+    const val = actual[key];
+    if (/^[A-Z]/.test(key) && (typeof val === 'function' || typeof val === 'object')) {
+      stubs[key] = passthrough('div');
+    }
+  }
+  stubs.makeStyles = (styles: Record<string, unknown>) => () =>
+    Object.fromEntries(Object.keys(styles).map((k) => [k, k])) as Record<string, string>;
+  stubs.tokens = new Proxy({}, { get: () => '' });
+  return stubs;
+});
+
+vi.mock('@fluentui/react-icons', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@fluentui/react-icons');
+  const iconStub = () => React.createElement('span', { 'data-icon': true });
+  const stubs: Record<string, unknown> = {};
+  for (const key of Object.keys(actual)) {
+    const val = actual[key];
+    if (/^[A-Z]/.test(key) && (typeof val === 'function' || typeof val === 'object')) {
+      stubs[key] = iconStub;
+    } else {
+      stubs[key] = val;
+    }
+  }
+  return stubs;
+});
+
+const { ChatMessage: ChatMessageView } = await import('../components/Chat/ChatMessage');
+const { ChatShell } = await import('../components/Chat/ChatShell');
+const { DebugPanel } = await import('../components/Chat/DebugPanel');
 import type { ChatMessage, TokenUsageSummary } from '../types';
 import { GENERATION_PROGRESS_TITLE, getLatestConversationPhase, rebuildChatSessionState } from '../utils/chat-a2ui';
 import { summarizeTokenUsage } from '../utils/chat-usage';

--- a/packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts
+++ b/packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts
@@ -66,15 +66,24 @@ function getFieldBehavior(
 ): BehaviorNode {
   let current: z.ZodTypeAny = type;
 
-  // Unwrap optionals/nullables/defaults
+  // Unwrap optionals/nullables/defaults. In Zod v4, some wrapped schemas don't
+  // expose `.unwrap()` as a direct method, so fall back to the internal
+  // `_def.innerType` / `def.innerType` pointer to stay robust across Zod
+  // minor releases.
   while (
     current instanceof z.ZodOptional ||
     current instanceof z.ZodNullable ||
     current instanceof z.ZodDefault
   ) {
-    current = (
-      current as z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny> | z.ZodDefault<z.ZodTypeAny>
-    ).unwrap() as z.ZodTypeAny;
+    const wrapper = current as z.ZodOptional<z.ZodTypeAny> | z.ZodNullable<z.ZodTypeAny> | z.ZodDefault<z.ZodTypeAny>;
+    const next =
+      typeof (wrapper as unknown as { unwrap?: () => z.ZodTypeAny }).unwrap === 'function'
+        ? (wrapper as unknown as { unwrap: () => z.ZodTypeAny }).unwrap()
+        : ((wrapper as unknown as { _def?: { innerType?: z.ZodTypeAny }; def?: { innerType?: z.ZodTypeAny } })._def
+            ?.innerType
+            ?? (wrapper as unknown as { def?: { innerType?: z.ZodTypeAny } }).def?.innerType);
+    if (!next) break;
+    current = next as z.ZodTypeAny;
   }
 
   if (propertyName === 'checks') {


### PR DESCRIPTION
Closes #761

## Summary
The whole `chat-ui.test.ts` file (8 cases, 6 failing) wouldn't run under vitest's node env. Two intertwined root causes:

1. **Fluent v9 context chain** — `ChatShell`, `ChatMessage`, `DebugPanel` and the A2UI surface pull in Fluent components and icons whose internal hooks (`useTextDirection`, `useButtonContext`, `useCardBase_unstable`, `createFluentIcon`) resolve `react` through commonjs and throw `Cannot read properties of null (reading 'useContext')` during `renderToStaticMarkup`. Fluent v9 components are `React.forwardRef` objects (not functions), so a simple `typeof === 'function'` filter missed them.
2. **Zod v4 shape change** — `packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts` unconditionally called `.unwrap()` on any `ZodOptional` / `ZodNullable` / `ZodDefault`, but some wrapped schemas in Zod v4 no longer expose `.unwrap()` as an own method — the surface missing-component test hit `current.unwrap is not a function`.

## Changes
- `packages/web/src/__tests__/chat-ui.test.ts`: mock `@fluentui/react-components` (passthrough HTML stubs for every capital-letter export, whether the underlying value is a function or an object; no-op `makeStyles`; zero-value `tokens` proxy) and `@fluentui/react-icons` (passthrough `<span data-icon>`). Components are re-imported after the mocks via top-level `await import`.
- `packages/web/src/vendor/a2ui/web_core/rendering/generic-binder.ts`: fall back to `_def.innerType` / `def.innerType` when `.unwrap()` isn't a function, keeping behavior stable across Zod 4.x minor versions.

## Testing
- `npx vitest run packages/web/src/__tests__/chat-ui.test.ts` → 8/8 pass
- `npm run build` → green
- Full `npx vitest run` → no new failures (the remaining failures — action.test.ts, registry.test.ts, plus the ones covered by #758 and #760 on their own branches — are pre-existing on v2-rewrite)

## Docs and changeset
- [ ] N/A — test + vendor-adapter safety fix

Working as Fry (Frontend).