### PR TITLE
fix(api): remove workspace and frontend deps from API package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17608,12 +17608,7 @@
         "bicep-node": "^0.0.9"
       },
       "devDependencies": {
-        "@fluentui/react-icons": "^2.0.324",
-        "@kickstart/harness": "*",
-        "@types/dompurify": "^3.2.0",
-        "dompurify": "^3.4.0",
-        "esbuild": "^0.28.0",
-        "vite": "^8.0.8"
+        "esbuild": "^0.28.0"
       }
     },
     "packages/web/node_modules/@esbuild/aix-ppc64": {

--- a/packages/web/api/.npmrc
+++ b/packages/web/api/.npmrc
@@ -1,0 +1,1 @@
+workspaces=false

--- a/packages/web/api/package.json
+++ b/packages/web/api/package.json
@@ -16,11 +16,6 @@
     "bicep-node": "^0.0.9"
   },
   "devDependencies": {
-    "@fluentui/react-icons": "^2.0.324",
-    "@kickstart/harness": "*",
-    "@types/dompurify": "^3.2.0",
-    "dompurify": "^3.4.0",
-    "esbuild": "^0.28.0",
-    "vite": "^8.0.8"
+    "esbuild": "^0.28.0"
   }
 }


### PR DESCRIPTION
Working as Bender (Backend Dev).

## Root cause

Oryx runs `npm install --production` inside `packages/web/api/` during SWA deploy. npm walks up to the root `package.json`, discovers the workspaces config, and tries to resolve `@kickstart/harness` from the npm registry — which fails because it's a private workspace package.

Having `@kickstart/harness` in devDependencies doesn't fix the issue: workspace resolution happens at the monorepo level regardless of dep vs devDep classification.

## Fix

The API's `package.json` should only list:
- **runtime externals** (things esbuild marks as external and Functions needs at runtime)
- **build tooling** (esbuild itself)

Everything else the code uses is bundled by esbuild at build time and does not need to be declared.

### Removed
- `@kickstart/harness` — bundled by esbuild, resolved via workspace during dev
- `@fluentui/react-icons`, `@types/dompurify`, `dompurify`, `vite` — web client deps that never belonged in the API package

### Kept
- `@azure/functions`, `bicep-node` — runtime externals
- `esbuild` — build tool

## Verification
- `grep @kickstart packages/web/api/package.json` — only the package's own `name` field remains
- `npm install` from root — clean
- `npm run build -w @kickstart/api` — ✅ bundled 20 functions
- `npm run build` (full repo) — ✅ passes

Closes the Oryx deploy failure.