### PR TITLE
fix(ci): build all workspaces in deploy-swa (#799)

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Install dependencies and build
         run: |
           npm ci
-          npm run build -w @kickstart/core
-          npm run build -w @kickstart/api
+          npm run build
 
       - name: Build web app (Vite)
         run: cd packages/web && npx vite build


### PR DESCRIPTION
Closes #799

## Summary
`deploy-swa.yml` failed on the v2 merge to main because it ran `npm run build -w @kickstart/core`, but `packages/core` no longer exists in v2.

## Changes
- Replaced the two hard-coded workspace build steps in `.github/workflows/deploy-swa.yml` with a single `npm run build`, which walks all workspaces in dependency order (same pattern as CI).

## Verification
- `grep -r '@kickstart/core' .github/workflows/` → no matches.
- YAML parses cleanly (`yaml.safe_load`).
- `npm ci && npm run build` runs successfully locally (all packs + web + api build).

## Docs and changeset
- [x] N/A — CI-only fix
