### PR TITLE
refactor: consolidate docs into docs-site (#811)

### DIFF
--- a/.github/workflows/squad-docs-gate.yml
+++ b/.github/workflows/squad-docs-gate.yml
@@ -35,7 +35,7 @@ jobs:
 
             const hasChangeset = paths.some(p => p.startsWith('.changeset/') && p.endsWith('.md') && !p.endsWith('README.md'));
             const hasDocsSite = paths.some(p => p.startsWith('docs-site/docs/'));
-            const hasApiRef = paths.some(p => p === 'docs/api-reference.md');
+            const hasApiDocs = paths.some(p => p === 'docs-site/docs/extending/api-endpoints.md');
 
             // User-facing signal: touches packages/** src but is not test/config only
             const userFacing = paths.some(p =>
@@ -48,7 +48,7 @@ jobs:
 
             core.setOutput('hasChangeset', String(hasChangeset));
             core.setOutput('hasDocsSite', String(hasDocsSite));
-            core.setOutput('hasApiRef', String(hasApiRef));
+            core.setOutput('hasApiDocs', String(hasApiDocs));
             core.setOutput('userFacing', String(userFacing));
 
       - name: Post or update sticky comment
@@ -56,7 +56,7 @@ jobs:
         env:
           HAS_CHANGESET: ${{ steps.changed.outputs.hasChangeset }}
           HAS_DOCS_SITE: ${{ steps.changed.outputs.hasDocsSite }}
-          HAS_API: ${{ steps.changed.outputs.hasApiRef }}
+          HAS_API: ${{ steps.changed.outputs.hasApiDocs }}
           USER_FACING: ${{ steps.changed.outputs.userFacing }}
         with:
           script: |
@@ -83,7 +83,7 @@ jobs:
               '',
               changesetLine,
               docLine(process.env.HAS_DOCS_SITE, 'docs-site/docs/', 'if user-facing behavior or UI changed'),
-              docLine(process.env.HAS_API, 'docs/api-reference.md', 'if the API surface changed'),
+              docLine(process.env.HAS_API, 'docs-site/docs/extending/api-endpoints.md', 'if the API surface changed'),
               '',
             ];
 

--- a/.squad/agents/leela/charter.md
+++ b/.squad/agents/leela/charter.md
@@ -11,7 +11,7 @@
 
 ## What I Own
 
-- High-level architecture direction, anchored in `docs/v2-implementation-brief.md`
+- High-level architecture direction, anchored in `docs-site/docs/architecture/v2-implementation-brief.md`
 - Scope and priorities — what to build next, what to defer
 - Design Proposal (DP) reviews on issues: architecture alignment, pack boundaries, primitive surface
 - PR code quality reviews
@@ -47,7 +47,7 @@
 
 Before starting work, run `git rev-parse --show-toplevel` to find the repo root. All `.squad/` paths resolve relative to it.
 
-Read `.squad/decisions.md` and `docs/v2-implementation-brief.md` before starting. Read `.squad/ceremonies.md` if the work came from an automated workflow.
+Read `.squad/decisions.md` and `docs-site/docs/architecture/v2-implementation-brief.md` before starting. Read `.squad/ceremonies.md` if the work came from an automated workflow.
 
 ## Voice
 

--- a/.squad/agents/nibbler/charter.md
+++ b/.squad/agents/nibbler/charter.md
@@ -55,7 +55,7 @@
 
 ### Architecture Alignment
 - Does the change respect pack boundaries?
-- Is the change consistent with `docs/v2-implementation-brief.md`?
+- Is the change consistent with `docs-site/docs/architecture/v2-implementation-brief.md`?
 - Does it introduce new dependencies without justification?
 
 ## Boundaries

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -56,7 +56,7 @@ All crons are UTC. `0 0 * * *` = 17:00 PDT / 16:00 PST.
 
 **Agenda:**
 1. Assigned agent drafts a Design Proposal comment on the issue
-2. Leela reviews for completeness — does it cover architecture alignment with `docs/v2-implementation-brief.md`?
+2. Leela reviews for completeness — does it cover architecture alignment with `docs-site/docs/architecture/v2-implementation-brief.md`?
 3. If incomplete, Leela requests revisions before proceeding to Design Review
 4. DP comment posted → triggers Design Review ceremony
 

--- a/.squad/extensions/kickstart-aks-dev/README.md
+++ b/.squad/extensions/kickstart-aks-dev/README.md
@@ -1,6 +1,6 @@
 # Kickstart AKS Development Extension
 
-Codifies development workflows for **Kickstart** — an AI-guided AKS onboarding app built on the `@openai/agents` SDK. Two-layer architecture: `@kickstart/harness` (runtime glue) plus packs (`pack-core`, `pack-azure`, `pack-aks-automatic`, `pack-github`). Design north star: [`docs/v2-implementation-brief.md`](../../../docs/v2-implementation-brief.md).
+Codifies development workflows for **Kickstart** — an AI-guided AKS onboarding app built on the `@openai/agents` SDK. Two-layer architecture: `@kickstart/harness` (runtime glue) plus packs (`pack-core`, `pack-azure`, `pack-aks-automatic`, `pack-github`). Design north star: [`docs-site/docs/architecture/v2-implementation-brief.md`](../../../docs-site/docs/architecture/v2-implementation-brief.md).
 
 ## Install
 

--- a/.squad/extensions/kickstart-aks-dev/directives/project-conventions.md
+++ b/.squad/extensions/kickstart-aks-dev/directives/project-conventions.md
@@ -2,7 +2,7 @@
 
 Kickstart-specific rules that override or extend the squad defaults. Every agent must read this before starting work.
 
-> **North star:** the v2 design lives in [`docs/v2-implementation-brief.md`](../../../../docs/v2-implementation-brief.md). All new code, agents, and tooling must align with the harness + packs architecture described there. If a brief section and an older convention disagree, the brief wins. Flag the conflict in a decision note.
+> **North star:** the v2 design lives in [`docs-site/docs/architecture/v2-implementation-brief.md`](../../../../docs-site/docs/architecture/v2-implementation-brief.md). All new code, agents, and tooling must align with the harness + packs architecture described there. If a brief section and an older convention disagree, the brief wins. Flag the conflict in a decision note.
 
 ---
 
@@ -27,8 +27,8 @@ Kickstart-specific rules that override or extend the squad defaults. Every agent
 ## Documentation (mandatory, not optional)
 
 - Every user-facing change updates [`docs-site/docs/`](../../../../docs-site/docs/) in the same PR. No "docs will follow" PRs.
-- Every architectural change updates or cites a section of `docs/v2-implementation-brief.md`. If the brief is wrong, update the brief in the same PR.
-- Public API changes (HTTP endpoints, SSE event shapes, tool schemas) update [`docs/api-reference.md`](../../../../docs/api-reference.md).
+- Every architectural change updates or cites a section of `docs-site/docs/architecture/v2-implementation-brief.md`. If the brief is wrong, update the brief in the same PR.
+- Public API changes (HTTP endpoints, SSE event shapes, tool schemas) update [`docs-site/docs/extending/api-endpoints.md`](../../../../docs-site/docs/extending/api-endpoints.md).
 - Pack additions get a short page in `docs-site/docs/extending/` describing the pack's agents, skills, tools, user actions, and components.
 - See the `docs-changelog` skill for the exact checklist.
 

--- a/.squad/extensions/kickstart-aks-dev/skills/a2ui-components.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/a2ui-components.md
@@ -6,7 +6,7 @@
 
 Kickstart v2 streams UI through one mechanism: the `core.emit_ui` tool. Agents call it. The harness forwards the payload as an SSE `a2ui` event. The web client renders the payload against the registered component catalog. There is no envelope. There is no JSON parser. There is no FSM.
 
-See [`docs/v2-implementation-brief.md`](../../../../docs/v2-implementation-brief.md) sections on A2UI streaming and components.
+See [`docs-site/docs/architecture/v2-implementation-brief.md`](../../../../docs-site/docs/architecture/v2-implementation-brief.md) sections on A2UI streaming and components.
 
 ## The contract
 

--- a/.squad/extensions/kickstart-aks-dev/skills/debug-mode.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/debug-mode.md
@@ -66,7 +66,7 @@ When adding a new debug field (token counts, latency breakdowns, guardrail trace
 1. Add the field to the `debug` object in `debug-mode.ts`.
 2. Update the `DebugMetadata` type.
 3. Render it in `DebugPanel` with a "Not available" fallback.
-4. Document the field in `docs/api-reference.md`.
+4. Document the field in `docs-site/docs/extending/api-endpoints.md`.
 
 ### 6. SDK trace
 

--- a/.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/docs-changelog.md
@@ -21,7 +21,7 @@ If any answer is missing, the PR is not ready.
 | **User-facing** | new component, new pack, new SSE event, new env var, UX change | changeset + public docs update |
 | **Architectural** | new primitive, harness contract change, pack boundary shift | changeset + public docs update + brief update |
 | **Internal only** | refactor, test-only, dev tooling | no changeset required, but add a note to the PR body |
-| **Docs-only** | fixes to `docs-site/` or `docs/` | no changeset |
+| **Docs-only** | fixes to `docs-site/` (and the legacy `docs/README.md` redirect) | no changeset |
 
 ### 2. Public docs update (`docs-site/docs/`)
 
@@ -39,7 +39,7 @@ Rules:
 - Code samples must be copy-pasteable and reference the actual repo layout.
 - Use KaTeX for math. Do not use emoji in headings.
 
-### 3. Brief update (`docs/v2-implementation-brief.md`)
+### 3. Brief update (`docs-site/docs/architecture/v2-implementation-brief.md`)
 
 Update the brief when a PR changes any of:
 
@@ -70,7 +70,7 @@ Good changeset:
 Bad changeset:
 > Refactored `azure-kit.ts` to add a new streaming hook and wired it through `useStreaming.ts`.
 
-### 5. API reference (`docs/api-reference.md`)
+### 5. API reference (`docs-site/docs/extending/api-endpoints.md`)
 
 Update for any change to:
 - HTTP endpoint shape (path, request body, response body, status codes)
@@ -107,8 +107,8 @@ Paste into the PR description:
 ```md
 - [ ] Changeset added (or marked internal-only with reason)
 - [ ] `docs-site/docs/` updated (or N/A)
-- [ ] `docs/v2-implementation-brief.md` updated (or N/A)
-- [ ] `docs/api-reference.md` updated (or N/A)
+- [ ] `docs-site/docs/architecture/v2-implementation-brief.md` updated (or N/A)
+- [ ] `docs-site/docs/extending/api-endpoints.md` updated (or N/A)
 - [ ] Pack docs updated (or N/A)
 - [ ] Tests added or existing tests cover the change
 ```

--- a/.squad/extensions/kickstart-aks-dev/skills/pack-authoring.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/pack-authoring.md
@@ -6,7 +6,7 @@
 
 Kickstart v2 is a harness plus packs. The harness never contains domain knowledge. Packs are the only place where domain logic, prompts, and Azure/GitHub/AKS specifics live. This skill defines the rules for authoring them.
 
-See [`docs/v2-implementation-brief.md`](../../../../docs/v2-implementation-brief.md) for full architecture.
+See [`docs-site/docs/architecture/v2-implementation-brief.md`](../../../../docs-site/docs/architecture/v2-implementation-brief.md) for full architecture.
 
 ## Primitives and their files
 

--- a/.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md
@@ -22,7 +22,7 @@ Move the project board status to **In progress**.
 Before writing code, post a DP comment on the issue with:
 
 - Problem statement (reference the issue body)
-- Proposed approach (reference the relevant section of `docs/v2-implementation-brief.md`)
+- Proposed approach (reference the relevant section of `docs-site/docs/architecture/v2-implementation-brief.md`)
 - Files to modify or create
 - Pack boundaries affected (which pack owns which change)
 - Tool / user-action / component surface changes
@@ -83,8 +83,8 @@ gh pr create --draft \
 ## Docs and changeset
 - [ ] Changeset added (or marked internal-only with reason)
 - [ ] docs-site/docs/ updated (or N/A)
-- [ ] docs/v2-implementation-brief.md updated (or N/A)
-- [ ] docs/api-reference.md updated (or N/A)
+- [ ] docs-site/docs/architecture/v2-implementation-brief.md updated (or N/A)
+- [ ] docs-site/docs/extending/api-endpoints.md updated (or N/A)
 - [ ] Pack docs updated (or N/A)
 - [ ] Tests added or covered
 " \

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -1,6 +1,6 @@
 # Squad Team
 
-> Kickstart — AI-guided onboarding experience for deploying apps to AKS. v2 runs on `@openai/agents` SDK with a harness + packs architecture. See [`docs/v2-implementation-brief.md`](../docs/v2-implementation-brief.md).
+> Kickstart — AI-guided onboarding experience for deploying apps to AKS. v2 runs on `@openai/agents` SDK with a harness + packs architecture. See [`docs-site/docs/architecture/v2-implementation-brief.md`](../docs-site/docs/architecture/v2-implementation-brief.md).
 
 ## Coordinator
 

--- a/docs-site/docs/architecture/v2-implementation-brief.md
+++ b/docs-site/docs/architecture/v2-implementation-brief.md
@@ -1,4 +1,10 @@
+---
+sidebar_position: 6
+---
+
 # Kickstart v2 — Implementation Brief
+
+**Last updated:** 2026-04-20
 
 **Audience:** the implementing agent.
 **Status:** ✅ All 13 steps merged into `v2-rewrite`. Implementation complete.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Legacy docs directory
+
+Kickstart now uses [`docs-site/docs/`](../docs-site/docs/) as the single source of truth for user-facing and engineering documentation.
+
+Common destinations:
+
+- [Architecture overview](../docs-site/docs/architecture/overview.md)
+- [Implementation brief](../docs-site/docs/architecture/v2-implementation-brief.md)
+- [API endpoints](../docs-site/docs/extending/api-endpoints.md)
+- [Extension guide](../docs-site/docs/extending/overview.md)
+- [A2UI component authoring](../docs-site/docs/components/extending-a2ui.md)
+- [Local setup](../docs-site/docs/getting-started/local-setup.md)
+- [Deployment](../docs-site/docs/getting-started/deployment.md)
+
+Legacy paths removed from `docs/`:
+
+- `architecture.md` → [`docs-site/docs/architecture/overview.md`](../docs-site/docs/architecture/overview.md)
+- `prompt-architecture.md` → [`docs-site/docs/architecture/prompt-pipeline.md`](../docs-site/docs/architecture/prompt-pipeline.md)
+- `fsm.md` → [`docs-site/docs/architecture/fsm.md`](../docs-site/docs/architecture/fsm.md)
+- `a2ui-catalog.md` → [`docs-site/docs/architecture/a2ui-integration.md`](../docs-site/docs/architecture/a2ui-integration.md)
+- `extending.md` → [`docs-site/docs/extending/overview.md`](../docs-site/docs/extending/overview.md)
+- `api-reference.md` → [`docs-site/docs/extending/api-endpoints.md`](../docs-site/docs/extending/api-endpoints.md)
+- `integration-kits.md` → [`docs-site/docs/extending/integration-kits.md`](../docs-site/docs/extending/integration-kits.md)
+- `mcp-server.md` → [`docs-site/docs/extending/mcp-tools.md`](../docs-site/docs/extending/mcp-tools.md)
+- `extending-components.md` → [`docs-site/docs/components/extending-a2ui.md`](../docs-site/docs/components/extending-a2ui.md)
+- `deployment.md` → [`docs-site/docs/getting-started/deployment.md`](../docs-site/docs/getting-started/deployment.md)
+- `development.md` → [`docs-site/docs/getting-started/local-setup.md`](../docs-site/docs/getting-started/local-setup.md)
+- `v2-implementation-brief.md` → [`docs-site/docs/architecture/v2-implementation-brief.md`](../docs-site/docs/architecture/v2-implementation-brief.md)

--- a/docs/a2ui-catalog.md
+++ b/docs/a2ui-catalog.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/architecture/a2ui-integration).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/extending/api-endpoints).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/architecture/overview).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/getting-started/deployment).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/getting-started/local-setup).

--- a/docs/extending-components.md
+++ b/docs/extending-components.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/components/extending-a2ui).

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/extending/overview).

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/architecture/fsm).

--- a/docs/integration-kits.md
+++ b/docs/integration-kits.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/extending/integration-kits).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/extending/mcp-tools).

--- a/docs/prompt-architecture.md
+++ b/docs/prompt-architecture.md
@@ -1,1 +1,0 @@
-> This page has moved. See the [Kickstart documentation site](https://sabbour.github.io/kickstart/docs/architecture/prompt-pipeline).

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -3,10 +3,10 @@
 // Historical stubs retained here are still referenced by v1 callers in
 // mcp-server/src/tools/*, mcp-server/src/a2ui.ts, and web/api/src/lib/session-store.ts.
 // Each stub block is annotated with the pack / runtime module that will own it
-// once the remaining v1 callers are migrated; see docs/v2-implementation-brief.md §2.
+// once the remaining v1 callers are migrated; see docs-site/docs/architecture/v2-implementation-brief.md §2.
 
 // ── Phase (was an enum in v1) ────────────────────────────────────────────────
-// Canonical order per docs/v2-implementation-brief.md §2:
+// Canonical order per docs-site/docs/architecture/v2-implementation-brief.md §2:
 // Discover → Design → Generate → Review → Handoff → Deploy
 export const Phase = {
   Discover: 'discover',


### PR DESCRIPTION
Closes #811

Working as Leela (Lead)

## Summary
- move the v2 implementation brief into docs-site so architecture guidance lives in the canonical docs tree
- collapse the legacy docs directory to a single README redirect map instead of maintaining duplicate stubs
- update docs gate automation, squad skills, conventions, and charters to point at canonical docs-site paths

## Validation
- npm run lint
- npm test
- npm --prefix docs-site ci
- npm --prefix docs-site run build

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)