### PR TITLE
fix(api): ship pack markdown assets in API bundle

### DIFF
--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -8,7 +8,7 @@
  */
 
 import * as esbuild from "esbuild";
-import { readdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,6 +19,22 @@ const entryPoints = readdirSync("src/functions")
   .filter((f) => f.endsWith(".ts"))
   .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"))
   .map((f) => join("src/functions", f));
+
+function copyMarkdownTree(sourceDir, targetDir) {
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = join(sourceDir, entry.name);
+    const targetPath = join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      mkdirSync(targetPath, { recursive: true });
+      copyMarkdownTree(sourcePath, targetPath);
+      continue;
+    }
+    if (entry.isFile() && sourcePath.endsWith(".md")) {
+      mkdirSync(dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
 
 // esbuild's `alias` option does not handle subpath exports like
 // `@kickstart/harness/runtime/sse`. A resolver plugin rewrites both the
@@ -53,3 +69,25 @@ await esbuild.build({
 });
 
 console.log(`✅ Bundled ${entryPoints.length} function(s) to dist/functions/`);
+
+// Pack agent/skill markdown is loaded at runtime from agentsDir/skillsDir URLs.
+// After bundling, those URLs resolve relative to dist/, so copy the markdown
+// assets into the exact locations the bundle will read from.
+const bundleAssetCopies = [
+  ["../../pack-core/src/agents", "dist/functions/agents"],
+  ["../../pack-core/src/skills", "dist/functions/skills"],
+  ["../../pack-azure/src/agents", "dist/functions/agents"],
+  ["../../pack-azure/src/skills", "dist/functions/skills"],
+  ["../../pack-aks-automatic/src/agents", "dist/functions/agents"],
+  ["../../pack-aks-automatic/src/skills", "dist/functions/skills"],
+  ["../../pack-github/agents", "dist/agents"],
+  ["../../pack-github/skills", "dist/skills"],
+];
+
+for (const [sourceRelative, targetRelative] of bundleAssetCopies) {
+  const sourceDir = resolve(__dirname, sourceRelative);
+  if (!statSync(sourceDir).isDirectory()) {
+    throw new Error(`Expected asset directory at ${sourceDir}`);
+  }
+  copyMarkdownTree(sourceDir, resolve(__dirname, targetRelative));
+}

--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -9,7 +9,7 @@
 
 import * as esbuild from "esbuild";
 import { copyFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -20,16 +20,33 @@ const entryPoints = readdirSync("src/functions")
   .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".spec.ts"))
   .map((f) => join("src/functions", f));
 
-function copyMarkdownTree(sourceDir, targetDir) {
+const RUNTIME_ASSET_MATCHERS = [
+  (filePath) => filePath.endsWith(".agent.md"),
+  (filePath) => basename(filePath) === "SKILL.md",
+];
+
+function isRuntimeAsset(filePath) {
+  return RUNTIME_ASSET_MATCHERS.some((matcher) => matcher(filePath));
+}
+
+function copyMarkdownTree(sourceDir, targetDir, seenTargets) {
   for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
     const sourcePath = join(sourceDir, entry.name);
     const targetPath = join(targetDir, entry.name);
     if (entry.isDirectory()) {
       mkdirSync(targetPath, { recursive: true });
-      copyMarkdownTree(sourcePath, targetPath);
+      copyMarkdownTree(sourcePath, targetPath, seenTargets);
       continue;
     }
-    if (entry.isFile() && sourcePath.endsWith(".md")) {
+    if (entry.isFile() && isRuntimeAsset(sourcePath)) {
+      const targetKey = relative(__dirname, targetPath).replace(/\\/g, "/");
+      const previousSource = seenTargets.get(targetKey);
+      if (previousSource && previousSource !== sourcePath) {
+        throw new Error(
+          `Runtime asset collision for ${targetKey}: ${previousSource} conflicts with ${sourcePath}`,
+        );
+      }
+      seenTargets.set(targetKey, sourcePath);
       mkdirSync(dirname(targetPath), { recursive: true });
       copyFileSync(sourcePath, targetPath);
     }
@@ -84,10 +101,12 @@ const bundleAssetCopies = [
   ["../../pack-github/skills", "dist/skills"],
 ];
 
+const seenBundleTargets = new Map();
+
 for (const [sourceRelative, targetRelative] of bundleAssetCopies) {
   const sourceDir = resolve(__dirname, sourceRelative);
   if (!statSync(sourceDir).isDirectory()) {
     throw new Error(`Expected asset directory at ${sourceDir}`);
   }
-  copyMarkdownTree(sourceDir, resolve(__dirname, targetRelative));
+  copyMarkdownTree(sourceDir, resolve(__dirname, targetRelative), seenBundleTargets);
 }


### PR DESCRIPTION
## Summary
- copy pack \.agent.md and SKILL.md assets into the API dist paths implied by bundled import.meta.url
- fix the runtime failure where /api/converse boots without core.triage or throws on missing pack asset directories
- keep the change focused to @kickstart/api packaging only

## Testing
- npm run build -w @kickstart/api
- verified built bundle contains markdown assets in dist/functions/{agents,skills} and dist/{agents,skills}

## Docs and changeset
- [ ] Changeset added (or marked internal-only with reason)
- [ ] docs-site/docs/ updated (or N/A)
- [ ] docs/v2-implementation-brief.md updated (or N/A)
- [ ] docs/api-reference.md updated (or N/A)
- [ ] Pack docs updated (or N/A)
- [x] Tests added or covered

Internal-only reason: this is production packaging glue for the existing harness/pack runtime; no public API contract changes.