### PR TITLE
feat(mcp): register core/azure/aks/github packs at boot

### DIFF
--- a/.changeset/mcp-register-packs.md
+++ b/.changeset/mcp-register-packs.md
@@ -1,0 +1,9 @@
+---
+"@kickstart/mcp-server": patch
+"@kickstart/pack-core": patch
+"@kickstart/pack-azure": patch
+"@kickstart/pack-aks-automatic": patch
+"@kickstart/pack-github": patch
+---
+
+MCP server now registers the core/azure/aks/github packs at boot through a sealed `PackRegistry` singleton that mirrors `packages/web/api/src/startup/packs.ts`, honouring the `KICKSTART_PACKS` env var. Each pack now exports a `./server-manifest` subpath so server-only runtimes (MCP + Azure Functions) can load it without pulling in React.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17397,6 +17397,10 @@
       "version": "0.7.0",
       "dependencies": {
         "@kickstart/harness": "*",
+        "@kickstart/pack-aks-automatic": "*",
+        "@kickstart/pack-azure": "*",
+        "@kickstart/pack-core": "*",
+        "@kickstart/pack-github": "*",
         "@modelcontextprotocol/sdk": "^1.12.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "worktrees": true
   },
   "scripts": {
-    "build": "npm run clean --workspaces --if-present && npm run build --workspaces --if-present",
+    "build": "npm run clean --workspaces --if-present && npm run build -w @kickstart/harness && npm run build -w @kickstart/pack-core -w @kickstart/pack-azure -w @kickstart/pack-aks-automatic -w @kickstart/pack-github && npm run build -w @kickstart/mcp-server && npm run build -w @kickstart/web && npm run build -w @kickstart/api",
     "test": "npx vitest run",
     "lint": "eslint packages/*/src/**/*.ts packages/*/src/**/*.tsx",
     "api:build": "npm run build -w @kickstart/harness && npm run build -w @kickstart/api",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -17,6 +17,10 @@
   },
   "dependencies": {
     "@kickstart/harness": "*",
+    "@kickstart/pack-core": "*",
+    "@kickstart/pack-azure": "*",
+    "@kickstart/pack-aks-automatic": "*",
+    "@kickstart/pack-github": "*",
     "@modelcontextprotocol/sdk": "^1.12.1"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -33,7 +33,6 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 
 import {
-  PackRegistry,
   Runner,
   getOrCreateSession,
   isVsCodeClient,
@@ -49,6 +48,7 @@ import {
   purgeExpiredInterrupts,
 } from './adapter/interrupt-store.js';
 import { withSessionMutex } from './adapter/session-mutex.js';
+import { getRegistry } from './startup/packs.js';
 
 // ── Load app HTML ──────────────────────────────────────────────────
 
@@ -67,11 +67,7 @@ const APP_RESOURCE_URI = 'kickstart://app/main' as const;
 
 // ── Harness setup ──────────────────────────────────────────────────
 
-const registry = new PackRegistry();
-// TODO(pack registration): register packs at startup once pack-core etc. are available.
-// import { corePack } from '@kickstart/pack-core';
-// registry.register(corePack);
-// registry.seal();
+const registry = getRegistry();
 
 const runner = new Runner(registry);
 

--- a/packages/mcp-server/src/startup/packs.ts
+++ b/packages/mcp-server/src/startup/packs.ts
@@ -1,0 +1,66 @@
+/**
+ * @module @kickstart/mcp-server/startup/packs
+ *
+ * MCP-server pack registration. Mirrors packages/web/api/src/startup/packs.ts
+ * so the MCP runtime and the web API expose the same sealed PackRegistry shape.
+ *
+ * Both surfaces honour `KICKSTART_PACKS` (comma-separated list) and always
+ * register `core` first because every other pack depends on it.
+ */
+
+import type { Pack } from '@kickstart/harness';
+import { PackRegistry } from '@kickstart/harness';
+import { corePackServer } from '@kickstart/pack-core/server-manifest';
+import { azurePackServer } from '@kickstart/pack-azure/server-manifest';
+import { aksAutomaticPackServer } from '@kickstart/pack-aks-automatic/server-manifest';
+import { githubPackServer } from '@kickstart/pack-github/server-manifest';
+
+let _registry: PackRegistry | null = null;
+
+const PACK_ORDER = ['core', 'azure', 'aks', 'github'] as const;
+type PackId = (typeof PACK_ORDER)[number];
+
+const PACK_BY_ID: Record<PackId, Pack> = {
+  core: corePackServer,
+  azure: azurePackServer,
+  aks: aksAutomaticPackServer,
+  github: githubPackServer,
+};
+
+function parseEnabledPacks(raw: string | undefined): PackId[] {
+  if (!raw || raw.trim() === '') {
+    return [...PACK_ORDER];
+  }
+  const requested = new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  // `core` is always registered — everything else depends on it.
+  requested.add('core');
+  return PACK_ORDER.filter((id): id is PackId => requested.has(id));
+}
+
+/**
+ * Returns the sealed PackRegistry singleton for the MCP server.
+ *
+ * Registers the configured packs in dependency order and seals on first
+ * call. The enabled pack set is controlled by `KICKSTART_PACKS`
+ * (comma-separated list: `core`, `azure`, `aks`, `github`). When unset or
+ * empty, all four packs are enabled. `core` is always registered.
+ */
+export function getRegistry(): PackRegistry {
+  if (!_registry) {
+    _registry = new PackRegistry();
+    const enabled = parseEnabledPacks(process.env['KICKSTART_PACKS']);
+    for (const id of enabled) {
+      _registry.register(PACK_BY_ID[id]);
+    }
+    _registry.seal();
+    process.stderr.write(
+      `[kickstart-mcp] registered packs: ${enabled.join(', ')}\n`,
+    );
+  }
+  return _registry;
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -9,6 +9,10 @@
     "baseUrl": ".",
     "paths": {
       "@kickstart/harness": ["../../packages/harness/src/index.ts"],
+      "@kickstart/pack-core/server-manifest": ["../pack-core/dist/server-manifest.d.ts"],
+      "@kickstart/pack-azure/server-manifest": ["../pack-azure/dist/server-manifest.d.ts"],
+      "@kickstart/pack-aks-automatic/server-manifest": ["../pack-aks-automatic/dist/server-manifest.d.ts"],
+      "@kickstart/pack-github/server-manifest": ["../pack-github/dist/server-manifest.d.ts"],
     }
   },
   "references": [

--- a/packages/pack-aks-automatic/package.json
+++ b/packages/pack-aks-automatic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kickstart/pack-aks-automatic",
   "version": "0.1.0",
-  "description": "AKS Automatic pack — agents, skills, tools, user actions, and components for Kickstart v2",
+  "description": "AKS Automatic pack \u2014 agents, skills, tools, user actions, and components for Kickstart v2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server-manifest": {
+      "import": "./dist/server-manifest.js",
+      "types": "./dist/server-manifest.d.ts"
     }
   },
   "scripts": {

--- a/packages/pack-azure/package.json
+++ b/packages/pack-azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kickstart/pack-azure",
   "version": "0.1.0",
-  "description": "Azure pack — agents, skills, tools, user actions, and components for Kickstart v2",
+  "description": "Azure pack \u2014 agents, skills, tools, user actions, and components for Kickstart v2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server-manifest": {
+      "import": "./dist/server-manifest.js",
+      "types": "./dist/server-manifest.d.ts"
     }
   },
   "scripts": {

--- a/packages/pack-core/package.json
+++ b/packages/pack-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kickstart/pack-core",
   "version": "0.1.0",
-  "description": "Core pack — agents, skills, tools, and domain-neutral components for Kickstart v2",
+  "description": "Core pack \u2014 agents, skills, tools, and domain-neutral components for Kickstart v2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server-manifest": {
+      "import": "./dist/server-manifest.js",
+      "types": "./dist/server-manifest.d.ts"
     }
   },
   "scripts": {

--- a/packages/pack-github/package.json
+++ b/packages/pack-github/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kickstart/pack-github",
   "version": "0.1.0",
-  "description": "GitHub pack — agents, skills, tools, user actions, and components for Kickstart v2",
+  "description": "GitHub pack \u2014 agents, skills, tools, user actions, and components for Kickstart v2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server-manifest": {
+      "import": "./dist/server-manifest.js",
+      "types": "./dist/server-manifest.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Closes #777

Working as Bender (Backend Dev).

## Summary
Brings the MCP server up to parity with the web API: both surfaces now expose the same sealed `PackRegistry` populated with the four server-manifest packs at boot.

## Changes
- New `packages/mcp-server/src/startup/packs.ts` mirroring `packages/web/api/src/startup/packs.ts`. Same `getRegistry()` singleton, same `KICKSTART_PACKS` env handling, same dependency-safe order (`core` → `azure` → `aks` → `github`), and `core` is always registered.
- `packages/mcp-server/src/index.ts` now calls `getRegistry()` instead of constructing an empty `PackRegistry` with a TODO.
- Each pack gains a `./server-manifest` subpath export (`pack-core`, `pack-azure`, `pack-aks-automatic`, `pack-github`) so server-only runtimes can import without pulling in React.
- mcp-server `package.json` declares the four pack packages as deps.
- mcp-server `tsconfig.json` adds path mappings that resolve `@kickstart/pack-*/server-manifest` to the pack's built `.d.ts`.

Boot log now prints `[kickstart-mcp] registered packs: core, azure, aks, github`.

## Runtime follow-up (not in this PR)
`pack-core`'s vendored `basic_components.js` has an extensionless relative import that breaks pure-Node ESM resolution of the compiled `server-manifest.js`. The web API sidesteps this because esbuild bundles at build time; the MCP server (tsc + Node) will trip on it the first time a session actually uses a core tool. The registration wiring in this PR is correct; the vendor import needs its own fix.

## Testing
- `npm run build` ✅
- `npm run build -w @kickstart/mcp-server` ✅
- `npx vitest run` ✅ 809 passed, 159 todo, 3 skipped (MCP suite: 151 passed)
- `cd packages/web && npx tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors, pre-existing warnings only)

## Docs and changeset
- [x] Changeset added (`.changeset/mcp-register-packs.md`)
- [x] docs-site/docs/ — N/A
- [x] docs/v2-implementation-brief.md — N/A (implements existing §2 plan)
- [x] docs/api-reference.md — N/A
- [x] Pack docs — N/A (mechanical registration)
- [x] Tests: existing mcp-adapter / protocol tests cover the runner wiring; no new tests needed for this mechanical boot step.