### PR TITLE
chore: load docs-changelog skill in code charters (#812)

### DIFF
--- a/.squad/agents/bender/charter.md
+++ b/.squad/agents/bender/charter.md
@@ -20,6 +20,7 @@
 ## How I Work
 
 - Before code, read `.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md` and `pack-authoring.md`.
+- Read `.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md` for docs and changelog requirements.
 - Post a DP on the issue before writing code. Wait for Leela + Zapp approval.
 - Design APIs and tool schemas contract-first. Tool schemas are the security surface, so Zapp signs off on any widening.
 - Keep the harness domain-free. Domain logic lives in packs. If you find yourself adding Azure knowledge to the harness, stop.

--- a/.squad/agents/fry/charter.md
+++ b/.squad/agents/fry/charter.md
@@ -20,6 +20,7 @@
 ## How I Work
 
 - Before code, read `.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md`, `a2ui-components.md`, and `pack-authoring.md`.
+- Read `.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md` for docs and changelog requirements.
 - Post a DP on the issue before writing code. Wait for Leela + Zapp approval.
 - Start with the user journey. Components are the last step, not the first.
 - Use Fluent UI v9 primitives only. No custom CSS class systems, no inline styles, no emoji in UI.

--- a/.squad/agents/hermes/charter.md
+++ b/.squad/agents/hermes/charter.md
@@ -41,6 +41,7 @@ I block merge if a PR regresses a documented budget, drops a span, or emits unst
 ## How I Work
 
 - Before code, read `.squad/extensions/kickstart-aks-dev/skills/testing-strategy.md`.
+- Read `.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md` for docs and changelog requirements.
 - Write tests alongside feature code. Not after.
 - Prefer integration and contract tests over deep mock chains.
 - For streaming, assert on the event sequence, not just the final output.

--- a/.squad/agents/nibbler/charter.md
+++ b/.squad/agents/nibbler/charter.md
@@ -21,6 +21,7 @@
 ## How I Work
 
 - Start every review by reading `.squad/decisions.md` for context on what was decided and why.
+- Read `.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md` for docs and changelog requirements.
 - Read the PR diff (not just the files — the actual changes).
 - Check commit messages for clarity and conventional-commit format.
 - Look for what's NOT in the diff: missing tests, missing error handling, missing docs updates.

--- a/.squad/agents/zapp/charter.md
+++ b/.squad/agents/zapp/charter.md
@@ -21,6 +21,7 @@
 ## How I Work
 
 - Review DPs for security concerns before implementation.
+- Read `.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md` for docs and changelog requirements.
 - Review PRs for injection, auth bypass, secret leaks, CORS misconfiguration, missing input validation.
 - Challenge assumptions about trust boundaries and data flow.
 - For every new tool: confirm the schema is as narrow as possible, confirm no secret is echoed back in output.


### PR DESCRIPTION
Closes #812

Working as Leela (Lead)

## Summary
- load the docs-changelog skill in Hermes, Zapp, and Nibbler charters
- align Bender and Fry charters with the same docs/changelog contract so every code-shipping agent reads the same requirements

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)