### PR TITLE
chore: extend retros with slo trip triggers (#808)

### DIFF
--- a/.github/workflows/squad-weekly-pulse.yml
+++ b/.github/workflows/squad-weekly-pulse.yml
@@ -29,6 +29,11 @@ jobs:
             const log = fs.existsSync('.squad/retro-log.md')
               ? fs.readFileSync('.squad/retro-log.md', 'utf8')
               : '';
+            const gradedLabels = new Map([
+              ['process:succeeded', '✅ succeeded'],
+              ['process:no-effect', '🟡 no effect'],
+              ['process:reverted', '🔴 reverted'],
+            ]);
 
             const lines = log.split('\n').filter(l => /^- \d{4}-\d{2}-\d{2} \| #\d+/.test(l));
             const weekLines = lines.filter(l => {
@@ -56,6 +61,25 @@ jobs:
               if (m && sizes[m[1]] !== undefined) sizes[m[1]]++;
             });
 
+            const processIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              labels: 'process',
+              since: weekStart.toISOString(),
+              per_page: 100,
+            });
+            const gradedExperiments = processIssues
+              .filter((item) => !item.pull_request)
+              .map((item) => {
+                const label = item.labels
+                  .map((entry) => typeof entry === 'string' ? entry : entry.name)
+                  .find((name) => gradedLabels.has(name));
+                if (!label) return null;
+                return `- ${gradedLabels.get(label)} — #${item.number} "${item.title}"`;
+              })
+              .filter(Boolean);
+
             const body = [
               '**Working as Scribe** · see `.squad/agents/scribe/charter.md`',
               '',
@@ -69,6 +93,9 @@ jobs:
               '',
               '### PRs this week',
               weekLines.length ? weekLines.join('\n') : '_No closed PRs._',
+              '',
+              '### Process experiments graded this week',
+              gradedExperiments.length ? gradedExperiments.join('\n') : '_No graded process experiments this week._',
               '',
               '### Prompt for the team',
               '> Anything we should change?',

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -130,7 +130,7 @@ This protocol applies to all agents (squad members AND @copilot). It is enforced
 |-------|-------|
 | **Trigger** | auto |
 | **When** | after |
-| **Condition** | build failure, test failure, or reviewer rejection |
+| **Condition** | build failure, test failure, reviewer rejection, or any quality SLO in `.squad/velocity.md` turning 🔴 |
 | **Facilitator** | Leela |
 | **Participants** | all-involved, Nibbler for code quality analysis |
 | **Time budget** | focused |
@@ -138,9 +138,10 @@ This protocol applies to all agents (squad members AND @copilot). It is enforced
 
 **Agenda:**
 1. What happened? (facts only)
-2. Root cause analysis
-3. What should change? (concrete, testable)
-4. Open a `process` issue for each action item → daily pulse tracks them
+2. If an SLO tripped, inspect the latest `.squad/velocity.md` snapshot, name the breached metric, and compare it with the prior 4-week trend plus the relevant retro-log / pulse evidence
+3. Root cause analysis
+4. What should change? (concrete, testable)
+5. Open a `process` issue for each action item → daily pulse tracks them
 
 ---
 


### PR DESCRIPTION
Closes #808

Working as Leela (Lead)

## Summary
- trigger the Retrospective ceremony when any quality SLO in .squad/velocity.md turns red
- document how retros investigate SLO breaches using the latest velocity snapshot and recent pulse evidence
- add a weekly pulse section for process experiments graded this week from process:* outcome labels

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)