### PR TITLE
feat: Process grader workflow (close the learning loop)

### DIFF
--- a/.github/ISSUE_TEMPLATE/process-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/process-improvement.yml
@@ -1,0 +1,87 @@
+name: Process Improvement
+description: Propose a measurable process experiment with an expiry and grading target.
+title: "[Process]: "
+labels: ["squad", "process"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Process Improvement Experiment
+        Process issues must be measurable and reversible. Fill in the hypothesis block so the grader workflow can evaluate the experiment on the revisit date.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: What recurring delivery or quality problem are you trying to change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Hypothesis
+      description: State the proposed process change as a testable hypothesis.
+      placeholder: "If we do X, then Y should improve because Z."
+    validations:
+      required: true
+
+  - type: input
+    id: signal
+    attributes:
+      label: Signal
+      description: Metric name from `.squad/velocity.md` to track.
+      placeholder: "Rework rate"
+    validations:
+      required: true
+
+  - type: input
+    id: baseline
+    attributes:
+      label: Baseline
+      description: Starting value before the experiment.
+      placeholder: "24.0%"
+    validations:
+      required: true
+
+  - type: input
+    id: target
+    attributes:
+      label: Target
+      description: Goal the experiment must hit.
+      placeholder: "<= 20%"
+    validations:
+      required: true
+
+  - type: input
+    id: revisit-date
+    attributes:
+      label: Revisit date
+      description: Date the experiment must be graded (YYYY-MM-DD).
+      placeholder: "2026-05-04"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must happen for the experiment to be considered implemented?
+      placeholder: |
+        - [ ] Workflow or rule change lands
+        - [ ] Owners know how to follow it
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Add the following block to the issue body so automation can parse it:
+
+        ```
+        Hypothesis: <copy from the field above>
+        Signal: <copy from the field above>
+        Baseline: <copy from the field above>
+        Target: <copy from the field above>
+        Revisit date: <copy from the field above>
+        ```

--- a/.github/workflows/squad-process-grader.yml
+++ b/.github/workflows/squad-process-grader.yml
@@ -1,0 +1,290 @@
+name: Squad · Process Grader
+
+# Every day, grade due process experiments against the latest velocity snapshot.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  grade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Grade due process issues
+        id: grade
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const VELOCITY_PATH = '.squad/velocity.md';
+            const DECISIONS_DIR = '.squad/decisions/inbox';
+            const GRADE_LABELS = ['process:succeeded', 'process:no-effect', 'process:reverted'];
+            const TODAY = new Date().toISOString().slice(0, 10);
+
+            if (!fs.existsSync(VELOCITY_PATH)) {
+              core.setFailed('Missing .squad/velocity.md. Merge the velocity report workflow first.');
+              return;
+            }
+
+            const velocityText = fs.readFileSync(VELOCITY_PATH, 'utf8');
+            const latestSnapshot = velocityText.match(/## Snapshot · (\d{4}-\d{2}-\d{2})[\s\S]*?(?=\n## Snapshot · |$)/);
+            if (!latestSnapshot) {
+              core.setFailed('Unable to parse the latest velocity snapshot.');
+              return;
+            }
+
+            const snapshotDate = latestSnapshot[1];
+            const snapshotBody = latestSnapshot[0];
+            const medianThroughput = snapshotBody.match(/Median throughput: \*\*(\d+(?:\.\d+)?)\*\* size-points\/week/);
+            const qualityPanel = snapshotBody.match(/### Quality SLO panel\s*\n([\s\S]*?)(?:\n### |\n## |\n---|$)/);
+
+            const metrics = {};
+            if (medianThroughput) {
+              metrics['median throughput'] = { value: Number.parseFloat(medianThroughput[1]), unit: 'pts/wk' };
+            }
+            if (qualityPanel) {
+              for (const line of qualityPanel[1].split('\n')) {
+                const row = line.match(/^\| ([^|]+) \| ([^|]+) \|/);
+                if (!row) continue;
+                const signal = row[1].trim().toLowerCase();
+                const actual = row[2].trim();
+                const numeric = actual.match(/-?\d+(?:\.\d+)?/);
+                if (!numeric) continue;
+                metrics[signal] = {
+                  value: Number.parseFloat(numeric[0]),
+                  unit: actual.includes('%') ? '%' : '',
+                };
+              }
+            }
+
+            const normalizeSignal = (signal) => signal.trim().toLowerCase();
+            const parseField = (body, label) => {
+              const inline = body.match(new RegExp(`^${label}:\\s*(.+)$`, 'mi'));
+              if (inline) return inline[1].trim();
+              const section = body.match(new RegExp(`^###\\s+${label}\\s*$\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`, 'mi'));
+              return section ? section[1].trim() : null;
+            };
+            const replaceField = (body, label, value) => {
+              if (new RegExp(`^${label}:\\s*.+$`, 'mi').test(body)) {
+                return body.replace(new RegExp(`^${label}:\\s*.+$`, 'mi'), `${label}: ${value}`);
+              }
+              if (new RegExp(`^###\\s+${label}\\s*$`, 'mi').test(body)) {
+                return body.replace(
+                  new RegExp(`(^###\\s+${label}\\s*$\\n+)([\\s\\S]*?)(?=\\n###\\s+|$)`, 'mi'),
+                  `$1${value}\n`
+                );
+              }
+              return body;
+            };
+            const parseTarget = (text) => {
+              const match = text.match(/^(<=|>=|<|>)\s*(-?\d+(?:\.\d+)?)\s*(%|pts\/wk)?$/i);
+              if (!match) return null;
+              return { op: match[1], value: Number.parseFloat(match[2]), unit: (match[3] || '').toLowerCase() };
+            };
+            const parseBaseline = (text) => {
+              const match = text.match(/(-?\d+(?:\.\d+)?)/);
+              if (!match) return null;
+              return Number.parseFloat(match[1]);
+            };
+            const compare = (actual, target) => {
+              if (target.op === '<') return actual < target.value;
+              if (target.op === '<=') return actual <= target.value;
+              if (target.op === '>') return actual > target.value;
+              if (target.op === '>=') return actual >= target.value;
+              return false;
+            };
+            const betterDirection = (target) => target.op.includes('<') ? 'lower' : 'higher';
+            const epsilonFor = (unit) => unit === '%' ? 0.5 : 1;
+            const addDays = (dateText, days) => {
+              const date = new Date(`${dateText}T00:00:00Z`);
+              date.setUTCDate(date.getUTCDate() + days);
+              return date.toISOString().slice(0, 10);
+            };
+
+            const processIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'process',
+              per_page: 100,
+            });
+
+            const candidates = processIssues.filter((issue) =>
+              !issue.pull_request &&
+              !issue.labels.some((label) => {
+                const name = typeof label === 'string' ? label : label.name;
+                return name === 'process:succeeded' || name === 'process:reverted';
+              })
+            );
+
+            fs.mkdirSync(DECISIONS_DIR, { recursive: true });
+
+            const graded = [];
+            for (const issue of candidates) {
+              const signalField = parseField(issue.body || '', 'Signal');
+              const targetField = parseField(issue.body || '', 'Target');
+              const baselineField = parseField(issue.body || '', 'Baseline');
+              const revisitDate = parseField(issue.body || '', 'Revisit date');
+              const hypothesis = parseField(issue.body || '', 'Hypothesis') || issue.title;
+
+              if (!signalField || !targetField || !baselineField || !revisitDate || revisitDate > TODAY) {
+                continue;
+              }
+
+              const signal = normalizeSignal(signalField);
+              const metric = metrics[signal];
+              const target = parseTarget(targetField);
+              const baseline = parseBaseline(baselineField);
+              if (!metric || !target || baseline == null) {
+                continue;
+              }
+
+              const actual = metric.value;
+              const targetMet = compare(actual, target);
+              const direction = betterDirection(target);
+              const epsilon = epsilonFor(metric.unit || target.unit);
+              const delta = actual - baseline;
+
+              let grade = 'process:no-effect';
+              let badge = '🟡';
+              let summary = 'No material change yet. Extend the experiment by 2 weeks.';
+
+              if (targetMet) {
+                grade = 'process:succeeded';
+                badge = '✅';
+                summary = 'Target met. The experiment succeeded.';
+              } else {
+                const gotWorse = direction === 'lower'
+                  ? actual > baseline + epsilon
+                  : actual < baseline - epsilon;
+                if (gotWorse) {
+                  grade = 'process:reverted';
+                  badge = '🔴';
+                  summary = 'Signal moved the wrong way. Open a revert follow-up.';
+                }
+              }
+
+              const marker = `<!-- squad-process-grader:${snapshotDate}:${issue.number} -->`;
+              const commentBody = [
+                marker,
+                `### ${badge} Process grade (${snapshotDate})`,
+                '',
+                `- Signal: **${signalField}**`,
+                `- Baseline: **${baselineField}**`,
+                `- Actual: **${actual}${metric.unit || ''}**`,
+                `- Target: **${targetField}**`,
+                '',
+                summary,
+              ].join('\n');
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body?.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: commentBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: commentBody,
+                });
+              }
+
+              const currentLabels = issue.labels.map((label) => typeof label === 'string' ? label : label.name);
+              for (const label of GRADE_LABELS) {
+                if (label !== grade && currentLabels.includes(label)) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label,
+                  }).catch(() => {});
+                }
+              }
+              if (!currentLabels.includes(grade)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [grade],
+                });
+              }
+
+              let nextBody = issue.body || '';
+              if (grade === 'process:no-effect') {
+                const nextRevisit = addDays(revisitDate, 14);
+                nextBody = replaceField(nextBody, 'Revisit date', nextRevisit);
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: nextBody,
+                });
+              }
+
+              const decisionPath = path.join(DECISIONS_DIR, `process-grade-${issue.number}.md`);
+              const decisionBody = [
+                `# Process grade — #${issue.number}`,
+                '',
+                `**Date:** ${snapshotDate}`,
+                `**Issue:** #${issue.number}`,
+                '',
+                '## Hypothesis',
+                '',
+                hypothesis,
+                '',
+                '## Grade',
+                '',
+                `- Signal: ${signalField}`,
+                `- Baseline: ${baselineField}`,
+                `- Actual: ${actual}${metric.unit || ''}`,
+                `- Target: ${targetField}`,
+                `- Result: ${grade}`,
+                '',
+                summary,
+                '',
+                'Generated by `.github/workflows/squad-process-grader.yml` for Scribe to merge into `.squad/decisions.md`.',
+              ].join('\n');
+              fs.writeFileSync(decisionPath, decisionBody);
+
+              graded.push(`#${issue.number} → ${grade}`);
+            }
+
+            core.setOutput('graded', JSON.stringify(graded));
+            core.setOutput('has_changes', graded.length ? 'true' : 'false');
+
+      - name: Commit graded hypotheses (as Scribe)
+        if: steps.grade.outputs.has_changes == 'true'
+        run: |
+          set -e
+          git config user.name "squad-scribe[bot]"
+          git config user.email "scribe@squad.local"
+          git add -f .squad/decisions/inbox/process-grade-*.md
+          if git diff --cached --quiet; then
+            echo "No graded hypothesis files to commit."
+            exit 0
+          fi
+          git commit -m "chore(process-grader): grade process hypotheses [scribe]" -m "Working as Scribe — see .squad/agents/scribe/charter.md"
+          git push origin HEAD:${{ github.event.repository.default_branch }}

--- a/.github/workflows/sync-squad-custom-labels.yml
+++ b/.github/workflows/sync-squad-custom-labels.yml
@@ -32,6 +32,9 @@ jobs:
           script: |
             const labels = [
               { name: 'process',           color: '5319E7', description: 'Process improvement tracked by the weekly pulse' },
+              { name: 'process:succeeded', color: '0E8A16', description: 'Process experiment met its target' },
+              { name: 'process:no-effect', color: 'FBCA04', description: 'Process experiment showed no material change yet' },
+              { name: 'process:reverted',  color: 'D93F0B', description: 'Process experiment regressed and should be reverted' },
               { name: 'pulse:daily',       color: 'BFD4F2', description: 'Daily pulse rolling issue' },
               { name: 'pulse:weekly',      color: '6B8EB5', description: 'Weekly pulse issue' },
               { name: 'release',           color: '0E8A16', description: 'Release PR opened by the cadence workflow' },


### PR DESCRIPTION
Closes #805

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)

Working as Bender (Backend Dev)

## Summary
Add a daily process-grader workflow that evaluates due process experiments against the latest velocity snapshot, labels the outcome, and records the result for Scribe to merge.

## Changes
- add `.github/workflows/squad-process-grader.yml`
- add a `process-improvement` issue template with required hypothesis, signal, baseline, target, and revisit fields
- add `process:succeeded`, `process:no-effect`, and `process:reverted` labels
- grade due process issues from `.squad/velocity.md`, comment the result, extend revisit dates on no-effect, and write Scribe inbox artifacts

## Testing
- `npm test`
- workflow/template YAML parse check
- process-grader smoke test for issue parsing and revisit-date updates

## Docs and changeset
- Internal-only process automation; no package release surface changed, so no changeset
- No docs-site/API/pack docs changes required

## Notes
⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Known constraints
- The grader depends on `.squad/velocity.md` from #803; until that exists on `main`, it will fail closed with a clear message.
- Decision updates are written to Scribe inbox files for later merge into `.squad/decisions.md`.
