### PR TITLE
ci(swa): deploy bundled dist with host.json to bypass Oryx install

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build web app (Vite)
         run: cd packages/web && npx vite build
 
+      - name: Prepare API for SWA
+        run: cp packages/web/api/host.json packages/web/api/dist/host.json
+
       - name: Deploy to Azure Static Web Apps
         id: swa_deploy
         uses: Azure/static-web-apps-deploy@v1
@@ -52,11 +55,10 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "packages/web/dist"
-          api_location: "packages/web/api"
+          api_location: "packages/web/api/dist"
           output_location: ""
           skip_app_build: true
-          skip_api_build: false
-          api_build_command: "echo 'API already built'"
+          skip_api_build: true
 
       - name: Resolve production smoke target
         id: production_url


### PR DESCRIPTION
## Problem

Oryx still fails on SWA deploy. Root cause: SWA runs `npm install --production` inside `packages/web/api/`, and because the root `package.json` declares workspaces, npm walks up and tries to resolve `@kickstart/harness` from the public registry → 404.

Previous attempts (moving harness to devDependencies, setting `skip_api_build`) did not fully isolate us from this behavior.

## Fix

Point `api_location` at the **pre-built** `packages/web/api/dist/` directory and set `skip_api_build: true`. That directory has:

- No `package.json`
- No workspace references
- Just bundled function entry points (esbuild inlines `@kickstart/harness`)

We copy `host.json` into `dist/` before deploy so the Functions runtime finds it alongside the bundled entries. Oryx sees a clean flat directory and never runs `npm install`.

## Changes in `.github/workflows/deploy-swa.yml`

1. New step: `cp packages/web/api/host.json packages/web/api/dist/host.json`
2. `api_location` → `packages/web/api/dist`
3. `skip_api_build` → `true`
4. Removed the `api_build_command` stub (no longer needed)

Working as Bender (Backend Dev).

Closes the SWA deploy incident.