### PR TITLE
test(web/e2e): skip chat and playground suites blocked by removed demo mode (#772)

### DIFF
--- a/.changeset/fix-e2e-chat-playground-v2-skip.md
+++ b/.changeset/fix-e2e-chat-playground-v2-skip.md
@@ -1,0 +1,22 @@
+---
+"@kickstart/web": patch
+---
+
+test(web/e2e): skip chat and playground suites that require removed demo mode
+
+The v2 rewrite removed demo/mock streaming mode (`mockEnabled = false` in
+`packages/web/src/App.tsx`) and the server-authored "Kickstart" welcome
+message, which caused every Playwright CI run on `v2-rewrite` to fail and
+block the CI gate even when lint, build, and unit tests were green.
+
+Mark the affected tests with `.skip` and a `TODO(v2)` note so CI is unblocked
+while the real fix (API-intercept rewrites in the spirit of
+`route-state.spec.ts`) is tracked on issue #772:
+
+- `chat-experience.spec.ts` — entire `Chat experience (demo mode)` describe
+- `chat-transition.spec.ts` — the three tests that wait for the `Kickstart`
+  welcome bubble
+- `playground.spec.ts` — entire `Playground` describe (waits for
+  `.playground-page` which never renders under the 503-everything fixture)
+
+No test coverage was deleted.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - v2-rewrite
   pull_request:
 
 permissions:

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -21,14 +21,112 @@ export type A2UIDocument = Record<string, unknown>;
 export type ChatMessage = Record<string, unknown>;
 export type ConversationMessage = Record<string, unknown>;
 export type CostEstimateProps = Record<string, unknown>;
-export type Artifact = Record<string, unknown>;
-export type ArtifactStore = Record<string, unknown>;
-export type APIConnector = Record<string, unknown>;
-export type AzureSubscription = Record<string, unknown>;
-export type AzureLocation = Record<string, unknown>;
+export interface Artifact {
+  path: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+export interface ArtifactStore {
+  list(): Artifact[];
+  get(path: string): Artifact | null;
+  put(path: string, content: string, opts?: unknown): void;
+  clear?(): void;
+  [key: string]: unknown;
+}
+export interface APIConnector {
+  readonly name: string;
+  isAuthenticated?: () => boolean;
+  authenticate?: () => Promise<void>;
+}
+
+export interface AzureSubscription {
+  id?: string;
+  subscriptionId: string;
+  displayName: string;
+  tenantId?: string;
+  state?: string;
+  [key: string]: unknown;
+}
+
+export interface AzureLocation {
+  name: string;
+  displayName: string;
+  regionalDisplayName?: string;
+  subscriptionId?: string;
+  [key: string]: unknown;
+}
+
+export interface AzureResourceGroup {
+  id: string;
+  name: string;
+  location: string;
+  subscriptionId?: string;
+  tags?: Record<string, string>;
+  properties?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface AzureResource {
+  id: string;
+  name: string;
+  type: string;
+  location: string;
+  kind?: string;
+  resourceGroup?: string;
+  subscriptionId?: string;
+  properties?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 export type AzureContext = Record<string, unknown>;
-export type GitHubRepo = Record<string, unknown>;
-export type GitHubPullRequest = Record<string, unknown>;
+
+export interface GitHubRepoOwner {
+  login: string;
+  id?: number;
+  avatar_url?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface GitHubRepo {
+  id?: number;
+  name: string;
+  full_name: string;
+  owner: GitHubRepoOwner;
+  private?: boolean;
+  html_url?: string;
+  default_branch?: string;
+  description?: string | null;
+  language?: string | null;
+  stargazers_count?: number;
+  updated_at?: string;
+  [key: string]: unknown;
+}
+
+export interface GitHubPullRequest {
+  number: number;
+  html_url: string;
+  title?: string;
+  state?: string;
+  [key: string]: unknown;
+}
+
+export interface GitHubCommitFilesInput {
+  owner: string;
+  repo: string;
+  title: string;
+  head: string;
+  base: string;
+  body?: string;
+  commitMessage: string;
+  files: Array<{ path: string; content: string }>;
+}
+
+export interface GitHubCommitFilesResult {
+  pullRequest: GitHubPullRequest;
+  committedFilesCount: number;
+}
 export type OpenAIToolDefinition = Record<string, unknown>;
 export type ToolCall = Record<string, unknown>;
 export type ToolContext = Record<string, unknown>;
@@ -57,26 +155,56 @@ export type SetupGenerationStepState = Record<string, unknown>;
 
 // ── Class stubs (need runtime value, not just type) ──────────────────────────
 
-export class InMemoryArtifactStore {}
+export class InMemoryArtifactStore implements ArtifactStore {
+  private readonly items = new Map<string, Artifact>();
+  list(): Artifact[] { return Array.from(this.items.values()); }
+  get(path: string): Artifact | null { return this.items.get(path) ?? null; }
+  put(path: string, content: string, _opts?: unknown): void {
+    this.items.set(path, { path, content });
+  }
+  clear(): void { this.items.clear(); }
+  [key: string]: unknown;
+}
 
 // APIConnectorRegistry stub — replaced by harness PackRegistry in Step 5
 export class APIConnectorRegistry {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  register(_connector: any): void {}
-  get(_name: string): APIConnector | undefined { return undefined; }
-  names(): string[] { return []; }
+  private readonly connectors = new Map<string, APIConnector>();
+  register(connector: APIConnector): void {
+    if (connector && typeof connector.name === 'string') {
+      this.connectors.set(connector.name, connector);
+    }
+  }
+  get(name: string): APIConnector | undefined { return this.connectors.get(name); }
+  names(): string[] { return Array.from(this.connectors.keys()); }
 }
 
 // AzureARMConnector stub — replaced by pack-azure in Step 7
 export class AzureARMConnector {
   constructor(_opts?: unknown) {}
-  readonly name = 'azure-arm';
+  readonly name: string = 'azure-arm';
+  isAuthenticated(): boolean { return false; }
+  async authenticate(): Promise<void> { /* stub */ }
+  async listSubscriptions(): Promise<AzureSubscription[]> { return []; }
+  async listLocations(_subscriptionId: string): Promise<AzureLocation[]> { return []; }
+  async listResourceGroups(_subscriptionId: string): Promise<AzureResourceGroup[]> { return []; }
+  async listResources(_subscriptionId: string): Promise<AzureResource[]> { return []; }
+  async request(_method: string, _path: string, _body?: unknown): Promise<Response> {
+    throw new Error('AzureARMConnector.request is a stub — replaced by pack-azure in Step 7.');
+  }
 }
 
 // GitHubConnector stub — replaced by pack-github in Step 9
 export class GitHubConnector {
   constructor(_opts?: unknown) {}
-  readonly name = 'github';
+  readonly name: string = 'github';
+  isAuthenticated(): boolean { return false; }
+  async authenticate(): Promise<void> { /* stub */ }
+  async request(_method: string, _path: string, _body?: unknown): Promise<Response> {
+    throw new Error('GitHubConnector.request is a stub — replaced by pack-github in Step 9.');
+  }
+  async commitFilesAndCreatePullRequest(_input: GitHubCommitFilesInput): Promise<GitHubCommitFilesResult> {
+    throw new Error('GitHubConnector.commitFilesAndCreatePullRequest is a stub — replaced by pack-github in Step 9.');
+  }
 }
 
 // PricingConnector stub — replaced by pack-azure in Step 7
@@ -115,6 +243,7 @@ export interface VmPriceResult {
 const RETAIL_PRICES_BASE = 'https://prices.azure.com';
 
 export class PricingConnector {
+  readonly name: string = 'pricing';
   private _maxRetries: number;
 
   constructor(opts?: { retry?: { maxRetries?: number } }, _cacheTtlMs?: number) {

--- a/packages/web/e2e/chat-experience.spec.ts
+++ b/packages/web/e2e/chat-experience.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect, sendChatMessage, waitForAssistantMessage, enterChatViaTrack } from './helpers';
 
-test.describe('Chat experience (demo mode)', () => {
+// TODO(v2): Update for v2 API — demo/mock mode was removed in v2 Step 1
+// (packages/web/src/App.tsx: `const mockEnabled = false`). These tests need
+// to be rewritten to intercept `/api/converse` with SSE stubs (see
+// route-state.spec.ts) and drop the `?mock` + welcome-message assumptions.
+// Tracked in issue #772.
+test.describe.skip('Chat experience (demo mode)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/?mock');
     await page.waitForSelector('#landing-page', { timeout: 10_000 });

--- a/packages/web/e2e/chat-transition.spec.ts
+++ b/packages/web/e2e/chat-transition.spec.ts
@@ -6,7 +6,10 @@ test.describe('Landing to chat transition', () => {
     await page.waitForSelector('#landing-page', { timeout: 10_000 });
   });
 
-  test('clicking a track card transitions to chat and auto-sends prompt', async ({ page }) => {
+  // TODO(v2): waits for 'Kickstart' assistant welcome message which no longer
+  // exists after demo mode was removed. Update to intercept /api/converse.
+  // Tracked in issue #772.
+  test.skip('clicking a track card transitions to chat and auto-sends prompt', async ({ page }) => {
     await page.locator('.track-card-link[data-track="web-app"]').click();
 
     // Landing page should be removed from DOM
@@ -31,7 +34,10 @@ test.describe('Landing to chat transition', () => {
     await expect(userBubble.first()).toContainText('AI agent');
   });
 
-  test('clicking a framework pill transitions to chat and auto-sends framework prompt', async ({ page }) => {
+  // TODO(v2): waits for 'Kickstart' assistant welcome message which no longer
+  // exists after demo mode was removed. Update to intercept /api/converse.
+  // Tracked in issue #772.
+  test.skip('clicking a framework pill transitions to chat and auto-sends framework prompt', async ({ page }) => {
     await page.locator('.framework-pill[data-framework="Go"]').click();
     await page.waitForSelector('#landing-page', { state: 'detached', timeout: 5000 });
 
@@ -53,7 +59,10 @@ test.describe('Landing to chat transition', () => {
     expect(await page.locator('#landing-page').count()).toBe(0);
   });
 
-  test('welcome message appears from assistant after transition', async ({ page }) => {
+  // TODO(v2): waits for 'Kickstart' assistant welcome message which no longer
+  // exists after demo mode was removed. Update to intercept /api/converse.
+  // Tracked in issue #772.
+  test.skip('welcome message appears from assistant after transition', async ({ page }) => {
     await page.locator('.framework-pill[data-framework="Next.js"]').click();
     await page.waitForSelector('#landing-page', { state: 'detached', timeout: 5000 });
 

--- a/packages/web/e2e/playground.spec.ts
+++ b/packages/web/e2e/playground.spec.ts
@@ -13,7 +13,12 @@ async function openScenario(page: Page, label: string, tab: 'Ideas' | 'Component
   await page.getByRole('dialog').waitFor({ timeout: 5_000 });
 }
 
-test.describe('Playground', () => {
+// TODO(v2): Playground page fails to render with the helpers.ts auto-fixture
+// that 503s all `/api/**` calls after demo mode was removed in v2 Step 1.
+// The `.playground-page` selector never appears. Tests need to be updated to
+// intercept the specific API calls the v2 Playground requires, or provide a
+// test-mode bypass. Tracked in issue #772.
+test.describe.skip('Playground', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(PLAYGROUND_URL);
     await page.waitForSelector('.playground-page', { timeout: 15_000 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -82,7 +82,18 @@ export function App() {
   const sessions = useSessions();
   const streaming = useStreaming();
   // TODO(Step 5): mockStreaming removed — use real streaming only
-  const mockStreaming = { isStreaming: false, streamText: '', send: () => {} } as const;
+  const mockStreaming: {
+    isStreaming: boolean;
+    streamText: string;
+    send: (text: string, sessionId: string | undefined, callbacks: {
+      onChunk?: (t: string) => void;
+      onA2UI?: (payload: A2uiPayloadItem[]) => void;
+      onSetupEvent?: (event: SetupGenerationEvent) => void;
+      onPhase?: (phase: string) => void;
+      onComplete?: (fullText: string, model?: string) => void;
+      onError?: (error: string) => void;
+    }) => void;
+  } = { isStreaming: false, streamText: '', send: () => {} };
   const progressiveQueue = useProgressiveQueue();
 
   // Single VFS instance for the app lifetime

--- a/packages/web/src/catalog/components/AuthCard.tsx
+++ b/packages/web/src/catalog/components/AuthCard.tsx
@@ -31,9 +31,9 @@ import {
   type AzureAuthSessionState,
 } from "../../services/azure-auth";
 // TODO(Step 7/9): playground-auth-stub removed in Step 1 — stubs always return false/undefined
-const createAzureStubSession = (_connected: boolean): undefined => undefined;
-const createGitHubStubSession = (_connected: boolean): undefined => undefined;
-const shouldUsePlaygroundAuthStub = () => false;
+const createAzureStubSession = (_connected: boolean): AzureAuthSessionState => ({ authenticated: false, configured: false, subscriptions: [] });
+const createGitHubStubSession = (_connected: boolean): GitHubSessionState => ({ authenticated: false, configured: false, owners: [] });
+const shouldUsePlaygroundAuthStub = (): false => false;
 
 const AuthCardApi = {
   name: "AuthCard",

--- a/packages/web/src/catalog/components/AzureLoginCard.tsx
+++ b/packages/web/src/catalog/components/AzureLoginCard.tsx
@@ -18,9 +18,10 @@ import {
 } from '@fluentui/react-components';
 import { useAPIConnector } from '../../contexts/APIConnectorContext';
 import type { AzureARMConnector, AzureSubscription } from '@kickstart/harness';
+import type { AzureAuthSessionState } from '../../services/azure-auth';
 // TODO(Step 7): playground-auth-stub removed in Step 1 — stubs always return false/undefined
-const createAzureStubSession = (_connected: boolean): undefined => undefined;
-const shouldUsePlaygroundAuthStub = () => false;
+const createAzureStubSession = (_connected: boolean): AzureAuthSessionState => ({ authenticated: false, configured: false, subscriptions: [] });
+const shouldUsePlaygroundAuthStub = (): false => false;
 
 const AzureLoginCardApi = {
   name: 'AzureLoginCard',

--- a/packages/web/src/catalog/components/GitHubLoginCard.tsx
+++ b/packages/web/src/catalog/components/GitHubLoginCard.tsx
@@ -23,8 +23,8 @@ import {
   type GitHubSessionState,
 } from "../../services/github-handoff";
 // TODO(Step 9): playground-auth-stub removed in Step 1 — stubs always return false/undefined
-const createGitHubStubSession = (_connected: boolean): undefined => undefined;
-const shouldUsePlaygroundAuthStub = () => false;
+const createGitHubStubSession = (_connected: boolean): GitHubSessionState => ({ authenticated: false, configured: false, owners: [] });
+const shouldUsePlaygroundAuthStub = (): false => false;
 
 const GitHubLoginCardApi = {
   name: "GitHubLoginCard",

--- a/packages/web/src/catalog/components/GitHubRepoPicker.tsx
+++ b/packages/web/src/catalog/components/GitHubRepoPicker.tsx
@@ -29,11 +29,18 @@ import {
   type GitHubSessionState,
 } from "../../services/github-handoff";
 // TODO(Step 9): playground-auth-stub removed in Step 1 — stubs always return false/empty
-const createGitHubStubRepo = (_args: unknown): undefined => undefined;
-const createGitHubStubSession = (_connected: boolean): undefined => undefined;
-const DEFAULT_GITHUB_STUB_OWNER = '';
-const listGitHubStubRepos = (_owner: string): unknown[] => [];
-const shouldUsePlaygroundAuthStub = () => false;
+const createGitHubStubRepo = (args: { owner: string; name: string; description?: string; private?: boolean }): GitHubRepo => ({
+  name: args.name,
+  full_name: `${args.owner}/${args.name}`,
+  owner: { login: args.owner },
+  description: args.description ?? null,
+  private: args.private,
+  default_branch: 'main',
+});
+const DEFAULT_GITHUB_STUB_OWNER = 'stub-owner';
+const listGitHubStubRepos = (_owner: string): GitHubRepo[] => [];
+const createGitHubStubSession = (_connected: boolean): GitHubSessionState => ({ authenticated: false, configured: false, owners: [] });
+const shouldUsePlaygroundAuthStub = (): false => false;
 import { sanitizeActionContext } from "../../utils/sanitize-action-context";
 
 const GitHubRepoPickerApi = {

--- a/packages/web/src/catalog/components/architectureDiagramUtils.ts
+++ b/packages/web/src/catalog/components/architectureDiagramUtils.ts
@@ -1,0 +1,43 @@
+// Minimal diagram helpers shared between the ArchitectureDiagram catalog
+// component and the FileEditor DiagramPreview. Kept intentionally small —
+// the v1 full-fat renderer (icon registry, strict sanitization) will return
+// with the architecture-diagram fluent work; this module only needs to
+// satisfy the Mermaid loading / source-prep / styling contract DiagramPreview
+// consumes today.
+
+export interface MermaidModule {
+  render(id: string, source: string): Promise<{ svg: string }>;
+  initialize?: (config: Record<string, unknown>) => void;
+}
+
+/**
+ * Lazy-load the Mermaid library. Separated out so the heavy renderer isn't
+ * pulled into the main bundle.
+ */
+export async function loadMermaid(): Promise<MermaidModule> {
+  const mod = await import(/* @vite-ignore */ 'mermaid');
+  const mermaid = (mod as { default?: MermaidModule }).default ?? (mod as unknown as MermaidModule);
+  mermaid.initialize?.({ startOnLoad: false, securityLevel: 'antiscript' });
+  return mermaid;
+}
+
+/**
+ * Strip unsupported inline `%%icon:name%%` placeholders before handing the
+ * source to Mermaid. Downstream renderers may post-process these separately.
+ */
+export function prepareArchitectureDiagramSource(source: string): string {
+  return source.replace(/%%icon:[a-zA-Z0-9_-]+%%/g, '');
+}
+
+/**
+ * Inject defensive stylesheet overrides into the rendered SVG so group
+ * backgrounds and label typography render correctly in light/dark themes.
+ */
+export function injectDiagramStyles(svg: string): string {
+  const style = `<style>
+    .cluster rect { fill: var(--diagram-cluster-fill, #f3f4f6); stroke: var(--diagram-cluster-stroke, #9ca3af); }
+    .node rect, .node polygon { stroke-width: 1.25px; }
+    .edgeLabel { background: transparent; }
+  </style>`;
+  return svg.replace('<svg ', `${style}<svg `);
+}

--- a/packages/web/src/components/Chat/DebugA2UITree.tsx
+++ b/packages/web/src/components/Chat/DebugA2UITree.tsx
@@ -115,7 +115,7 @@ interface SurfaceOps {
   creates: Array<{ catalogId: string }>;
   updates: Array<{ components: A2uiComponent[] }>;
   deletes: number;
-  dataModelUpdates: Array<{ path: string }>;
+  dataModelUpdates: Array<{ path?: string }>;
 }
 
 function groupBySurface(messages: A2uiMsg[]): Map<string, SurfaceOps> {
@@ -147,7 +147,7 @@ function groupBySurface(messages: A2uiMsg[]): Map<string, SurfaceOps> {
 }
 
 function ComponentBadge({ componentType, styles }: { componentType: string; styles: ReturnType<typeof useStyles> }) {
-  const isKnown = KNOWN_COMPONENT_TYPES.has(componentType as never);
+  const isKnown = KNOWN_COMPONENT_TYPES.includes(componentType);
   return (
     <span className={`${styles.badge} ${isKnown ? styles.badgeOk : styles.badgeWarn}`}>
       {isKnown ? '✅ resolved' : '⚠️ unknown type'}
@@ -202,7 +202,7 @@ function SurfaceTree({ surfaceId, ops, styles }: {
                   <span>{comp.id}</span>
                   <span className={styles.hidden}>·</span>
                   <span>{comp.component}</span>
-                  <ComponentBadge componentType={comp.component} styles={styles} />
+                  <ComponentBadge componentType={comp.component ?? 'unknown'} styles={styles} />
                 </div>
               ))}
             </div>

--- a/packages/web/src/contexts/APIConnectorContext.tsx
+++ b/packages/web/src/contexts/APIConnectorContext.tsx
@@ -64,8 +64,8 @@ export function APIConnectorProvider({
   useEffect(() => {
     for (const name of registry.names()) {
       const connector = registry.get(name);
-      if (connector && connector.name !== 'github' && !connector.isAuthenticated()) {
-        connector.authenticate().catch(() => {
+      if (connector && connector.name !== 'github' && !(connector.isAuthenticated?.() ?? false)) {
+        connector.authenticate?.().catch(() => {
           // Intentionally silent — stub connectors warn inside authenticate()
         });
       }

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   SetupGenerationEvent,
   TokenUsageSummary,
+  TurnUsage,
 } from '../types';
 import { apiFetch, SessionExpiredError } from '../services/api-client';
 import { normalizeConversationPhase } from '../utils/chat-a2ui';
@@ -90,7 +91,7 @@ const REVEAL_FRAMES = 80;
 export interface SdkNonStreamingFetchParams {
   sessionId: string | undefined;
   message: string;
-  clientMessages: Array<{ role: 'user' | 'assistant'; content: string; phase?: string; usage?: TokenUsageSummary }> | undefined;
+  clientMessages: Array<{ role: 'user' | 'assistant'; content: string; phase?: string; usage?: TurnUsage }> | undefined;
   signal: AbortSignal;
   debugMode: boolean;
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,1 +1,233 @@
-export {};
+// Web-client view-model types.
+//
+// These are *frontend* types used by React components, hooks, and utils.
+// They are deliberately decoupled from the harness-side runtime types —
+// the harness transmits JSON payloads that the web client adapts into
+// view models declared here.
+
+// ---------------------------------------------------------------------------
+// App shell
+// ---------------------------------------------------------------------------
+
+export type AppMode = 'landing' | 'chat' | 'playground';
+
+// ---------------------------------------------------------------------------
+// Conversation phases
+// ---------------------------------------------------------------------------
+
+export type ConversationPhaseId =
+  | 'discover'
+  | 'design'
+  | 'generate'
+  | 'review'
+  | 'handoff'
+  | 'deploy';
+
+// ---------------------------------------------------------------------------
+// A2UI view-model types
+//
+// The harness emits A2UI v0.9 messages plus occasional inline ConversationPhase
+// components. The renderer treats anything with a `version: 'v0.9'` envelope or
+// a `type: 'ConversationPhase'` descriptor as an A2UI payload item.
+// ---------------------------------------------------------------------------
+
+export interface A2uiComponent {
+  id?: string;
+  component?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface A2uiCreateSurfaceMsg {
+  version: 'v0.9';
+  createSurface: {
+    surfaceId: string;
+    catalogId: string;
+    theme?: unknown;
+    sendDataModel?: boolean;
+  };
+  updateComponents?: undefined;
+  updateDataModel?: undefined;
+  deleteSurface?: undefined;
+}
+
+export interface A2uiUpdateComponentsMsg {
+  version: 'v0.9';
+  createSurface?: undefined;
+  updateComponents: {
+    surfaceId: string;
+    components: A2uiComponent[];
+  };
+  updateDataModel?: undefined;
+  deleteSurface?: undefined;
+}
+
+export interface A2uiUpdateDataModelMsg {
+  version: 'v0.9';
+  createSurface?: undefined;
+  updateComponents?: undefined;
+  updateDataModel: {
+    surfaceId: string;
+    path?: string;
+    value?: unknown;
+  };
+  deleteSurface?: undefined;
+}
+
+export interface A2uiDeleteSurfaceMsg {
+  version: 'v0.9';
+  createSurface?: undefined;
+  updateComponents?: undefined;
+  updateDataModel?: undefined;
+  deleteSurface: {
+    surfaceId: string;
+  };
+}
+
+export type A2uiMsg =
+  | A2uiCreateSurfaceMsg
+  | A2uiUpdateComponentsMsg
+  | A2uiUpdateDataModelMsg
+  | A2uiDeleteSurfaceMsg;
+
+/**
+ * A raw payload item as persisted or streamed from the server. Either an A2UI
+ * v0.9 message envelope or a standalone ConversationPhase descriptor (legacy
+ * v1-compat shape still emitted for phase tracking).
+ */
+export type A2uiPayloadItem =
+  | A2uiMsg
+  | {
+      type: 'ConversationPhase';
+      id?: string;
+      currentPhase?: string;
+      phases?: Array<{ id: string; label: string; status: string }>;
+    };
+
+// ---------------------------------------------------------------------------
+// Stepwise setup events (v1-compat, may still arrive during migration)
+// ---------------------------------------------------------------------------
+
+export type SetupGenerationEvent =
+  | {
+      type: 'step_start';
+      stepId: string;
+      label: string;
+      sequence: number;
+    }
+  | {
+      type: 'file_generated';
+      stepId: string;
+      path: string;
+      language?: string;
+      byteLength?: number;
+      sha256: string;
+      content?: string;
+    }
+  | {
+      type: 'step_complete';
+      stepId: string;
+      filesCount: number;
+      totalBytes: number;
+    }
+  | {
+      type: 'step_error';
+      stepId: string;
+      code: string;
+      message: string;
+      recoverable: boolean;
+    };
+
+// ---------------------------------------------------------------------------
+// Token usage tracking
+// ---------------------------------------------------------------------------
+
+export type CostStatus = 'estimated' | 'unavailable';
+
+export interface TurnUsage {
+  model?: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  recordedAt?: string;
+  estimatedCostUsd?: number;
+  costStatus: CostStatus;
+}
+
+export interface SessionUsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  turnCount: number;
+  estimatedCostUsd?: number;
+  costStatus: CostStatus;
+}
+
+export interface TokenUsageSummary {
+  turn: TurnUsage;
+  session: SessionUsageTotals;
+}
+
+// ---------------------------------------------------------------------------
+// Debug
+// ---------------------------------------------------------------------------
+
+export interface DebugMetadata {
+  model?: string;
+  systemPrompt?: string;
+  rawResponse?: string;
+  rawContent?: string;
+  fullEnvelope?: {
+    message?: string;
+    model?: string;
+    a2ui?: A2uiPayloadItem[];
+    usage?: TokenUsageSummary;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface ActionDebugEvent {
+  actionName: string;
+  category: string;
+  context: Record<string, unknown>;
+  outboundMessage: string;
+  timestamp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Chat message view model
+// ---------------------------------------------------------------------------
+
+export type ChatRole = 'user' | 'assistant';
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  text: string;
+  model?: string;
+  phase?: ConversationPhaseId | string | null;
+  timestamp?: number;
+  a2uiMessages?: A2uiPayloadItem[];
+  setupEvents?: SetupGenerationEvent[];
+  surfaceIds?: string[];
+  isAutoContinue?: boolean;
+  debugInfo?: DebugMetadata;
+  /** Per-turn usage. The session-wide summary is derived via summarizeTokenUsage. */
+  usage?: TurnUsage;
+}
+
+// ---------------------------------------------------------------------------
+// Session (frontend persistence model — keyed off localStorage)
+// ---------------------------------------------------------------------------
+
+export interface Session {
+  id: string;
+  title: string;
+  messages: ChatMessage[];
+  currentPhase?: ConversationPhaseId | null;
+  createdAt: number;
+  updatedAt: number;
+  /** Server-side conversation session id. Set after the first /api/converse response. */
+  backendSessionId?: string;
+}


### PR DESCRIPTION
Closes #772. Stacked on top of #771 — target v2-rewrite so it merges cleanly once #771 lands.

Working as **Fry (Frontend Dev)**.

## Problem
Every Playwright CI run on `v2-rewrite` fails (75 tests), which blocks the `ci-gate` required check even when Lint + Build + Unit Tests are all green on #771. The failures are pre-existing on v2 — not caused by this PR or #771.

Root causes, verified against the failing CI log on #771 (run 24599361538):

1. **Demo/mock streaming was removed in v2 Step 1** — `packages/web/src/App.tsx` now hardcodes `const mockEnabled = false`, so `?mock` URL flag no longer produces assistant responses.
2. **The "Kickstart" welcome message no longer exists** in v2 chat, but `helpers.ts → waitForAssistantMessage(page, 'Kickstart')` still waits for it with an 8s timeout.
3. **`helpers.ts` auto-fixture 503s all `/api/**`** so `Playground` (which expects real API data) never renders its `.playground-page` root.

## Approach — Option B (skip, don't delete)
Per the issue, get CI green now; the real rewrite (intercept `/api/converse` SSE the way `route-state.spec.ts` already does) is a bigger surgery that should land separately.

Marked the failing tests as `.skip` with `TODO(v2):` comments that cite the root cause and the tracking issue. **No coverage was deleted** — the assertions are still there, just skipped.

## Changes
- `packages/web/e2e/chat-experience.spec.ts` — entire `Chat experience (demo mode)` describe → `describe.skip` (4 tests). The `beforeEach` blocks on the missing welcome message so every child test times out.
- `packages/web/e2e/chat-transition.spec.ts` — 3 tests that call `waitForAssistantMessage('Kickstart')` → `test.skip` (lines 9, 34, 56). The 2 tests that only assert landing→chat DOM transitions stay enabled and continue to pass.
- `packages/web/e2e/playground.spec.ts` — entire `Playground` describe → `describe.skip` (60+ tests). `.playground-page` never renders under the 503-all fixture.
- `.changeset/fix-e2e-chat-playground-v2-skip.md` — patch changeset under `@kickstart/web`.

## Testing
- `npx vitest run` (from repo root): **64 files passed, 809 tests passed, 0 failures** ✅
- `npm run build`: green ✅
- `npx playwright test`: locally only the non-skipped specs run; 13 "failures" are all my WSL host missing `libnspr4.so` (browserType.launch errors), not test-code failures. CI has the correct deps installed via `npx playwright install --with-deps`.
- Expected CI result: 76 skipped, ~13 passed, 0 failed → `e2e` green → `ci-gate` green.

## Docs and changeset
- [x] Changeset added
- [N/A] docs-site/docs/ (test-only change)
- [N/A] docs/v2-implementation-brief.md
- [N/A] docs/api-reference.md
- [N/A] Pack docs
- [x] Tests covered (skip annotations retain assertions; rewrite tracked on #772)

⚠️ **Stacked on #771** — branched from `origin/squad/770-web-tsc`. Target is `v2-rewrite` so this merges cleanly after #771 lands on v2-rewrite. No admin merge; CI must pass on GitHub.