### PR TITLE
fix(api): register Azure Functions via single dist/index.js entry

### DIFF
--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -8,17 +8,18 @@
  */
 
 import * as esbuild from "esbuild";
-import { readdirSync } from "node:fs";
+import { readdirSync, writeFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HARNESS_SRC = resolve(__dirname, "../../harness/src");
 
-const entryPoints = readdirSync("src/functions")
+const functionFiles = readdirSync("src/functions")
   .filter((f) => f.endsWith(".ts"))
-  .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"))
-  .map((f) => join("src/functions", f));
+  .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"));
+
+const entryPoints = functionFiles.map((f) => join("src/functions", f));
 
 // esbuild's `alias` option does not handle subpath exports like
 // `@kickstart/harness/runtime/sse`. A resolver plugin rewrites both the
@@ -48,3 +49,15 @@ await esbuild.build({
 });
 
 console.log(`✅ Bundled ${entryPoints.length} function(s) to dist/functions/`);
+
+// Emit a single entry file that imports every function bundle for its
+// side-effect `app.http()` registrations. Azure Functions v4 loads the
+// path declared in package.json "main" and expects that module to register
+// every function. A glob (e.g. `dist/functions/*.js`) is silently ignored
+// by the runtime, which is why we must materialise an explicit index.js.
+const imports = functionFiles
+  .map((f) => `import "./functions/${f.replace(/\.ts$/, ".js")}";`)
+  .join("\n");
+writeFileSync("dist/index.js", `${imports}\n`);
+
+console.log(`✅ Wrote dist/index.js with ${functionFiles.length} registration import(s)`);

--- a/packages/web/api/package.json
+++ b/packages/web/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Azure Functions API for Kickstart web surface — LLM proxy",
   "type": "module",
-  "main": "dist/functions/*.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "node -e \"const f=require('fs');f.rmSync('dist',{recursive:true,force:true})\" && node esbuild.config.mjs",
     "build:tsc": "tsc",


### PR DESCRIPTION
## Problem

`az staticwebapp functions show` was returning `[]` — zero functions registered. Root cause: Azure Functions v4 Node.js runtime silently ignores globs in `package.json` "main". Our current `"main": "dist/functions/*.js"` meant no registrations ever loaded.

## Fix

- **esbuild** now emits a single `dist/index.js` alongside the per-function bundles. It contains one static `import "./functions/<name>.js"` per function file, generated from the same source list used for entry points — so new functions are picked up automatically.
- **package.json** `main` changed from `dist/functions/*.js` → `dist/index.js`.

The runtime now loads the aggregator, which triggers every `app.http()` side-effect registration.

## Verification

- `npm run build -w @kickstart/api` → produces `dist/index.js` with 20 imports (confirmed via `cat`).
- Full `npm run build` → passes.
- `npx vitest run` → 766 passed, 0 failed.

Closes #820

Working as Bender (Backend Dev)