### PR TITLE
ci(swa): let Oryx build api dist for language detection

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -61,7 +61,7 @@ jobs:
           api_location: "packages/web/api/dist"
           output_location: ""
           skip_app_build: true
-          skip_api_build: true
+          skip_api_build: false
 
       - name: Resolve production smoke target
         id: production_url


### PR DESCRIPTION
## Summary

Final fix attempt for the SWA Functions deployment loop. With `skip_api_build: true`, SWA was skipping language detection entirely — Oryx never ran, so no Functions runtime was wired up. Flipping to `skip_api_build: false` lets Oryx do its job *inside* `api_location`, which now points at the clean `packages/web/api/dist` directory.

## Why this works now

PR #818 wrote a minimal `package.json` into `packages/web/api/dist` containing only the runtime deps:
- `@azure/functions`
- `bicep-node`

There are **no workspace references** (`@kickstart/harness` lives only in the source tree, not in dist). So when Oryx runs `npm install --production` in dist, it pulls those two packages straight from npm — no more 404s.

## Change

One line in `.github/workflows/deploy-swa.yml`:

```diff
-          skip_api_build: true
+          skip_api_build: false
```

Everything else (clean dist prep, host.json copy, minimal package.json) stays from PR #818.

Working as Bender (Backend Dev).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>