### PR TITLE
feat(packs): add playground scenarios to core, azure, aks-automatic (#779)

### DIFF
--- a/packages/pack-aks-automatic/src/index.ts
+++ b/packages/pack-aks-automatic/src/index.ts
@@ -19,6 +19,10 @@ import { requireResourceLimitsGuardrail } from './guardrails/require-resource-li
 import { noHostpathVolumesGuardrail } from './guardrails/no-hostpath-volumes.js';
 import { noLatestTagGuardrail } from './guardrails/no-latest-tag.js';
 
+// Playground scenarios
+import { aksClusterCardScenario } from './playground/cluster-card.scenario.js';
+import { safeguardViolationsScenario } from './playground/safeguard-violations.scenario.js';
+
 const aksComponents: ComponentContribution[] = [
   architectureDiagramContribution,
   aksClusterCardContribution,
@@ -52,6 +56,8 @@ export const aksAutomaticPack: Pack = {
     noHostpathVolumesGuardrail,
     noLatestTagGuardrail,
   ],
+
+  playgroundScenarios: [aksClusterCardScenario, safeguardViolationsScenario],
 };
 
 // Named exports for individual contributions

--- a/packages/pack-aks-automatic/src/playground/cluster-card.scenario.ts
+++ b/packages/pack-aks-automatic/src/playground/cluster-card.scenario.ts
@@ -1,0 +1,37 @@
+import type { PlaygroundScenario } from '@kickstart/harness';
+import { A2UI_VERSION } from '@kickstart/harness';
+
+/**
+ * Playground scenario: aks.cluster-card
+ * Renders the aks/AksClusterCard component for a provisioned AKS Automatic cluster.
+ */
+export const aksClusterCardScenario: PlaygroundScenario = {
+  id: 'aks.cluster-card',
+  title: 'AKS Cluster Card',
+  description: 'Shows the AksClusterCard component for a small AKS Automatic cluster in East US.',
+  group: 'aks',
+  a2ui: [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId: 'aks-cluster-card', catalogId: 'kickstart' },
+    },
+    {
+      version: A2UI_VERSION,
+      updateComponents: {
+        surfaceId: 'aks-cluster-card',
+        components: [
+          {
+            type: 'aks/AksClusterCard',
+            clusterName: 'aks-kickstart-eastus',
+            resourceGroup: 'rg-kickstart-prod',
+            location: 'East US',
+            kubernetesVersion: '1.30.0',
+            nodeCount: 3,
+            tier: 'Standard',
+            fqdn: 'aks-kickstart-eastus-a1b2c3.hcp.eastus.azmk8s.io',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/pack-aks-automatic/src/playground/safeguard-violations.scenario.ts
+++ b/packages/pack-aks-automatic/src/playground/safeguard-violations.scenario.ts
@@ -1,0 +1,53 @@
+import type { PlaygroundScenario } from '@kickstart/harness';
+import { A2UI_VERSION } from '@kickstart/harness';
+
+/**
+ * Playground scenario: aks.safeguard-violations
+ * Renders the aks/SafeguardViolations component with a mixed-severity report.
+ */
+export const safeguardViolationsScenario: PlaygroundScenario = {
+  id: 'aks.safeguard-violations',
+  title: 'AKS Safeguard Violations',
+  description: 'Shows the SafeguardViolations component with a non-compliant manifest and three violations.',
+  group: 'aks',
+  a2ui: [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId: 'aks-safeguard-violations', catalogId: 'kickstart' },
+    },
+    {
+      version: A2UI_VERSION,
+      updateComponents: {
+        surfaceId: 'aks-safeguard-violations',
+        components: [
+          {
+            type: 'aks/SafeguardViolations',
+            manifestName: 'deployment.yaml',
+            compliant: false,
+            summary: '3 safeguard violations must be resolved before deployment.',
+            violations: [
+              {
+                ruleId: 'aks.no_latest_tag',
+                severity: 'high',
+                description: 'Container image uses the ":latest" tag. Pin to a specific tag or digest.',
+                line: 24,
+              },
+              {
+                ruleId: 'aks.require_resource_limits',
+                severity: 'medium',
+                description: 'Container does not declare resources.limits.memory.',
+                line: 31,
+              },
+              {
+                ruleId: 'aks.no_privileged_containers',
+                severity: 'high',
+                description: 'Container sets securityContext.privileged=true. AKS Automatic forbids privileged containers.',
+                line: 38,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/pack-azure/src/index.ts
+++ b/packages/pack-azure/src/index.ts
@@ -33,6 +33,10 @@ import { requireSubscriptionScopeGuardrail } from './guardrails/require-subscrip
 import { noHardcodedCredentialsGuardrail } from './guardrails/no-hardcoded-credentials.js';
 import { noSubscriptionScopedOwnerGuardrail } from './guardrails/no-subscription-scoped-owner.js';
 
+// Playground scenarios
+import { azureResourceCardScenario } from './playground/resource-card.scenario.js';
+import { costEstimateScenario } from './playground/cost-estimate.scenario.js';
+
 const azureComponents: ComponentContribution[] = [
   azureResourceCardContribution,
   costEstimateContribution,
@@ -80,6 +84,8 @@ export const azurePack: Pack = {
     noHardcodedCredentialsGuardrail,
     noSubscriptionScopedOwnerGuardrail,
   ],
+
+  playgroundScenarios: [azureResourceCardScenario, costEstimateScenario],
 };
 
 // Named exports for individual contributions

--- a/packages/pack-azure/src/playground/cost-estimate.scenario.ts
+++ b/packages/pack-azure/src/playground/cost-estimate.scenario.ts
@@ -1,0 +1,64 @@
+import type { PlaygroundScenario } from '@kickstart/harness';
+import { A2UI_VERSION } from '@kickstart/harness';
+
+/**
+ * Playground scenario: azure.cost-estimate
+ * Renders the azure/CostEstimate component with a plausible AKS + ACR + Key Vault breakdown.
+ */
+export const costEstimateScenario: PlaygroundScenario = {
+  id: 'azure.cost-estimate',
+  title: 'Azure Cost Estimate',
+  description: 'Shows the CostEstimate component with a line-item breakdown for a small AKS Automatic deployment.',
+  group: 'azure',
+  a2ui: [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId: 'azure-cost-estimate', catalogId: 'kickstart' },
+    },
+    {
+      version: A2UI_VERSION,
+      updateComponents: {
+        surfaceId: 'azure-cost-estimate',
+        components: [
+          {
+            type: 'azure/CostEstimate',
+            totalMonthlyUSD: 312.4,
+            currencyCode: 'USD',
+            region: 'East US',
+            disclaimer: 'Estimates are based on Azure retail pricing and do not include data egress.',
+            breakdown: [
+              {
+                name: 'AKS Automatic control plane (Standard tier)',
+                monthlyUSD: 73.0,
+                unitPrice: 0.1,
+                quantity: 730,
+                unitOfMeasure: 'hours',
+              },
+              {
+                name: 'Standard_D4s_v5 node pool (3 nodes)',
+                monthlyUSD: 210.24,
+                unitPrice: 0.096,
+                quantity: 2190,
+                unitOfMeasure: 'vCPU-hours',
+              },
+              {
+                name: 'Azure Container Registry (Standard)',
+                monthlyUSD: 20.0,
+                unitPrice: 20.0,
+                quantity: 1,
+                unitOfMeasure: 'registry/month',
+              },
+              {
+                name: 'Azure Key Vault (standard operations)',
+                monthlyUSD: 9.16,
+                unitPrice: 0.03,
+                quantity: 305,
+                unitOfMeasure: '10K ops',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/pack-azure/src/playground/resource-card.scenario.ts
+++ b/packages/pack-azure/src/playground/resource-card.scenario.ts
@@ -1,0 +1,46 @@
+import type { PlaygroundScenario } from '@kickstart/harness';
+import { A2UI_VERSION } from '@kickstart/harness';
+
+/**
+ * Playground scenario: azure.resource-card
+ * Renders the azure/AzureResourceCard component for a provisioned AKS cluster.
+ */
+export const azureResourceCardScenario: PlaygroundScenario = {
+  id: 'azure.resource-card',
+  title: 'Azure Resource Card',
+  description: 'Shows the AzureResourceCard component for an active AKS cluster with tags and key properties.',
+  group: 'azure',
+  a2ui: [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId: 'azure-resource-card', catalogId: 'kickstart' },
+    },
+    {
+      version: A2UI_VERSION,
+      updateComponents: {
+        surfaceId: 'azure-resource-card',
+        components: [
+          {
+            type: 'azure/AzureResourceCard',
+            resourceName: 'aks-kickstart-eastus',
+            resourceType: 'Microsoft.ContainerService/managedClusters',
+            location: 'East US',
+            resourceGroup: 'rg-kickstart-prod',
+            status: 'active',
+            tags: {
+              env: 'prod',
+              owner: 'platform-team',
+              costCenter: 'CC-1001',
+            },
+            properties: {
+              sku: 'Automatic',
+              kubernetesVersion: '1.30.0',
+              nodeCount: 3,
+              fqdn: 'aks-kickstart-eastus-a1b2c3.hcp.eastus.azmk8s.io',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/pack-core/src/core-pack.ts
+++ b/packages/pack-core/src/core-pack.ts
@@ -34,6 +34,10 @@ import { RadioGroup } from './components/rich/RadioGroup.js';
 import { SteppedCarousel } from './components/rich/SteppedCarousel.js';
 import { SummaryCard } from './components/rich/SummaryCard.js';
 
+// Playground scenarios
+import { questionnaireScenario } from './playground/questionnaire.scenario.js';
+import { generationProgressScenario } from './playground/generation-progress.scenario.js';
+
 function toContrib(impl: ReactComponentImplementation): ComponentContribution {
   return {
     name: `core/${impl.name}`,
@@ -89,4 +93,6 @@ export const corePack: Pack = {
     noSecretsInArtifactsGuardrail,
     noCredentialLeakGuardrail,
   ],
+
+  playgroundScenarios: [questionnaireScenario, generationProgressScenario],
 };

--- a/packages/pack-core/src/playground/generation-progress.scenario.ts
+++ b/packages/pack-core/src/playground/generation-progress.scenario.ts
@@ -1,0 +1,66 @@
+import type { PlaygroundScenario } from '@kickstart/harness';
+import { A2UI_VERSION } from '@kickstart/harness';
+
+/**
+ * Playground scenario: core.generation-progress
+ * Renders the core/GenerationProgress component mid-run with mixed step statuses.
+ */
+export const generationProgressScenario: PlaygroundScenario = {
+  id: 'core.generation-progress',
+  title: 'Core Generation Progress',
+  description: 'Shows the GenerationProgress rich component in running state with complete, running, and pending steps.',
+  group: 'core',
+  a2ui: [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId: 'core-generation-progress', catalogId: 'kickstart' },
+    },
+    {
+      version: A2UI_VERSION,
+      updateComponents: {
+        surfaceId: 'core-generation-progress',
+        components: [
+          {
+            type: 'core/GenerationProgress',
+            title: 'Generating deployment artifacts',
+            overallStatus: 'running',
+            statusMessage: 'Writing manifests…',
+            lastUpdated: '2026-04-18T09:12:05Z',
+            steps: [
+              {
+                id: 'design',
+                label: 'Design architecture',
+                status: 'complete',
+                detail: 'AKS Automatic + managed ACR + Key Vault',
+                timestamp: '2026-04-18T09:11:10Z',
+              },
+              {
+                id: 'bicep',
+                label: 'Write Bicep templates',
+                status: 'complete',
+                detail: '3 files generated',
+                timestamp: '2026-04-18T09:11:42Z',
+              },
+              {
+                id: 'manifests',
+                label: 'Write Kubernetes manifests',
+                status: 'running',
+                detail: 'Deployment, Service, HTTPRoute',
+              },
+              {
+                id: 'workflow',
+                label: 'Write GitHub Actions workflow',
+                status: 'pending',
+              },
+              {
+                id: 'review',
+                label: 'Run validators',
+                status: 'pending',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/pack-core/src/playground/questionnaire.scenario.ts
+++ b/packages/pack-core/src/playground/questionnaire.scenario.ts
@@ -1,0 +1,62 @@
+import type { PlaygroundScenario } from '@kickstart/harness';
+import { A2UI_VERSION } from '@kickstart/harness';
+
+/**
+ * Playground scenario: core.questionnaire
+ * Renders the core/Questionnaire component with a short multi-type question set.
+ */
+export const questionnaireScenario: PlaygroundScenario = {
+  id: 'core.questionnaire',
+  title: 'Core Questionnaire',
+  description: 'Shows the Questionnaire rich component with text, choice, and multiChoice questions.',
+  group: 'core',
+  a2ui: [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId: 'core-questionnaire', catalogId: 'kickstart' },
+    },
+    {
+      version: A2UI_VERSION,
+      updateComponents: {
+        surfaceId: 'core-questionnaire',
+        components: [
+          {
+            type: 'core/Questionnaire',
+            questions: [
+              {
+                id: 'app-name',
+                label: 'What is the name of your application?',
+                type: 'text',
+                required: true,
+              },
+              {
+                id: 'runtime',
+                label: 'Which runtime does your app use?',
+                type: 'choice',
+                choices: [
+                  { id: 'node', label: 'Node.js' },
+                  { id: 'python', label: 'Python' },
+                  { id: 'dotnet', label: '.NET' },
+                  { id: 'java', label: 'Java' },
+                ],
+                required: true,
+              },
+              {
+                id: 'concerns',
+                label: 'Which non-functional concerns matter most?',
+                type: 'multiChoice',
+                choices: [
+                  { id: 'cost', label: 'Cost' },
+                  { id: 'latency', label: 'Latency' },
+                  { id: 'availability', label: 'Availability' },
+                  { id: 'compliance', label: 'Compliance' },
+                ],
+              },
+            ],
+            submitLabel: 'Continue',
+          },
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Closes #779

## Summary
Only `pack-github` shipped playground scenarios. This PR adds the matching scenarios for the remaining v2 packs so the Playground can exercise every pack's hero components with stub data.

## Changes

**pack-core** (`packages/pack-core/src/playground/`):
- `core.questionnaire` — Questionnaire with text, choice, and multiChoice questions.
- `core.generation-progress` — GenerationProgress mid-run with complete/running/pending steps.

**pack-azure** (`packages/pack-azure/src/playground/`):
- `azure.resource-card` — AzureResourceCard for an active AKS cluster with tags and key properties.
- `azure.cost-estimate` — CostEstimate with a plausible four-line-item breakdown.

**pack-aks-automatic** (`packages/pack-aks-automatic/src/playground/`):
- `aks.cluster-card` — AksClusterCard for a provisioned AKS Automatic cluster.
- `aks.safeguard-violations` — SafeguardViolations report with three mixed-severity findings.

Each scenario follows the `PlaygroundScenario` shape from `@kickstart/harness` and mirrors the `pack-github` template (`createSurface` → `updateComponents`). Scenarios are wired into each pack's `playgroundScenarios` array on the `Pack` export.

## Testing
- `npm run build` — green
- `npm run lint` — 0 errors
- `npx vitest run` — 809 passed / 3 skipped / 159 todo

## Docs and changeset
- [ ] Changeset: internal-only (playground-only additions; no runtime behavior change).
- [x] Pack docs: N/A — scenarios self-document via `title`/`description`.
- [x] Tests: existing harness scenario tests cover the shape.
