### PR TITLE
docs: fix post-consolidation entry points

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -310,6 +310,11 @@ code — no fake data, no placeholder URLs, no pretend deployments.
 - **Ahmed Sabbour** — confirm "download project" is acceptable as #271 scope; confirm GitHub OAuth App registration goes into a follow-up issue.
 ---
 
+### 2026-04-20: `docs-site/docs/` is the canonical docs surface
+**By:** Scribe (Scribe)
+**What:** After #811, contributor guidance, release entry points, and docs automation should treat `docs-site/docs/` as the canonical docs tree and `docs-site/docs/architecture/v2-implementation-brief.md` as the canonical brief path. `docs/README.md` is the redirect map for removed legacy `docs/*` pages.
+**Why:** This keeps follow-up docs cleanup work from reintroducing dead `docs/*` paths or split-brain guidance between the docs site and top-level docs.
+
 # Decision: Issue #271 — Ship complete flow with real project delivery
 
 **Date:** 2026-04-15T08:39:29.427Z

--- a/.squad/skills/docs-canonical-surface/SKILL.md
+++ b/.squad/skills/docs-canonical-surface/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: "docs-canonical-surface"
+description: "Keep one canonical docs surface and repoint workflows when legacy docs paths are removed"
+domain: "documentation"
+confidence: "high"
+source: "earned"
+last_updated: 2026-04-20T11:30:00Z
+---
+
+## Context
+
+Use this when a repo has both a public docs site and a legacy top-level docs tree, and a cleanup needs to remove duplication without leaving broken contributor or release workflows behind.
+
+## Patterns
+
+- **Pick one canonical docs tree.** In Kickstart, `docs-site/docs/` is the source of truth for public docs and the v2 implementation brief.
+- **Keep `docs/` as a redirect map only.** Use `docs/README.md` to point old paths at their replacements instead of maintaining duplicate pages.
+- **Fix entry points in the same change.** When the brief or API docs move, update contributor guidance, release docs, and any automation that links to them before merging.
+- **Repoint workflows and skills immediately.** If a legacy path like `docs/api-reference.md` is removed, update docs gates, weekly pulse checks, and squad skills in the same sweep.
+- **Validate the docs package directly if it is not a workspace.** Use `cd docs-site && npm run build` instead of assuming a root workspace command exists.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,11 +97,13 @@ For the full release workflow — cutting releases, tagging, deploying — see *
 
 The canonical documentation lives in **`docs-site/docs/`** and is published to [sabbour.github.io/kickstart](https://sabbour.github.io/kickstart/). This is the single source of truth.
 
-**Do not edit files in `docs/`** — that directory contains redirect stubs only. All documentation updates go to `docs-site/docs/`.
+**Do not edit files in `docs/`** — that directory contains the redirect map only. All documentation updates go to `docs-site/docs/`.
 
 ### Editing docs
 
 - Docs are Markdown files in `docs-site/docs/`
+- The architecture brief lives at `docs-site/docs/architecture/v2-implementation-brief.md`
+- `docs/README.md` is the redirect map for removed legacy `docs/*` paths
 - Run the site locally: `cd docs-site && npm install && npm start`
 - New pages are auto-added to the sidebar based on directory structure and `sidebar_position` frontmatter
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,17 @@
 
 This project uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation across the monorepo.
 
+## Documentation Entry Points
+
+Before cutting a release, make sure these entry points agree:
+
+- `README.md`
+- `CHANGELOG.md`
+- `docs-site/docs/`
+- `docs-site/docs/architecture/v2-implementation-brief.md`
+
+If you fix an old `docs/*` link during release prep, update the source link or `docs/README.md` redirect map instead of recreating legacy stubs.
+
 ## How It Works
 
 1. **Contributors add changesets** alongside their code changes


### PR DESCRIPTION
Follow-up to #844 and #811.

Working as Scribe (Scribe)

## Summary
- point contributor and release entry points at the canonical docs-site brief path
- add the docs-canonical-surface skill so future sweeps repoint workflows and release docs together
- record the canonical docs surface decision directly in .squad/decisions.md

## Validation
- npm test
- npm run lint
- git diff --check

## Notes
- npm run build still fails on the current baseline because root devDependencies do not include @vitejs/plugin-react; this follow-up does not change build inputs