### PR TITLE
feat(workflow): auto-merge low-risk PR categories

### DIFF
--- a/.github/workflows/squad-auto-merge.yml
+++ b/.github/workflows/squad-auto-merge.yml
@@ -267,7 +267,6 @@ jobs:
                                   conclusion
                                   startedAt
                                   completedAt
-                                  workflowName
                                 }
                               }
                             }
@@ -362,10 +361,10 @@ jobs:
             }
 
             const rawCheckRuns = pr.commits.nodes[0]?.commit.statusCheckRollup?.contexts?.nodes ?? [];
-            const checkRuns = [...dedupeBy(rawCheckRuns.filter((node) => node?.__typename === 'CheckRun'), (node) => `${node.workflowName ?? 'unknown'}:${node.name}`).values()];
-            const ciGate = checkRuns.find((node) => node.name === 'CI Gate' && node.workflowName === 'CI');
+            const checkRuns = [...dedupeBy(rawCheckRuns.filter((node) => node?.__typename === 'CheckRun'), (node) => node.name).values()];
+            const ciGate = checkRuns.find((node) => node.name === 'CI Gate');
             if (!isSuccessfulCheckRun(ciGate)) {
-              core.info(`PR #${pr.number} does not yet have a green CI Gate check from workflow CI.`);
+              core.info(`PR #${pr.number} does not yet have a green CI Gate check.`);
               return;
             }
 

--- a/.github/workflows/squad-auto-merge.yml
+++ b/.github/workflows/squad-auto-merge.yml
@@ -28,6 +28,10 @@ jobs:
             const XL_THRESHOLD = 1000;
             const APPROVAL_LABELS = ['leela:approved', 'zapp:approved'];
             const REVIEW_GATE_CONTEXT = 'squad/review-gate';
+            const SENSITIVE_PATH_PATTERNS = [
+              /^\.github\/workflows\//i,
+              /(^|[\/._-])(auth|guardrail|guardrails|security)([\/._-]|$)/i,
+            ];
             const TRUSTED_CI_WORKFLOW = '.github/workflows/ci.yml';
             const TRUSTED_REVIEW_WORKFLOW = '.github/workflows/squad-review-gate.yml';
 
@@ -75,13 +79,35 @@ jobs:
               return /security|cve-\d{4}-\d+|ghsa-|vuln|vulnerability/i.test(securitySignals);
             }
 
-            function getRequiredApprovals(pr, labels) {
+            function isSensitivePath(filename) {
+              return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(filename));
+            }
+
+            function getZappRequirementReason(pr, labels, changedFiles) {
+              if (!labels.has(LOW_RISK_LABEL)) {
+                return 'standard review path';
+              }
+
+              if (isSecurityPatch(pr, labels)) {
+                return 'security-sensitive title/body/branch/label signal';
+              }
+
+              const sensitiveFiles = changedFiles.filter(isSensitivePath);
+              if (sensitiveFiles.length > 0) {
+                const preview = sensitiveFiles.slice(0, 3).map((file) => `\`${file}\``).join(', ');
+                return `sensitive paths touched (${preview}${sensitiveFiles.length > 3 ? ', …' : ''})`;
+              }
+
+              return null;
+            }
+
+            function getRequiredApprovals(pr, labels, changedFiles) {
               if (!labels.has(LOW_RISK_LABEL)) {
                 return [...APPROVAL_LABELS];
               }
 
               const required = ['leela:approved'];
-              if (isSecurityPatch(pr, labels)) {
+              if (getZappRequirementReason(pr, labels, changedFiles)) {
                 required.push('zapp:approved');
               }
               return required;
@@ -94,6 +120,16 @@ jobs:
                 issue_number: prNumber,
                 per_page: 100,
               });
+            }
+
+            async function listChangedFiles(prNumber) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              return files.map((file) => file.filename);
             }
 
             async function upsertAuditComment(prNumber, body, createIfMissing = true) {
@@ -257,6 +293,8 @@ jobs:
             }
 
             const labels = new Set(pr.labels.nodes.map((label) => label.name));
+            const changedFiles = await listChangedFiles(pr.number);
+            const zappRequirementReason = getZappRequirementReason(pr, labels, changedFiles);
             const removedLabels = await clearApprovalLabels(pr, labels);
             if (removedLabels.length > 0) {
               await disableAutoMerge(
@@ -290,7 +328,7 @@ jobs:
               blockers.push('PR title is marked refactor');
             }
 
-            const requiredApprovals = getRequiredApprovals(pr, labels);
+            const requiredApprovals = getRequiredApprovals(pr, labels, changedFiles);
             const missingApprovals = requiredApprovals.filter((label) => !labels.has(label));
             if (missingApprovals.length > 0) {
               blockers.push(`missing fresh approval labels: ${missingApprovals.join(', ')}`);
@@ -385,7 +423,7 @@ jobs:
                 '🤖 Auto-merge armed.',
                 '',
                 labels.has(LOW_RISK_LABEL)
-                  ? `- opt-in \`${LOW_RISK_LABEL}\` label is present and fresh ${requiredApprovals.map((label) => `\`${label}\``).join(' + ')} label${requiredApprovals.length > 1 ? 's are' : ' is'} present on the current head`
+                  ? `- opt-in \`${LOW_RISK_LABEL}\` label is present and fresh ${requiredApprovals.map((label) => `\`${label}\``).join(' + ')} label${requiredApprovals.length > 1 ? 's are' : ' is'} present on the current head${zappRequirementReason ? ` (${zappRequirementReason})` : ''}`
                   : '- fresh `leela:approved` + `zapp:approved` labels are present on the current head',
                 '- trusted merge signals are green: `CI Gate` from workflow `CI` and `squad/review-gate` from `Squad Review Gate`',
                 '- PR is not XL and title is not marked `refactor`',

--- a/.github/workflows/squad-auto-merge.yml
+++ b/.github/workflows/squad-auto-merge.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           script: |
             const AUTO_MERGE_MARKER = '<!-- squad-auto-merge -->';
+            const LOW_RISK_LABEL = 'squad:chore-auto';
             const XL_THRESHOLD = 1000;
             const APPROVAL_LABELS = ['leela:approved', 'zapp:approved'];
             const REVIEW_GATE_CONTEXT = 'squad/review-gate';
@@ -62,6 +63,28 @@ jobs:
 
             function isSuccessfulCheckRun(node) {
               return node?.status === 'COMPLETED' && node?.conclusion === 'SUCCESS';
+            }
+
+            function isSecurityPatch(pr, labels) {
+              const securitySignals = [
+                pr.title,
+                pr.body,
+                pr.headRefName,
+                ...labels,
+              ].filter(Boolean).join(' ');
+              return /security|cve-\d{4}-\d+|ghsa-|vuln|vulnerability/i.test(securitySignals);
+            }
+
+            function getRequiredApprovals(pr, labels) {
+              if (!labels.has(LOW_RISK_LABEL)) {
+                return [...APPROVAL_LABELS];
+              }
+
+              const required = ['leela:approved'];
+              if (isSecurityPatch(pr, labels)) {
+                required.push('zapp:approved');
+              }
+              return required;
             }
 
             async function listComments(prNumber) {
@@ -178,11 +201,13 @@ jobs:
                     id
                     number
                     title
+                    body
                     state
                     isDraft
                     mergeStateStatus
                     additions
                     deletions
+                    headRefName
                     headRefOid
                     autoMergeRequest {
                       enabledAt
@@ -242,7 +267,7 @@ jobs:
                   '🤖 Auto-merge disarmed.',
                   '',
                   `- removed stale approval labels: ${removedLabels.join(', ')}`,
-                  '- new commits require fresh Leela + Zapp approval labels before re-arming',
+                  '- new commits require fresh approval labels before re-arming',
                 ].join('\n'),
               );
               core.info(`Cleared stale approval labels for PR #${pr.number}: ${removedLabels.join(', ')}`);
@@ -265,8 +290,10 @@ jobs:
               blockers.push('PR title is marked refactor');
             }
 
-            if (!(labels.has('leela:approved') && labels.has('zapp:approved'))) {
-              blockers.push('missing fresh approval labels');
+            const requiredApprovals = getRequiredApprovals(pr, labels);
+            const missingApprovals = requiredApprovals.filter((label) => !labels.has(label));
+            if (missingApprovals.length > 0) {
+              blockers.push(`missing fresh approval labels: ${missingApprovals.join(', ')}`);
             }
 
             if (pr.mergeStateStatus === 'DIRTY') {
@@ -357,7 +384,9 @@ jobs:
                 AUTO_MERGE_MARKER,
                 '🤖 Auto-merge armed.',
                 '',
-                '- fresh `leela:approved` + `zapp:approved` labels are present on the current head',
+                labels.has(LOW_RISK_LABEL)
+                  ? `- opt-in \`${LOW_RISK_LABEL}\` label is present and fresh ${requiredApprovals.map((label) => `\`${label}\``).join(' + ')} label${requiredApprovals.length > 1 ? 's are' : ' is'} present on the current head`
+                  : '- fresh `leela:approved` + `zapp:approved` labels are present on the current head',
                 '- trusted merge signals are green: `CI Gate` from workflow `CI` and `squad/review-gate` from `Squad Review Gate`',
                 '- PR is not XL and title is not marked `refactor`',
                 '',

--- a/.github/workflows/squad-review-gate.yml
+++ b/.github/workflows/squad-review-gate.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
   statuses: write
 
 jobs:
@@ -15,20 +16,46 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const LOW_RISK_LABEL = 'squad:chore-auto';
+            const SENSITIVE_PATH_PATTERNS = [
+              /^\.github\/workflows\//i,
+              /(^|[\/._-])(auth|guardrail|guardrails|security)([\/._-]|$)/i,
+            ];
+
+            function isSecurityPatch(pr, labels) {
+              const securitySignals = [
+                pr.title,
+                pr.body,
+                pr.head?.ref,
+                ...labels,
+              ].filter(Boolean).join(' ');
+              return /security|cve-\d{4}-\d+|ghsa-|vuln|vulnerability/i.test(securitySignals);
+            }
+
+            function isSensitivePath(filename) {
+              return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(filename));
+            }
+
+            async function listChangedFiles(prNumber) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              return files.map((file) => file.filename);
+            }
+
             const pr = context.payload.pull_request;
             const labels = new Set(pr.labels.map((label) => label.name));
+            const changedFiles = await listChangedFiles(pr.number);
             const leelaApproved = labels.has('leela:approved');
             const zappApproved = labels.has('zapp:approved');
-            const isLowRisk = labels.has('squad:chore-auto');
-            const securitySignals = [
-              pr.title,
-              pr.body,
-              pr.head?.ref,
-              ...labels,
-            ].filter(Boolean).join(' ');
-            const isSecurityPatch = /security|cve-\d{4}-\d+|ghsa-|vuln|vulnerability/i.test(securitySignals);
+            const isLowRisk = labels.has(LOW_RISK_LABEL);
+            const touchesSensitivePaths = changedFiles.some(isSensitivePath);
+            const hasSecuritySignals = isSecurityPatch(pr, labels);
 
-            const requiresZapp = !isLowRisk || isSecurityPatch;
+            const requiresZapp = !isLowRisk || hasSecuritySignals || touchesSensitivePaths;
             const requiredApprovals = ['leela:approved'];
             if (requiresZapp) {
               requiredApprovals.push('zapp:approved');

--- a/.github/workflows/squad-review-gate.yml
+++ b/.github/workflows/squad-review-gate.yml
@@ -1,7 +1,7 @@
 name: Squad Review Gate
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [labeled, unlabeled, opened, synchronize, reopened, edited, ready_for_review]
 
 permissions:
   contents: read
@@ -15,25 +15,46 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            const leelaApproved = labels.includes('leela:approved');
-            const zappApproved = labels.includes('zapp:approved');
+            const pr = context.payload.pull_request;
+            const labels = new Set(pr.labels.map((label) => label.name));
+            const leelaApproved = labels.has('leela:approved');
+            const zappApproved = labels.has('zapp:approved');
+            const isLowRisk = labels.has('squad:chore-auto');
+            const securitySignals = [
+              pr.title,
+              pr.body,
+              pr.head?.ref,
+              ...labels,
+            ].filter(Boolean).join(' ');
+            const isSecurityPatch = /security|cve-\d{4}-\d+|ghsa-|vuln|vulnerability/i.test(securitySignals);
+
+            const requiresZapp = !isLowRisk || isSecurityPatch;
+            const requiredApprovals = ['leela:approved'];
+            if (requiresZapp) {
+              requiredApprovals.push('zapp:approved');
+            }
+
+            const missingApprovals = requiredApprovals.filter((label) => !labels.has(label));
+            const leelaStatus = leelaApproved ? '✅' : '⏳';
+            const zappStatus = zappApproved ? '✅' : (requiresZapp ? '⏳' : '➖');
 
             let state, description;
-            if (leelaApproved && zappApproved) {
+            if (missingApprovals.length === 0) {
               state = 'success';
-              description = 'Squad review gate: Leela ✅ Zapp ✅';
+              description = isLowRisk && !requiresZapp
+                ? 'Squad review gate: low-risk path Leela ✅'
+                : 'Squad review gate: Leela ✅ Zapp ✅';
             } else {
               state = 'pending';
-              const leelaStatus = leelaApproved ? '✅' : '⏳';
-              const zappStatus = zappApproved ? '✅' : '⏳';
-              description = `Squad review gate: Leela ${leelaStatus} Zapp ${zappStatus}`;
+              description = isLowRisk && !requiresZapp
+                ? `Squad review gate: low-risk path Leela ${leelaStatus}`
+                : `Squad review gate: Leela ${leelaStatus} Zapp ${zappStatus}`;
             }
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
+              sha: pr.head.sha,
               state,
               description,
               context: 'squad/review-gate'

--- a/.github/workflows/sync-squad-custom-labels.yml
+++ b/.github/workflows/sync-squad-custom-labels.yml
@@ -5,7 +5,8 @@
 # workflow lives alongside it and syncs labels that are NOT in the
 # upstream list (review gates, pulse/retro labels, release PRs, etc.).
 #
-# Same trigger and upsert pattern as sync-squad-labels.yml.
+# Same upsert pattern as sync-squad-labels.yml, but it also re-runs when this
+# workflow changes so new custom labels roll out on merge.
 
 name: Sync Squad Custom Labels
 
@@ -14,6 +15,7 @@ on:
     paths:
       - '.squad/team.md'
       - '.ai-team/team.md'
+      - '.github/workflows/sync-squad-custom-labels.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-squad-custom-labels.yml
+++ b/.github/workflows/sync-squad-custom-labels.yml
@@ -35,6 +35,7 @@ jobs:
               { name: 'pulse:daily',       color: 'BFD4F2', description: 'Daily pulse rolling issue' },
               { name: 'pulse:weekly',      color: '6B8EB5', description: 'Weekly pulse issue' },
               { name: 'release',           color: '0E8A16', description: 'Release PR opened by the cadence workflow' },
+              { name: 'squad:chore-auto',  color: 'BFDADC', description: 'Opt in low-risk PR for auto-merge when gates pass' },
               { name: 'leela:approved',    color: '0E8A16', description: 'Architecture review approved' },
               { name: 'leela:rejected',    color: 'D93F0B', description: 'Architecture review rejected' },
               { name: 'zapp:approved',     color: '0E8A16', description: 'Security review approved' },

--- a/.squad/decisions/inbox/copilot-low-risk-auto-merge-gate.md
+++ b/.squad/decisions/inbox/copilot-low-risk-auto-merge-gate.md
@@ -13,9 +13,10 @@ author: Copilot
 Add an explicit `squad:chore-auto` label and treat it as a low-risk auto-merge opt-in:
 
 - the review gate turns green with fresh `leela:approved` alone for `squad:chore-auto` PRs
-- if the PR title/body/branch/labels look security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`), `zapp:approved` is still required
+- if the PR title/body/branch/labels look security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`) or it touches sensitive paths (`.github/workflows/**`, auth, guardrail, security code), `zapp:approved` is still required
+- the custom label sync also triggers when `.github/workflows/sync-squad-custom-labels.yml` changes so new low-risk labels are created as part of the rollout merge
 - `Squad Auto Merge` reuses the same trusted CI/review-gate checks, XL exclusion, `refactor` exclusion, stale-label clearing, and audit-comment trail
 
 ## Why
 
-This keeps the fast path explicit and narrow while preserving the stronger security gate where the change hints at a patch or vulnerability fix. It also avoids creating a second auto-merge workflow with duplicate trust logic.
+This keeps the fast path explicit and narrow while preserving the stronger security gate for workflow/auth/guardrail/security changes, even when the PR text looks harmless. Triggering the custom label sync on its own workflow file also makes the rollout self-hosting instead of depending on a later team-file edit or manual dispatch.

--- a/.squad/decisions/inbox/copilot-low-risk-auto-merge-gate.md
+++ b/.squad/decisions/inbox/copilot-low-risk-auto-merge-gate.md
@@ -1,0 +1,21 @@
+---
+title: Low-risk PRs get an opt-in auto-merge gate
+date: 2026-04-20
+author: Copilot
+---
+
+## Context
+
+`Squad Auto Merge` already covered dual-approved PRs, but low-risk chore/config changes still needed the same full approval path and manual merge step. Retro data for issue #784 showed those PRs spend disproportionate time waiting after CI.
+
+## Decision
+
+Add an explicit `squad:chore-auto` label and treat it as a low-risk auto-merge opt-in:
+
+- the review gate turns green with fresh `leela:approved` alone for `squad:chore-auto` PRs
+- if the PR title/body/branch/labels look security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`), `zapp:approved` is still required
+- `Squad Auto Merge` reuses the same trusted CI/review-gate checks, XL exclusion, `refactor` exclusion, stale-label clearing, and audit-comment trail
+
+## Why
+
+This keeps the fast path explicit and narrow while preserving the stronger security gate where the change hints at a patch or vulnerability fix. It also avoids creating a second auto-merge workflow with duplicate trust logic.

--- a/.squad/issue-lifecycle.md
+++ b/.squad/issue-lifecycle.md
@@ -569,7 +569,7 @@ See `.squad/templates/ralph-reference.md` for Ralph's full lifecycle.
 If the project has no human reviewers configured:
 1. PR opens
 2. CI runs
-3. If CI passes, Ralph (or the `Squad Auto Merge` workflow for dual-approved non-XL/non-`refactor` PRs) auto-merges
+3. If CI passes, Ralph (or the `Squad Auto Merge` workflow for qualifying non-XL/non-`refactor` PRs, including opt-in `squad:chore-auto` PRs) auto-merges
 4. Issue closes
 
 ### Human Review Required
@@ -578,7 +578,7 @@ If the project requires human approval:
 1. PR opens
 2. Human reviewer is notified (GitHub/ADO notifications)
 3. Reviewer approves or requests changes
-4. If approved + CI passes, Ralph merges (or the `Squad Auto Merge` workflow arms squash auto-merge for dual-approved non-XL/non-`refactor` PRs)
+4. If approved + CI passes, Ralph merges (or the `Squad Auto Merge` workflow arms squash auto-merge for dual-approved PRs and opt-in `squad:chore-auto` low-risk PRs that satisfy the review gate)
 5. If changes requested, agent addresses feedback
 
 ### Squad Member Review

--- a/.squad/skills/pr-workflow/SKILL.md
+++ b/.squad/skills/pr-workflow/SKILL.md
@@ -201,7 +201,7 @@ Zapp's review is a **pre-merge gate** for foundational patterns. Do not merge wi
   gh pr edit {number} --add-label "zapp:approved" --repo sabbour/kickstart
   ```
 
-No GitHub formal PR review approval is required — squad agents share a single GitHub account with the repo owner, making self-approval impossible. The `squad/review-gate` status check (`.github/workflows/squad-review-gate.yml`) automatically turns green when both labels are present, and `Squad Auto Merge` clears `leela:approved` / `zapp:approved` on every `synchronize` so new commits always need fresh approval labels.
+No GitHub formal PR review approval is required — squad agents share a single GitHub account with the repo owner, making self-approval impossible. The `squad/review-gate` status check (`.github/workflows/squad-review-gate.yml`) normally turns green when both labels are present. For explicitly low-risk PRs labeled `squad:chore-auto`, the gate accepts `leela:approved` alone unless the PR looks security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`), in which case `zapp:approved` is still required. `Squad Auto Merge` clears approval labels on every `synchronize` so new commits always need fresh approval labels.
 
 ### Requesting Copilot Review
 
@@ -269,7 +269,7 @@ When a PR has review comments or formal review threads, the full feedback loop i
 
 **NEVER silently fix code and move on.** A reply is required for every piece of feedback, even if the fix is trivial. This is not optional.
 
-**Why this matters:** `require_conversation_resolution: true` is enforced in branch protection. Unresolved threads block the `squad/review-gate` status check. Even if both `leela:approved` and `zapp:approved` labels are present, GitHub will not allow merge while threads are open.
+**Why this matters:** `require_conversation_resolution: true` is enforced in branch protection. Unresolved threads block the `squad/review-gate` status check. Even if the required label set for the PR is present (`leela:approved` + `zapp:approved`, or the low-risk `squad:chore-auto` path), GitHub will not allow merge while threads are open.
 
 ### CI Requirements
 
@@ -282,9 +282,18 @@ All CI checks must pass, including Playwright E2E tests. If checks fail:
 
 **Rule:** Never call `gh pr merge` without first verifying ALL of the following:
 
-1. **Squad label gate** — both approval labels must be present:
+1. **Squad label gate** — verify the PR satisfies one of the allowed approval paths on the current head:
+   - standard path: `leela:approved` + `zapp:approved`
+   - low-risk path: `squad:chore-auto` + `leela:approved`
+   - low-risk security path: `squad:chore-auto` + `leela:approved` + `zapp:approved`
+
    ```bash
-   gh pr view {number} --json labels --jq '[.labels[].name] | contains(["leela:approved", "zapp:approved"])'
+   gh pr view {number} --json title,body,headRefName,labels --jq '
+     (.labels | map(.name)) as $labels
+     | ([.title, .body, .headRefName] + $labels | join(" ")) as $signals
+     | ($signals | test("security|cve-[0-9]{4}-[0-9]+|ghsa-|vuln|vulnerability"; "i")) as $security
+     | (($labels | index("squad:chore-auto")) and ($labels | index("leela:approved")) and ((($security | not) or ($labels | index("zapp:approved"))))) or ($labels | contains(["leela:approved", "zapp:approved"]))
+   '
    ```
    Must return `true`.
 
@@ -294,7 +303,7 @@ All CI checks must pass, including Playwright E2E tests. If checks fail:
    ```
    Must return `0`.
 
-If either check fails — STOP. Do not merge. Comment on the PR requesting review from Leela or Zapp.
+If either check fails — STOP. Do not merge. Comment on the PR requesting the missing approval path from Leela or Zapp.
 
 **NEVER use `--admin` flag.** Branch protection exists to enforce review. Bypassing it with `--admin` defeats the entire gate. If protection blocks a merge, that is correct behavior — request review, do not force.
 
@@ -307,7 +316,11 @@ Once merge gate checks pass, all reviews are addressed, threads resolved, and CI
 gh pr merge <N> --squash --delete-branch
 ```
 
-Qualifying GitHub PRs can now skip the manual merge command: the `Squad Auto Merge` workflow arms squash auto-merge when fresh `leela:approved` + `zapp:approved` labels are present on the current head, trusted merge signals are green (`CI Gate` from workflow `CI` plus `squad/review-gate` from `Squad Review Gate`), and the PR is neither XL (>1000 changed lines) nor titled `refactor`.
+Qualifying GitHub PRs can now skip the manual merge command: the `Squad Auto Merge` workflow arms squash auto-merge when trusted merge signals are green (`CI Gate` from workflow `CI` plus `squad/review-gate` from `Squad Review Gate`), the PR is neither XL (>1000 changed lines) nor titled `refactor`, and one of these approval paths is satisfied on the current head:
+
+- standard path: fresh `leela:approved` + `zapp:approved`
+- low-risk path: opt-in `squad:chore-auto` + fresh `leela:approved`
+- low-risk security path: opt-in `squad:chore-auto` + fresh `leela:approved` + `zapp:approved`
 
 ---
 

--- a/.squad/skills/pr-workflow/SKILL.md
+++ b/.squad/skills/pr-workflow/SKILL.md
@@ -201,7 +201,7 @@ Zapp's review is a **pre-merge gate** for foundational patterns. Do not merge wi
   gh pr edit {number} --add-label "zapp:approved" --repo sabbour/kickstart
   ```
 
-No GitHub formal PR review approval is required — squad agents share a single GitHub account with the repo owner, making self-approval impossible. The `squad/review-gate` status check (`.github/workflows/squad-review-gate.yml`) normally turns green when both labels are present. For explicitly low-risk PRs labeled `squad:chore-auto`, the gate accepts `leela:approved` alone unless the PR looks security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`), in which case `zapp:approved` is still required. `Squad Auto Merge` clears approval labels on every `synchronize` so new commits always need fresh approval labels.
+No GitHub formal PR review approval is required — squad agents share a single GitHub account with the repo owner, making self-approval impossible. The `squad/review-gate` status check (`.github/workflows/squad-review-gate.yml`) normally turns green when both labels are present. For explicitly low-risk PRs labeled `squad:chore-auto`, the gate accepts `leela:approved` alone unless the PR looks security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`) or touches sensitive paths (`.github/workflows/**`, auth, guardrail, security code), in which case `zapp:approved` is still required. `Squad Auto Merge` clears approval labels on every `synchronize` so new commits always need fresh approval labels.
 
 ### Requesting Copilot Review
 
@@ -283,19 +283,23 @@ All CI checks must pass, including Playwright E2E tests. If checks fail:
 **Rule:** Never call `gh pr merge` without first verifying ALL of the following:
 
 1. **Squad label gate** — verify the PR satisfies one of the allowed approval paths on the current head:
-   - standard path: `leela:approved` + `zapp:approved`
-   - low-risk path: `squad:chore-auto` + `leela:approved`
-   - low-risk security path: `squad:chore-auto` + `leela:approved` + `zapp:approved`
+    - standard path: `leela:approved` + `zapp:approved`
+    - low-risk path: `squad:chore-auto` + `leela:approved`
+    - low-risk sensitive path: `squad:chore-auto` + `leela:approved` + `zapp:approved` when the PR text looks security-sensitive or it touches `.github/workflows/**`, auth, guardrail, or security code
 
-   ```bash
-   gh pr view {number} --json title,body,headRefName,labels --jq '
-     (.labels | map(.name)) as $labels
-     | ([.title, .body, .headRefName] + $labels | join(" ")) as $signals
-     | ($signals | test("security|cve-[0-9]{4}-[0-9]+|ghsa-|vuln|vulnerability"; "i")) as $security
-     | (($labels | index("squad:chore-auto")) and ($labels | index("leela:approved")) and ((($security | not) or ($labels | index("zapp:approved"))))) or ($labels | contains(["leela:approved", "zapp:approved"]))
-   '
-   ```
-   Must return `true`.
+    ```bash
+    PR_JSON=$(gh pr view {number} --json number,title,body,headRefName,labels)
+    FILES_JSON=$(gh api repos/sabbour/kickstart/pulls/{number}/files --paginate)
+    jq -n --argjson pr "$PR_JSON" --argjson files "$FILES_JSON" '
+      ($pr.labels | map(.name)) as $labels
+      | ([ $pr.title, $pr.body, $pr.headRefName ] + $labels | map(select(. != null)) | join(" ")) as $signals
+      | ($signals | test("security|cve-[0-9]{4}-[0-9]+|ghsa-|vuln|vulnerability"; "i")) as $security
+      | ($files | map(.filename) | any(test("^\\.github/workflows/|(^|[/._-])(auth|guardrail|guardrails|security)([/._-]|$)"; "i"))) as $sensitive_paths
+      | (($labels | index("squad:chore-auto")) and ($labels | index("leela:approved")) and ((($security or $sensitive_paths) | not) or ($labels | index("zapp:approved"))))
+        or ($labels | contains(["leela:approved", "zapp:approved"]))
+    '
+    ```
+    Must return `true`.
 
 2. **Conversation resolution** — all review threads resolved:
    ```bash
@@ -320,7 +324,7 @@ Qualifying GitHub PRs can now skip the manual merge command: the `Squad Auto Mer
 
 - standard path: fresh `leela:approved` + `zapp:approved`
 - low-risk path: opt-in `squad:chore-auto` + fresh `leela:approved`
-- low-risk security path: opt-in `squad:chore-auto` + fresh `leela:approved` + `zapp:approved`
+- low-risk sensitive path: opt-in `squad:chore-auto` + fresh `leela:approved` + `zapp:approved` when the PR text looks security-sensitive or it touches `.github/workflows/**`, auth, guardrail, or security code
 
 ---
 

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -393,7 +393,7 @@ See `.squad/templates/ralph-reference.md` for Ralph's full lifecycle.
 If the project has no human reviewers configured:
 1. PR opens
 2. CI runs
-3. If CI passes, Ralph (or the `Squad Auto Merge` workflow for dual-approved non-XL/non-`refactor` PRs) auto-merges
+3. If CI passes, Ralph (or the `Squad Auto Merge` workflow for qualifying non-XL/non-`refactor` PRs, including opt-in `squad:chore-auto` PRs) auto-merges
 4. Issue closes
 
 ### Human Review Required
@@ -402,7 +402,7 @@ If the project requires human approval:
 1. PR opens
 2. Human reviewer is notified (GitHub/ADO notifications)
 3. Reviewer approves or requests changes
-4. If approved + CI passes, Ralph merges
+4. If approved + CI passes, Ralph merges (or the `Squad Auto Merge` workflow arms squash auto-merge for dual-approved PRs and opt-in `squad:chore-auto` low-risk PRs that satisfy the review gate)
 5. If changes requested, agent addresses feedback
 
 ### Squad Member Review


### PR DESCRIPTION
Closes #784

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)

Working as Bender (Backend Dev)

## Summary
Add an opt-in low-risk auto-merge path so chore/config PRs can arm squash auto-merge once trusted gates are green, while still requiring Zapp approval for security-like patches.

## Changes
- extend `squad-review-gate` so `squad:chore-auto` PRs can pass with fresh `leela:approved`, but still require `zapp:approved` for security-signaled patches
- teach `squad-auto-merge` to accept the low-risk path while keeping trusted CI/review-gate checks, XL/refactor exclusions, stale-label clearing, and audit comments
- sync the new `squad:chore-auto` label and document the low-risk merge path in squad workflow docs

## Testing
- `git --no-pager diff --check`
- `ruby -e "require 'yaml'; %w[.github/workflows/sync-squad-custom-labels.yml .github/workflows/squad-review-gate.yml .github/workflows/squad-auto-merge.yml].each { |f| YAML.load_file(f) }; puts 'YAML OK'"`
- inline Node smoke test covering standard, low-risk, and security-patch approval paths
- `CI=1 npm test -- --reporter=dot`
