### PR TITLE
feat(packs): server-manifests for azure/aks/github + register all packs

### DIFF
--- a/.changeset/pack-server-manifests.md
+++ b/.changeset/pack-server-manifests.md
@@ -1,0 +1,11 @@
+---
+"@kickstart/pack-azure": patch
+"@kickstart/pack-aks-automatic": patch
+"@kickstart/pack-github": patch
+"@kickstart/api": patch
+---
+
+Add server-safe pack manifests for `pack-azure`, `pack-aks-automatic`, and `pack-github`, and register them in the web API startup alongside `pack-core`.
+
+- Each domain pack now exports a `server-manifest.ts` that mirrors `pack-core`'s pattern: tools, user-actions, guardrails, and (for github) playground scenarios/stubs are imported directly, while components are listed with placeholder schemas to keep React out of the Functions bundle.
+- `packages/web/api/src/startup/packs.ts` registers packs in dependency order (`core` → `azure` → `aks` → `github`) and gates the non-core packs via the `KICKSTART_PACKS` env var (comma-separated list; default: all four enabled). `core` is always registered.

--- a/packages/pack-aks-automatic/src/server-manifest.ts
+++ b/packages/pack-aks-automatic/src/server-manifest.ts
@@ -1,0 +1,77 @@
+/**
+ * Server-safe pack manifest for `aksAutomaticPack` — no JSX imports.
+ *
+ * Mirrors `pack-core/src/server-manifest.ts`: tools, user actions, and
+ * guardrails are imported directly because they are plain TypeScript with
+ * no React dependency. Component contributions are listed by name with
+ * placeholder schemas so the server can expose the catalog over
+ * `/api/packs` without pulling Fluent UI or React into the Azure Functions
+ * bundle.
+ *
+ * TODO: Extract component schemas from the `.tsx` files into shared
+ * non-JSX modules so the server can serve accurate JSON schemas.
+ */
+
+import { z } from 'zod';
+import type { Pack, ComponentContribution } from '@kickstart/harness';
+
+// Tools (no JSX)
+import { validateManifestsTool } from './tools/validate-manifests.js';
+import { validateSafeguardsTool } from './tools/validate-safeguards.js';
+
+// User actions (no JSX)
+import { aksDeployUserAction } from './user-actions/deploy.js';
+
+// Guardrails (no JSX)
+import { noPrivilegedContainersGuardrail } from './guardrails/no-privileged-containers.js';
+import { requireResourceLimitsGuardrail } from './guardrails/require-resource-limits.js';
+import { noHostpathVolumesGuardrail } from './guardrails/no-hostpath-volumes.js';
+import { noLatestTagGuardrail } from './guardrails/no-latest-tag.js';
+
+// ---------------------------------------------------------------------------
+// Component contributions (server-safe, no React renderer)
+// ---------------------------------------------------------------------------
+
+const AKS_COMPONENT_NAMES = [
+  'ArchitectureDiagram',
+  'AksClusterCard',
+  'SafeguardViolations',
+  'DeploymentProgress',
+];
+
+const serverComponents: ComponentContribution[] = AKS_COMPONENT_NAMES.map((name) => ({
+  name: `aks/${name}`,
+  propertySchema: z.unknown(),
+  renderer: null,
+}));
+
+// ---------------------------------------------------------------------------
+// Server-safe aksAutomaticPack
+// ---------------------------------------------------------------------------
+
+export const aksAutomaticPackServer: Pack = {
+  name: 'aks',
+  version: '0.1.0',
+  dependsOn: ['core', 'azure'],
+
+  agentsDir: new URL('./agents/', import.meta.url),
+  skillsDir: new URL('./skills/', import.meta.url),
+
+  tools: [
+    validateManifestsTool,
+    validateSafeguardsTool,
+  ],
+
+  userActions: [
+    aksDeployUserAction,
+  ],
+
+  components: serverComponents,
+
+  guardrails: [
+    noPrivilegedContainersGuardrail,
+    requireResourceLimitsGuardrail,
+    noHostpathVolumesGuardrail,
+    noLatestTagGuardrail,
+  ],
+};

--- a/packages/pack-azure/src/server-manifest.ts
+++ b/packages/pack-azure/src/server-manifest.ts
@@ -1,0 +1,101 @@
+/**
+ * Server-safe pack manifest for `azurePack` — no JSX imports.
+ *
+ * Mirrors `pack-core/src/server-manifest.ts`: tools, user actions, and
+ * guardrails are imported directly because they are plain TypeScript with
+ * no React dependency. Component contributions are listed by name with
+ * placeholder schemas so the server can expose the catalog over
+ * `/api/packs` without pulling Fluent UI or React into the Azure Functions
+ * bundle.
+ *
+ * TODO: Extract component schemas from the `.tsx` files into shared
+ * non-JSX modules so the server can serve accurate JSON schemas.
+ */
+
+import { z } from 'zod';
+import type { Pack, ComponentContribution } from '@kickstart/harness';
+
+// Tools (no JSX)
+import { armGetTool } from './tools/arm-get.js';
+import { armDeployResourceTool } from './tools/arm-deploy-resource.js';
+import { armDeleteResourceTool } from './tools/arm-delete-resource.js';
+import { armUpdateResourceTool } from './tools/arm-update-resource.js';
+import { pricingLookupTool } from './tools/pricing-lookup.js';
+import { estimateCostTool } from './tools/estimate-cost.js';
+import { validateBicepTool } from './tools/validate-bicep.js';
+import { whatIfTool } from './tools/what-if.js';
+
+// User actions (no JSX)
+import { deployResourceUserAction } from './user-actions/deploy-resource.js';
+import { deleteResourceUserAction } from './user-actions/delete-resource.js';
+import { updateResourceUserAction } from './user-actions/update-resource.js';
+import { deployUserAction } from './user-actions/deploy.js';
+import { selectSubscriptionUserAction } from './user-actions/select-subscription.js';
+
+// Guardrails (no JSX)
+import { noPrivilegedOperationsGuardrail } from './guardrails/no-privileged-operations.js';
+import { requireSubscriptionScopeGuardrail } from './guardrails/require-subscription-scope.js';
+import { noHardcodedCredentialsGuardrail } from './guardrails/no-hardcoded-credentials.js';
+import { noSubscriptionScopedOwnerGuardrail } from './guardrails/no-subscription-scoped-owner.js';
+
+// ---------------------------------------------------------------------------
+// Component contributions (server-safe, no React renderer)
+// ---------------------------------------------------------------------------
+
+const AZURE_COMPONENT_NAMES = [
+  'AzureResourceCard',
+  'CostEstimate',
+  'DeploymentStatus',
+  'SubscriptionSelector',
+  'ResourceGroupSelector',
+  'BicepEditor',
+  'AzureAction',
+  'LocationSelector',
+];
+
+const serverComponents: ComponentContribution[] = AZURE_COMPONENT_NAMES.map((name) => ({
+  name: `azure/${name}`,
+  propertySchema: z.unknown(),
+  renderer: null,
+}));
+
+// ---------------------------------------------------------------------------
+// Server-safe azurePack
+// ---------------------------------------------------------------------------
+
+export const azurePackServer: Pack = {
+  name: 'azure',
+  version: '0.1.0',
+  dependsOn: ['core'],
+
+  agentsDir: new URL('./agents/', import.meta.url),
+  skillsDir: new URL('./skills/', import.meta.url),
+
+  tools: [
+    armGetTool,
+    armDeployResourceTool,
+    armDeleteResourceTool,
+    armUpdateResourceTool,
+    pricingLookupTool,
+    estimateCostTool,
+    validateBicepTool,
+    whatIfTool,
+  ],
+
+  userActions: [
+    deployResourceUserAction,
+    deleteResourceUserAction,
+    updateResourceUserAction,
+    deployUserAction,
+    selectSubscriptionUserAction,
+  ],
+
+  components: serverComponents,
+
+  guardrails: [
+    noPrivilegedOperationsGuardrail,
+    requireSubscriptionScopeGuardrail,
+    noHardcodedCredentialsGuardrail,
+    noSubscriptionScopedOwnerGuardrail,
+  ],
+};

--- a/packages/pack-github/src/server-manifest.ts
+++ b/packages/pack-github/src/server-manifest.ts
@@ -1,0 +1,112 @@
+/**
+ * Server-safe pack manifest for `githubPack` — no JSX imports.
+ *
+ * Mirrors `pack-core/src/server-manifest.ts`: tools, user actions,
+ * guardrails, and playground scenarios are imported directly because they
+ * are plain TypeScript with no React dependency. Component contributions
+ * are listed by name with placeholder schemas so the server can expose
+ * the catalog over `/api/packs` without pulling Fluent UI or React into
+ * the Azure Functions bundle.
+ *
+ * TODO: Extract component schemas from the `.tsx` files into shared
+ * non-JSX modules so the server can serve accurate JSON schemas.
+ */
+
+import { z } from 'zod';
+import type { Pack, ComponentContribution } from '@kickstart/harness';
+
+// Tools (no JSX)
+import { apiGetTool } from './tools/api-get.js';
+
+// User actions (no JSX)
+import { loginUserAction } from './user-actions/login.js';
+import { pickOrgUserAction } from './user-actions/pick-org.js';
+import { pickRepoUserAction } from './user-actions/pick-repo.js';
+import { createRepoUserAction } from './user-actions/create-repo.js';
+import { createPRUserAction } from './user-actions/create-pr.js';
+import { setSecretUserAction } from './user-actions/set-secret.js';
+
+// Guardrails (no JSX)
+import { noSecretExposureGuardrail } from './guardrails/no-secret-exposure.js';
+
+// Playground scenarios (no JSX)
+import { repoPickerScenario } from './playground/repo-picker.scenario.js';
+import { createPRScenario } from './playground/create-pr.scenario.js';
+
+// ---------------------------------------------------------------------------
+// Component contributions (server-safe, no React renderer)
+// ---------------------------------------------------------------------------
+
+const GITHUB_COMPONENT_NAMES = [
+  'Login',
+  'OrgPicker',
+  'RepoPicker',
+  'RepoInfo',
+  'Action',
+  'CreatePRFlow',
+  'SecretSetter',
+];
+
+const serverComponents: ComponentContribution[] = GITHUB_COMPONENT_NAMES.map((name) => ({
+  name: `github/${name}`,
+  propertySchema: z.unknown(),
+  renderer: null,
+}));
+
+// ---------------------------------------------------------------------------
+// Server-safe githubPack
+// ---------------------------------------------------------------------------
+
+export const githubPackServer: Pack = {
+  name: 'github',
+  version: '0.1.0',
+  dependsOn: ['core'],
+
+  // pack-github keeps agents/skills at the package root (not under src/),
+  // matching the live manifest in ./index.ts.
+  agentsDir: new URL('../agents/', import.meta.url),
+  skillsDir: new URL('../skills/', import.meta.url),
+
+  tools: [apiGetTool],
+
+  userActions: [
+    loginUserAction,
+    pickOrgUserAction,
+    pickRepoUserAction,
+    createRepoUserAction,
+    createPRUserAction,
+    setSecretUserAction,
+  ],
+
+  components: serverComponents,
+
+  guardrails: [noSecretExposureGuardrail],
+
+  playgroundScenarios: [repoPickerScenario, createPRScenario],
+
+  playgroundStubs: {
+    'github:login': async () => ({
+      authenticated: true,
+      viewer: { login: 'octocat', name: 'The Octocat', avatarUrl: 'https://github.com/octocat.png' },
+    }),
+    'github:pick_org': async () => ({ owner: 'acme-corp', type: 'Organization' }),
+    'github:pick_repo': async () => ({
+      owner: 'acme-corp',
+      name: 'aks-deploy',
+      defaultBranch: 'main',
+      htmlUrl: 'https://github.com/acme-corp/aks-deploy',
+    }),
+    'github:create_repo': async () => ({
+      owner: 'acme-corp',
+      name: 'aks-deploy',
+      private: true,
+      htmlUrl: 'https://github.com/acme-corp/aks-deploy',
+    }),
+    'github:create_pr': async () => ({
+      prNumber: 42,
+      prUrl: 'https://github.com/acme-corp/aks-deploy/pull/42',
+      branch: 'feat/aks-deploy',
+    }),
+    'github:set_secret': async () => ({ secretName: 'AZURE_CLIENT_ID', set: true }),
+  },
+};

--- a/packages/web/api/src/startup/packs.ts
+++ b/packages/web/api/src/startup/packs.ts
@@ -1,17 +1,60 @@
+import type { Pack } from '@kickstart/harness';
 import { PackRegistry } from '@kickstart/harness/runtime/registry';
 import { corePackServer } from '../../../../pack-core/src/server-manifest.js';
+import { azurePackServer } from '../../../../pack-azure/src/server-manifest.js';
+import { aksAutomaticPackServer } from '../../../../pack-aks-automatic/src/server-manifest.js';
+import { githubPackServer } from '../../../../pack-github/src/server-manifest.js';
 
 let _registry: PackRegistry | null = null;
 
 /**
+ * Pack identifiers understood by `KICKSTART_PACKS`. The order here defines
+ * the dependency-safe registration order: `core` → `azure` → `aks` → `github`.
+ */
+const PACK_ORDER = ['core', 'azure', 'aks', 'github'] as const;
+type PackId = (typeof PACK_ORDER)[number];
+
+const PACK_BY_ID: Record<PackId, Pack> = {
+  core: corePackServer,
+  azure: azurePackServer,
+  aks: aksAutomaticPackServer,
+  github: githubPackServer,
+};
+
+function parseEnabledPacks(raw: string | undefined): PackId[] {
+  if (!raw || raw.trim() === '') {
+    return [...PACK_ORDER];
+  }
+  const requested = new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  // `core` is always registered — everything else depends on it.
+  requested.add('core');
+  return PACK_ORDER.filter((id): id is PackId => requested.has(id));
+}
+
+/**
  * Returns the sealed PackRegistry singleton.
- * Registers corePack and seals on first call; subsequent calls return the
- * same sealed instance (safe for Azure Functions warm-start sharing).
+ *
+ * Registers the configured packs in dependency order and seals on first
+ * call; subsequent calls return the same sealed instance (safe for Azure
+ * Functions warm-start sharing).
+ *
+ * The enabled pack set is controlled by `KICKSTART_PACKS` (comma-separated
+ * list of pack ids: `core`, `azure`, `aks`, `github`). When unset or empty,
+ * all four packs are enabled. `core` is always registered regardless of
+ * configuration because every other pack depends on it.
  */
 export function getRegistry(): PackRegistry {
   if (!_registry) {
     _registry = new PackRegistry();
-    _registry.register(corePackServer);
+    const enabled = parseEnabledPacks(process.env.KICKSTART_PACKS);
+    for (const id of enabled) {
+      _registry.register(PACK_BY_ID[id]);
+    }
     _registry.seal();
   }
   return _registry;


### PR DESCRIPTION
Closes #774
Closes #775

## Summary

Brings the three domain packs to parity with `pack-core` by adding server-safe `server-manifest.ts` files, then registers all four packs in the web API startup in dependency order with env-gated enablement.

## Changes

- **`packages/pack-azure/src/server-manifest.ts`** — exports `azurePackServer` (dependsOn `core`): 8 tools, 5 user-actions, 4 guardrails, 8 components (placeholder schemas), agentsDir/skillsDir from `./agents|skills/`.
- **`packages/pack-aks-automatic/src/server-manifest.ts`** — exports `aksAutomaticPackServer` (dependsOn `core`, `azure`): 2 tools, 1 user-action, 4 guardrails, 4 components (placeholder schemas).
- **`packages/pack-github/src/server-manifest.ts`** — exports `githubPackServer` (dependsOn `core`): 1 tool, 6 user-actions, 1 guardrail, 7 components, 2 playground scenarios + stub map. agentsDir/skillsDir come from `../agents|skills/` to match the existing `index.ts` layout (github keeps those at pack root, not under `src/`).
- **`packages/web/api/src/startup/packs.ts`** — imports the three new manifests, registers `core → azure → aks → github` in order, gates by `KICKSTART_PACKS` env var (comma-separated pack ids; default: all four enabled). `core` is always registered regardless of configuration because every other pack depends on it.
- **Changeset** — `.changeset/pack-server-manifests.md` (patch across the three packs + api).

Components are listed with `z.unknown()` placeholder schemas and `renderer: null`, mirroring the approach `pack-core`'s rich components already use. This keeps React/Fluent UI out of the Azure Functions bundle. Extracting real schemas to non-JSX modules is tracked as a TODO in each file (same TODO pack-core carries).

## Testing

- `npm run build` — green (all packages build, Azure Functions bundle OK).
- `npm run lint` — 0 errors (38 pre-existing warnings untouched).
- `npx vitest run` — 64 files / 809 tests passing, 0 failures.
- `cd packages/web && npx tsc --noEmit` — 0 errors.

## Docs and changeset
- [x] Changeset added
- [ ] docs-site/docs/ updated (N/A — server-side wiring only)
- [ ] docs/v2-implementation-brief.md updated (N/A — brief already specifies this shape)
- [ ] docs/api-reference.md updated (N/A)
- [ ] Pack docs updated (N/A)
- [x] Tests: existing pack registration tests still pass; no new behavior to assert beyond startup wiring.