### PR TITLE
ci(swa): add minimal package.json to api dist for SWA language detection

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Build web app (Vite)
         run: cd packages/web && npx vite build
 
-      - name: Prepare API for SWA
-        run: cp packages/web/api/host.json packages/web/api/dist/host.json
+      - name: Prepare API dist for SWA
+        run: |
+          cp packages/web/api/host.json packages/web/api/dist/host.json
+          echo '{"name":"kickstart-api","version":"1.0.0","type":"module","dependencies":{"@azure/functions":"^4.6.0","bicep-node":"^0.0.9"}}' > packages/web/api/dist/package.json
+          cd packages/web/api/dist && npm install --omit=dev --no-package-lock
 
       - name: Deploy to Azure Static Web Apps
         id: swa_deploy


### PR DESCRIPTION
Working as Bender (Backend Dev)

## Problem
SWA deploys were failing with **"Function language info isn't provided"**. With `skip_api_build: true` and `api_location: packages/web/api/dist`, the deploy engine had no `package.json` in the dist folder to detect Node.js from.

## Fix
In `deploy-swa.yml`, after the existing `host.json` copy, generate a minimal `package.json` in `packages/web/api/dist` and `npm install` it:

```json
{"name":"kickstart-api","version":"1.0.0","type":"module","dependencies":{"@azure/functions":"^4.6.0","bicep-node":"^0.0.9"}}
```

## Why both deps?
`packages/web/api/esbuild.config.mjs` marks **both** `@azure/functions` and `bicep-node` as `external`, so they must be resolvable from `node_modules` at runtime. Everything else (including `@kickstart/harness`) is bundled in by esbuild.

## Verified locally
- `npm run build` produces `dist/functions/*.js` (20 functions bundled)
- `echo … > dist/package.json && npm install --omit=dev --no-package-lock` succeeds, installing 9 packages with both `@azure/functions` and `bicep-node` resolved — no workspace lookups, no dev deps.

No app code changes.