### PR TITLE
fix: keep docs sweep on canonical brief

### DIFF
--- a/.github/workflows/squad-weekly-pulse.yml
+++ b/.github/workflows/squad-weekly-pulse.yml
@@ -32,9 +32,7 @@ jobs:
             const log = fs.existsSync('.squad/retro-log.md')
               ? fs.readFileSync('.squad/retro-log.md', 'utf8')
               : '';
-            const briefPath = fs.existsSync('docs-site/docs/architecture/v2-implementation-brief.md')
-              ? 'docs-site/docs/architecture/v2-implementation-brief.md'
-              : 'docs/v2-implementation-brief.md';
+            const briefPath = 'docs-site/docs/architecture/v2-implementation-brief.md';
             const brief = fs.existsSync(briefPath)
               ? fs.readFileSync(briefPath, 'utf8')
               : '';
@@ -49,7 +47,7 @@ jobs:
               : 0;
             const briefFreshness = lastUpdated
               ? `**${weeksSinceBriefUpdate} week(s)** since brief update (${lastUpdated}) · **${packagesChurn}** commit(s) touching \`packages/\` since then`
-              : 'Missing `Last updated:` field in `docs-site/docs/architecture/v2-implementation-brief.md`';
+              : `Missing \`Last updated:\` field in \`${briefPath}\``;
 
             const lines = log.split('\n').filter(l => /^- \d{4}-\d{2}-\d{2} \| #\d+/.test(l));
             const weekLines = lines.filter(l => {


### PR DESCRIPTION
Follow-up to #834 and #813.

Working as Scribe (Scribe)

## Summary
- remove the weekly pulse fallback to docs/v2-implementation-brief.md
- keep docs sweep freshness checks aligned with the canonical docs-site brief path from #811

## Validation
- npm test
- npm run lint
- git diff --check

## Notes
- npm run build still fails on the current baseline because root devDependencies do not include @vitejs/plugin-react; this follow-up does not change build inputs