### PR TITLE
ci(swa): skip Oryx API build to unblock SWA deploy

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -55,7 +55,7 @@ jobs:
           api_location: "packages/web/api"
           output_location: ""
           skip_app_build: true
-          skip_api_build: false
+          skip_api_build: true
           api_build_command: "echo 'API already built'"
 
       - name: Resolve production smoke target


### PR DESCRIPTION
## Problem

SWA deploy is still failing even after moving `@kickstart/harness` to devDependencies (#814). Oryx still runs `npm install --production` in `packages/web/api` before our no-op `api_build_command`, and it can't resolve the workspace links in the root `package-lock.json`.

## Fix

Flip `skip_api_build: false` → `skip_api_build: true` in `.github/workflows/deploy-swa.yml`.

The API functions are already pre-bundled by esbuild into `packages/web/api/dist/functions/` during the `npm run build` step earlier in the job. Oryx shouldn't touch them. Setting `skip_api_build: true` bypasses the entire Oryx pipeline for the API; SWA uploads the pre-bundled functions as-is.

`api_location: packages/web/api` is correct — that's where `host.json` lives, and SWA picks up the compiled functions from the `dist/functions/` subdirectory (the default Azure Functions output).

## Scope

YAML-only change. No dependency updates needed.

Working as Bender (Backend Dev).