### PR TITLE
fix(workflow): fix weekly pulse table-format parsing

### DIFF
--- a/.github/workflows/squad-weekly-pulse.yml
+++ b/.github/workflows/squad-weekly-pulse.yml
@@ -49,9 +49,10 @@ jobs:
               ? `**${weeksSinceBriefUpdate} week(s)** since brief update (${lastUpdated}) · **${packagesChurn}** commit(s) touching \`packages/\` since then`
               : `Missing \`Last updated:\` field in \`${briefPath}\``;
 
-            const lines = log.split('\n').filter(l => /^- \d{4}-\d{2}-\d{2} \| #\d+/.test(l));
+            const retroEntryPattern = /^(?:-\s*|\|\s*)(\d{4}-\d{2}-\d{2})\s*\|/;
+            const lines = log.split('\n').filter(l => retroEntryPattern.test(l));
             const weekLines = lines.filter(l => {
-              const m = l.match(/^- (\d{4}-\d{2}-\d{2})/);
+              const m = l.match(retroEntryPattern);
               return m && new Date(m[1]).getTime() >= weekStart.getTime();
             });
 


### PR DESCRIPTION
Closes #793

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)

Working as Bender (Backend Dev)

## Summary
Fix the weekly pulse parser so it reads the repo's current retro-log row format instead of silently reporting zero weekly activity.

## Changes
- update `.github/workflows/squad-weekly-pulse.yml` to use a shared retro-entry date regex
- accept both current table-style rows and legacy list-style rows for compatibility
- preserve the existing weekly aggregation logic while fixing line discovery/date extraction

## Testing
- `npm test`
- workflow YAML parse check
- local smoke test against both legacy and table-format retro-log samples

## Docs and changeset
- Internal-only workflow bug fix; no package release surface changed, so no changeset
- No docs-site/API/pack docs changes required

## Notes
⚠️ This task was flagged as "needs review" — please have a squad member review before merging.
