### PR TITLE
fix(api): add Azure Functions register-all entrypoint

### DIFF
--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -15,10 +15,12 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HARNESS_SRC = resolve(__dirname, "../../harness/src");
 
-const entryPoints = readdirSync("src/functions")
+const functionEntryPoints = readdirSync("src/functions")
   .filter((f) => f.endsWith(".ts"))
   .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"))
   .map((f) => join("src/functions", f));
+
+const entryPoints = ["src/register-all.ts", ...functionEntryPoints];
 
 // esbuild's `alias` option does not handle subpath exports like
 // `@kickstart/harness/runtime/sse`. A resolver plugin rewrites both the
@@ -38,7 +40,7 @@ const harnessResolver = {
 await esbuild.build({
   entryPoints,
   bundle: true,
-  outdir: "dist/functions",
+  outdir: "dist",
   format: "esm",
   platform: "node",
   target: "node20",
@@ -47,4 +49,6 @@ await esbuild.build({
   plugins: [harnessResolver],
 });
 
-console.log(`✅ Bundled ${entryPoints.length} function(s) to dist/functions/`);
+console.log(
+  `✅ Bundled ${functionEntryPoints.length} function(s) plus register-all.js`,
+);

--- a/packages/web/api/package.json
+++ b/packages/web/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Azure Functions API for Kickstart web surface — LLM proxy",
   "type": "module",
-  "main": "dist/functions/*.js",
+  "main": "dist/register-all.js",
   "scripts": {
     "build": "node -e \"const f=require('fs');f.rmSync('dist',{recursive:true,force:true})\" && node esbuild.config.mjs",
     "build:tsc": "tsc",

--- a/packages/web/api/src/register-all.ts
+++ b/packages/web/api/src/register-all.ts
@@ -1,0 +1,21 @@
+// Azure Functions v4 entry point — imports all function registrations.
+import "./functions/action.js";
+import "./functions/arm-proxy.js";
+import "./functions/azure-deployments.js";
+import "./functions/azure-target.js";
+import "./functions/converse.js";
+import "./functions/cost-estimate.js";
+import "./functions/deploy-cost-gate.js";
+import "./functions/generate.js";
+import "./functions/github-auth.js";
+import "./functions/github-oauth.js";
+import "./functions/github-proxy.js";
+import "./functions/github-pulls.js";
+import "./functions/github-repos.js";
+import "./functions/health.js";
+import "./functions/inspirations.js";
+import "./functions/packs.js";
+import "./functions/playground.js";
+import "./functions/pricing-proxy.js";
+import "./functions/resume.js";
+import "./functions/widget-inspirations.js";


### PR DESCRIPTION
Related to #820 (already closed).

Working as Bender (Backend Dev)

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Summary
- add a single Azure Functions v4 entrypoint that imports every function registration
- point @kickstart/api main at dist/register-all.js so SWA has a concrete startup file
- keep per-function bundles in dist/functions while emitting the new root entrypoint

## Testing
- npm run build -w @kickstart/api
- npm run build
- npx vitest run
- npm run lint

## Docs and changeset
- [ ] Changeset added (or marked internal-only with reason)
- [ ] docs-site/docs/ updated (or N/A)
- [ ] docs/v2-implementation-brief.md updated (or N/A)
- [ ] docs/api-reference.md updated (or N/A)
- [ ] Pack docs updated (or N/A)
- [x] Tests added or covered

Internal-only reason: this fixes Azure Functions startup wiring without changing the public API surface.