### PR TITLE
fix(workflow): daily pulse fails to parse table-format retro-log

### DIFF
--- a/.github/workflows/squad-daily-pulse.yml
+++ b/.github/workflows/squad-daily-pulse.yml
@@ -33,8 +33,12 @@ jobs:
               : '';
             const today = new Date().toISOString().slice(0, 10);
             const yesterday = new Date(Date.now() - 24*60*60*1000).toISOString().slice(0, 10);
+            const retroEntryPattern = /^(?:-\s*|\|\s*)(\d{4}-\d{2}-\d{2})\s*\|/;
             const recentPrs = log.split('\n')
-              .filter(l => l.startsWith(`- ${today}`) || l.startsWith(`- ${yesterday}`))
+              .filter(l => {
+                const match = l.match(retroEntryPattern);
+                return match && (match[1] === today || match[1] === yesterday);
+              })
               .join('\n') || '_No PRs closed in the last 24h._';
 
             // Open PRs aging >3d


### PR DESCRIPTION
Closes #787

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)

Working as Bender (Backend Dev)

## Summary
Fix the daily pulse so the closed-PR section reads the repo's current retro-log row format instead of reporting an empty last-24h pulse.

## Changes
- update `.github/workflows/squad-daily-pulse.yml` to use a shared retro-entry date regex
- accept both legacy list rows and current table-style rows for compatibility
- keep the aging-PR and process-issue sections unchanged

## Testing
- `npm test -- --reporter=dot`
- workflow YAML parse check
- local smoke test against both legacy and table-format retro-log samples

## Docs and changeset
- Internal-only workflow bug fix; no package release surface changed, so no changeset
- No docs-site/API/pack docs changes required

## Notes
⚠️ This task was flagged as "needs review" — please have a squad member review before merging.
