### PR TITLE
docs: add docs review checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Changes
+
+- <!-- change 1 -->
+
+## Testing
+
+- [ ] Not needed (docs-only)
+- [ ] Verified locally
+
+## Docs review checklist
+
+Complete this section for docs-only PRs or PRs with meaningful documentation updates. Reviewers may add `docs:ready` when every required item is checked.
+
+- [ ] Links validated (including anchors)
+- [ ] Code blocks use language tags and examples match the current repo layout
+- [ ] Cross-references updated
+- [ ] No stale paths or outdated package/file references
+
+## Docs and changeset
+
+- [ ] Changeset added
+- [ ] Internal-only or docs-only (no changeset needed)

--- a/DOCS_REVIEW_CHECKLIST.md
+++ b/DOCS_REVIEW_CHECKLIST.md
@@ -1,0 +1,20 @@
+# Docs Review Checklist
+
+Use this checklist for documentation-only PRs and mixed PRs with meaningful docs updates. If every required item passes, reviewers can add the `docs:ready` label and fast-track the PR for an expedited merge target of 5–10 minutes.
+
+## Required checks
+
+- [ ] **Links validated** — internal links resolve, external links are intentional, and anchors point at real headings.
+- [ ] **Examples are runnable** — code fences include language tags and the commands or snippets match the current repo layout.
+- [ ] **Cross-references updated** — related pages, README links, and extension/contributing references still point at the canonical docs surface.
+- [ ] **No stale paths** — file paths, package names, and doc targets match the current repository structure (especially redirect-sensitive paths called out in #393).
+
+## Reviewer notes
+
+- Use `docs-site/docs/` as the canonical source for product and contributor docs unless the change is explicitly for a root-level reference file.
+- Treat `docs/` as redirect or compatibility surface unless the PR is intentionally updating a root-level stub.
+- If any item fails, leave the PR unlabeled until the author updates the docs.
+
+## `docs:ready` label rule
+
+Add `docs:ready` when all required checks pass and the PR does not need deeper architecture, security, or runtime review.


### PR DESCRIPTION
Closes #782

## Summary
Adds a lightweight docs review checklist so compliant documentation PRs can be fast-tracked and labeled `docs:ready`.

## Changes
- add `DOCS_REVIEW_CHECKLIST.md` with required review criteria and label guidance
- add a docs checklist section to the PR template for docs-heavy PRs

## Testing
- Not needed (docs-only)

## Docs and changeset
- [ ] Changeset added
- [x] Internal-only or docs-only (no changeset needed)
