### PR TITLE
fix(swa): set main field in api dist package.json so /api/* resolves

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Prepare API dist for SWA
         run: |
           cp packages/web/api/host.json packages/web/api/dist/host.json
-          echo '{"name":"kickstart-api","version":"1.0.0","type":"module","dependencies":{"@azure/functions":"^4.6.0","bicep-node":"^0.0.9"}}' > packages/web/api/dist/package.json
+          echo '{"name":"kickstart-api","version":"1.0.0","type":"module","main":"functions/*.js","dependencies":{"@azure/functions":"^4.6.0","bicep-node":"^0.0.9"}}' > packages/web/api/dist/package.json
           cd packages/web/api/dist && npm install --omit=dev --no-package-lock
 
       - name: Deploy to Azure Static Web Apps


### PR DESCRIPTION
Working as Bender (Backend Dev)

Closes #820

## Problem
SWA deploy succeeds but every `/api/*` route (including `/api/health`) returns 404. The smoke check at `https://kickstart.aks.azure.sabbour.me/api/health` was failing.

## Root cause
The Azure Functions Node.js v4 programming model discovers route handlers by loading the file(s) listed in `package.json`'s `main` field — those files import `@azure/functions` and call `app.http(...)` to register routes.

PR #818 added a minimal `dist/package.json` for SWA/Oryx language detection but **omitted** `main`. With no `main`, the Functions host loaded zero handler files, so `app.http("health", ...)` never ran and every request 404'd.

The source `packages/web/api/package.json` has `"main": "dist/functions/*.js"`. Since SWA's `api_location` is `packages/web/api/dist`, the equivalent inside dist is `functions/*.js`.

## Fix
Add `"main": "functions/*.js"` to the dist package.json generated by the deploy workflow. One-line change.

## Verification
- Will be verified by the existing post-deploy smoke check (`scripts/check-swa-health.mjs` against `/api/health`) on this PR's deploy run after merge.
- No code or test changes; pure CI workflow fix.
