### PR TITLE
fix(swa): revert deploy-swa.yml to original working pattern

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -44,12 +44,6 @@ jobs:
       - name: Build web app (Vite)
         run: cd packages/web && npx vite build
 
-      - name: Prepare API dist for SWA
-        run: |
-          cp packages/web/api/host.json packages/web/api/dist/host.json
-          echo '{"name":"kickstart-api","version":"1.0.0","type":"module","main":"functions/*.js","dependencies":{"@azure/functions":"^4.6.0","bicep-node":"^0.0.9"}}' > packages/web/api/dist/package.json
-          cd packages/web/api/dist && npm install --omit=dev --no-package-lock
-
       - name: Deploy to Azure Static Web Apps
         id: swa_deploy
         uses: Azure/static-web-apps-deploy@v1
@@ -58,10 +52,11 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "packages/web/dist"
-          api_location: "packages/web/api/dist"
+          api_location: "packages/web/api"
           output_location: ""
           skip_app_build: true
           skip_api_build: false
+          api_build_command: "echo 'API already built'"
 
       - name: Resolve production smoke target
         id: production_url


### PR DESCRIPTION
Working as Bender (Backend Dev).

Reverts `deploy-swa.yml` back to the pre-v2 working pattern. The deploy worked before the v2 merge; the only thing that broke was that `@kickstart/harness` was in `dependencies` (PR #814 already fixed that — it's now in `devDependencies`).

### Changes
- `api_location: "packages/web/api"` (source dir, not dist)
- `skip_api_build: false` — let Oryx run
- `api_build_command: "echo 'API already built'"` — skip the real build, upload pre-built dist/
- Removed the "Prepare API dist for SWA" step — unnecessary

### Why this works
Oryx detects Node.js → runs `npm install --production` → that skips devDependencies → `@kickstart/harness` (workspace package) is not resolved → no 404.

`packages/web/api/package.json` already has `@kickstart/harness` in `devDependencies`, confirmed on main.

Closes the SWA deploy regression.