### PR TITLE
ci(swa): re-enable Oryx API build to fix function language detection

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -55,7 +55,7 @@ jobs:
           api_location: "packages/web/api"
           output_location: ""
           skip_app_build: true
-          skip_api_build: true
+          skip_api_build: false
           api_build_command: "echo 'API already built'"
 
       - name: Resolve production smoke target


### PR DESCRIPTION
## Problem

SWA deploy fails with:
```
Cannot deploy to the function app because Function language info isn't provided.
```

After #815 set `skip_api_build: true`, Oryx no longer runs and SWA has no way to detect the function runtime language.

## Fix

Revert `skip_api_build` to `false` so Oryx detects the language from `host.json`/`package.json`. Keep `api_build_command: "echo 'API already built'"` so Oryx skips the actual build step (TypeScript output is already produced by the workspace `npm run build`).

The workspace devDeps fix (#814) means Oryx only installs runtime deps (`@azure/functions`, `bicep-node`) — both resolve from npm without workspace shenanigans.

## Notes

Working as Bender (Backend Dev).