### PR TITLE
feat: add docs sweep ceremony (#813)

### DIFF
--- a/.github/workflows/squad-weekly-pulse.yml
+++ b/.github/workflows/squad-weekly-pulse.yml
@@ -32,7 +32,9 @@ jobs:
             const log = fs.existsSync('.squad/retro-log.md')
               ? fs.readFileSync('.squad/retro-log.md', 'utf8')
               : '';
-            const briefPath = 'docs/v2-implementation-brief.md';
+            const briefPath = fs.existsSync('docs-site/docs/architecture/v2-implementation-brief.md')
+              ? 'docs-site/docs/architecture/v2-implementation-brief.md'
+              : 'docs/v2-implementation-brief.md';
             const brief = fs.existsSync(briefPath)
               ? fs.readFileSync(briefPath, 'utf8')
               : '';
@@ -47,7 +49,7 @@ jobs:
               : 0;
             const briefFreshness = lastUpdated
               ? `**${weeksSinceBriefUpdate} week(s)** since brief update (${lastUpdated}) · **${packagesChurn}** commit(s) touching \`packages/\` since then`
-              : 'Missing `Last updated:` field in `docs/v2-implementation-brief.md`';
+              : 'Missing `Last updated:` field in `docs-site/docs/architecture/v2-implementation-brief.md`';
 
             const lines = log.split('\n').filter(l => /^- \d{4}-\d{2}-\d{2} \| #\d+/.test(l));
             const weekLines = lines.filter(l => {

--- a/.github/workflows/squad-weekly-pulse.yml
+++ b/.github/workflows/squad-weekly-pulse.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Build weekly body
         id: build
@@ -25,10 +27,27 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { execSync } = require('child_process');
             const weekStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
             const log = fs.existsSync('.squad/retro-log.md')
               ? fs.readFileSync('.squad/retro-log.md', 'utf8')
               : '';
+            const briefPath = 'docs/v2-implementation-brief.md';
+            const brief = fs.existsSync(briefPath)
+              ? fs.readFileSync(briefPath, 'utf8')
+              : '';
+            const lastUpdatedMatch = brief.match(/^\*\*Last updated:\*\*\s+([0-9]{4}-[0-9]{2}-[0-9]{2})$/m);
+            const lastUpdated = lastUpdatedMatch?.[1] || null;
+            const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+            const weeksSinceBriefUpdate = lastUpdated
+              ? Math.floor((Date.now() - new Date(`${lastUpdated}T00:00:00Z`).getTime()) / MS_PER_WEEK)
+              : null;
+            const packagesChurn = lastUpdated
+              ? parseInt(execSync(`git rev-list --count --since='${lastUpdated}T00:00:00Z' HEAD -- packages`, { encoding: 'utf8' }).trim(), 10)
+              : 0;
+            const briefFreshness = lastUpdated
+              ? `**${weeksSinceBriefUpdate} week(s)** since brief update (${lastUpdated}) · **${packagesChurn}** commit(s) touching \`packages/\` since then`
+              : 'Missing `Last updated:` field in `docs/v2-implementation-brief.md`';
 
             const lines = log.split('\n').filter(l => /^- \d{4}-\d{2}-\d{2} \| #\d+/.test(l));
             const weekLines = lines.filter(l => {
@@ -66,6 +85,7 @@ jobs:
               `- Closed without merge: **${closed}**`,
               `- Median review time: **${medianReview}m**`,
               `- Size mix: S=${sizes.S} · M=${sizes.M} · L=${sizes.L} · XL=${sizes.XL}`,
+              `- Brief freshness: ${briefFreshness}`,
               '',
               '### PRs this week',
               weekLines.length ? weekLines.join('\n') : '_No closed PRs._',

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -161,7 +161,7 @@ This protocol applies to all agents (squad members AND @copilot). It is enforced
 
 **Checklist:**
 1. Broken links across repo docs and docs-site
-2. Brief freshness: compare `Last updated:` in `docs/v2-implementation-brief.md` against recent `packages/` churn
+2. Brief freshness: compare `Last updated:` in `docs-site/docs/architecture/v2-implementation-brief.md` against recent `packages/` churn
 3. Pack-page completeness: each active pack page still lists current agents, skills, tools, user actions, components, guardrails, and dependencies
 4. Charter relevance: role boundaries and owned artifacts still match current workflows
 5. Skill accuracy: workflow-facing skills still match the real repo layout and ceremony gates

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -9,6 +9,7 @@ Ceremonies are structured team interactions that the Squad coordinator triggers 
 | Design Proposal | auto | before work | Leela | assigned agent | ✅ Blocks implementation until DP posted |
 | Design Review | auto | before code | Leela | Zapp, Nibbler, all-relevant | ✅ Blocks code until approved |
 | PR Review Gate | auto | before merge | Nibbler | Leela (architecture), Zapp (security), Hermes (tests) | ✅ Blocks merge until all feedback addressed |
+| Docs Sweep | auto | monthly | Scribe | all-relevant | ❌ Freshness audit, not blocking |
 | Retrospective | auto | after failure | Leela | Nibbler, all-involved | ❌ Diagnostic, not blocking |
 
 ## Automated workflows (not coordinator ceremonies)
@@ -141,6 +142,31 @@ This protocol applies to all agents (squad members AND @copilot). It is enforced
 2. Root cause analysis
 3. What should change? (concrete, testable)
 4. Open a `process` issue for each action item → daily pulse tracks them
+
+---
+
+## Docs Sweep
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | auto |
+| **When** | monthly |
+| **Condition** | first docs hygiene pass of the month, or manual trigger when docs drift is suspected |
+| **Facilitator** | Scribe |
+| **Participants** | all-relevant |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Goal:** Catch silent docs rot before it lands in charters, skills, the brief, or docs-site pages.
+
+**Checklist:**
+1. Broken links across repo docs and docs-site
+2. Brief freshness: compare `Last updated:` in `docs/v2-implementation-brief.md` against recent `packages/` churn
+3. Pack-page completeness: each active pack page still lists current agents, skills, tools, user actions, components, guardrails, and dependencies
+4. Charter relevance: role boundaries and owned artifacts still match current workflows
+5. Skill accuracy: workflow-facing skills still match the real repo layout and ceremony gates
+
+**Output:** Scribe records findings in the current pulse issue or opens focused `process` issues when drift needs follow-up work.
 
 ---
 

--- a/docs-site/docs/architecture/v2-implementation-brief.md
+++ b/docs-site/docs/architecture/v2-implementation-brief.md
@@ -7,7 +7,6 @@ sidebar_position: 6
 **Last updated:** 2026-04-20
 
 **Audience:** the implementing agent.
-**Last updated:** 2026-04-20
 **Status:** ✅ All 13 steps merged into `v2-rewrite`. Implementation complete.
 **Scope:** greenfield rewrite on `main`. v1 does not need to keep working. Delete aggressively. No user state to preserve.
 

--- a/docs-site/docs/architecture/v2-implementation-brief.md
+++ b/docs-site/docs/architecture/v2-implementation-brief.md
@@ -7,6 +7,7 @@ sidebar_position: 6
 **Last updated:** 2026-04-20
 
 **Audience:** the implementing agent.
+**Last updated:** 2026-04-20
 **Status:** ✅ All 13 steps merged into `v2-rewrite`. Implementation complete.
 **Scope:** greenfield rewrite on `main`. v1 does not need to keep working. Delete aggressively. No user state to preserve.
 


### PR DESCRIPTION
Closes #813

Working as Leela (Lead)

## Summary
- add the monthly Docs Sweep ceremony and checklist to ceremonies.md
- add a Last updated field to the v2 implementation brief
- surface brief freshness in the weekly pulse using package churn since the last brief update

## Follow-up
- #831 tracks monthly Docs Sweep automation after docs consolidation lands

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)