### PR TITLE
chore(workflow): automate monthly docs sweep

### DIFF
--- a/.github/workflows/squad-monthly-docs-sweep.yml
+++ b/.github/workflows/squad-monthly-docs-sweep.yml
@@ -1,0 +1,203 @@
+name: Squad · Monthly Docs Sweep
+
+# Scribe refreshes a single rolling docs-sweep issue on the first Pacific
+# evening of the month. Cron is UTC: 00:00 on the 2nd ~= 17:00 PDT / 16:00 PST
+# on the 1st.
+
+on:
+  schedule:
+    - cron: '0 0 2 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  docs-sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Build docs sweep body
+        id: build
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { execSync } = require('child_process');
+
+            const canonicalDocsRoot = 'docs-site/docs';
+            const briefPath = `${canonicalDocsRoot}/architecture/v2-implementation-brief.md`;
+            const legacyDocsRedirect = 'docs/README.md';
+
+            function walk(dir) {
+              if (!fs.existsSync(dir)) return [];
+              return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+                const fullPath = path.join(dir, entry.name);
+                return entry.isDirectory() ? walk(fullPath) : [fullPath];
+              });
+            }
+
+            function unique(values) {
+              return [...new Set(values)];
+            }
+
+            function normalizeLinkTarget(rawTarget) {
+              let target = rawTarget.trim();
+              if (!target) return null;
+              if (target.startsWith('<') && target.endsWith('>')) target = target.slice(1, -1);
+              if (/^(https?:|mailto:|tel:|javascript:)/i.test(target) || target.startsWith('#')) return null;
+              if (/^\{.+\}$/.test(target)) return null;
+              return target.split('#')[0].split('?')[0];
+            }
+
+            function resolveCandidates(fromFile, target) {
+              const basePath = target.startsWith('/')
+                ? target.replace(/^\/+/, '')
+                : path.normalize(path.join(path.dirname(fromFile), target));
+              return [
+                basePath,
+                `${basePath}.md`,
+                path.join(basePath, 'README.md'),
+                path.join(basePath, 'index.md'),
+              ];
+            }
+
+            function collectBrokenLinks(files) {
+              const broken = [];
+              const linkPattern = /\[[^\]]+\]\(([^)]+)\)/g;
+
+              for (const file of files) {
+                const content = fs.readFileSync(file, 'utf8');
+                for (const match of content.matchAll(linkPattern)) {
+                  const target = normalizeLinkTarget(match[1]);
+                  if (!target) continue;
+                  const candidates = resolveCandidates(file, target);
+                  if (!candidates.some(candidate => fs.existsSync(candidate))) {
+                    broken.push(`- \`${file}\` → \`${match[1]}\``);
+                  }
+                }
+              }
+
+              return unique(broken).sort();
+            }
+
+            const docsFiles = walk(canonicalDocsRoot)
+              .filter(file => file.endsWith('.md'))
+              .sort();
+            const docsSections = unique(
+              docsFiles.map(file => path.relative(canonicalDocsRoot, file).split(path.sep)[0].replace(/\.md$/, ''))
+            ).sort();
+            const packDirs = fs.existsSync('packages')
+              ? fs.readdirSync('packages', { withFileTypes: true })
+                  .filter(entry => entry.isDirectory() && entry.name.startsWith('pack-'))
+                  .map(entry => entry.name)
+                  .sort()
+              : [];
+            const charterFiles = walk('.squad/agents')
+              .filter(file => file.endsWith('charter.md'))
+              .sort();
+            const docsSkills = walk('.squad/skills')
+              .filter(file => /docs|changelog|release|external-comms/i.test(file))
+              .map(file => file.replace(/\\/g, '/'))
+              .sort();
+            const brokenLinks = collectBrokenLinks([...docsFiles, legacyDocsRedirect].filter(file => fs.existsSync(file)));
+
+            const brief = fs.existsSync(briefPath)
+              ? fs.readFileSync(briefPath, 'utf8')
+              : '';
+            const lastUpdatedMatch = brief.match(/^\*\*Last updated:\*\*\s+([0-9]{4}-[0-9]{2}-[0-9]{2})$/m);
+            const lastUpdated = lastUpdatedMatch?.[1] || null;
+            const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+            const weeksSinceBriefUpdate = lastUpdated
+              ? Math.floor((Date.now() - new Date(`${lastUpdated}T00:00:00Z`).getTime()) / MS_PER_WEEK)
+              : null;
+            const packagesChurn = lastUpdated
+              ? parseInt(
+                  execSync(`git rev-list --count --since='${lastUpdated}T00:00:00Z' HEAD -- packages`, { encoding: 'utf8' }).trim() || '0',
+                  10,
+                )
+              : 0;
+            const briefFreshness = lastUpdated
+              ? `**${weeksSinceBriefUpdate} week(s)** since brief update (${lastUpdated}) · **${packagesChurn}** commit(s) touching \`packages/\` since then`
+              : `Missing \`Last updated:\` field in \`${briefPath}\``;
+
+            const brokenLinkSummary = brokenLinks.length
+              ? brokenLinks.slice(0, 20).join('\n')
+              : '_None detected._';
+            const moreBrokenLinks = brokenLinks.length > 20
+              ? `\n- _${brokenLinks.length - 20} more omitted from this issue body._`
+              : '';
+
+            const body = [
+              '**Working as Scribe** · see `.squad/agents/scribe/charter.md`',
+              '',
+              `_Rolling docs sweep — last updated ${new Date().toISOString()}_`,
+              '',
+              '## Canonical docs surface',
+              `- Canonical docs root: \`${canonicalDocsRoot}/\` (${docsFiles.length} markdown file(s))`,
+              `- Canonical brief path: \`${briefPath}\``,
+              `- Legacy redirect map: ${fs.existsSync(legacyDocsRedirect) ? `\`${legacyDocsRedirect}\`` : `missing \`${legacyDocsRedirect}\``}`,
+              `- Current docs sections: ${docsSections.map(section => `\`${section}\``).join(', ') || '_None detected._'}`,
+              '',
+              '## Automated checks',
+              `- Broken relative markdown links: **${brokenLinks.length}**`,
+              brokenLinkSummary + moreBrokenLinks,
+              `- Brief freshness: ${briefFreshness}`,
+              `- Active pack packages to cross-check in docs: ${packDirs.map(pack => `\`${pack}\``).join(', ') || '_None detected._'}`,
+              `- Agent charters to spot-check: **${charterFiles.length}**`,
+              `- Docs-facing skills to spot-check: ${docsSkills.slice(0, 6).map(skill => `\`${skill}\``).join(', ') || '_None detected._'}`,
+              '',
+              '## Manual sweep checklist',
+              `- [ ] Pack-page completeness still matches active packs (${packDirs.join(', ') || 'none'})`,
+              `- [ ] Charter relevance still matches current workflows across ${charterFiles.length} charter(s)`,
+              `- [ ] Skill accuracy still matches the canonical docs surface and repo layout`,
+              '- [ ] Open focused `process` issues for any drift that needs follow-up work',
+              '',
+              '## Notes',
+              '- This is the monthly docs-sweep artifact. Weekly Pulse remains the weekly summary artifact and should not be duplicated here.',
+              '- Target the canonical docs tree at `docs-site/docs/` when opening any follow-up docs work.',
+              '',
+              '---',
+              '_Generated by `.github/workflows/squad-monthly-docs-sweep.yml`._',
+            ].join('\n');
+
+            core.setOutput('body', body);
+
+      - name: Upsert rolling docs-sweep issue
+        uses: actions/github-script@v8
+        env:
+          BODY: ${{ steps.build.outputs.body }}
+        with:
+          script: |
+            const title = '📚 Docs Sweep (rolling)';
+            const body = process.env.BODY;
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'squad:scribe,docs:sweep',
+              per_page: 20,
+            });
+            const match = existing.find(issue => !issue.pull_request && issue.title === title);
+
+            if (match) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['squad:scribe', 'docs:sweep', 'type:docs'],
+              });
+            }

--- a/.github/workflows/sync-squad-custom-labels.yml
+++ b/.github/workflows/sync-squad-custom-labels.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - '.squad/team.md'
       - '.ai-team/team.md'
+      - '.github/workflows/sync-squad-custom-labels.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-squad-custom-labels.yml
+++ b/.github/workflows/sync-squad-custom-labels.yml
@@ -32,6 +32,7 @@ jobs:
           script: |
             const labels = [
               { name: 'process',           color: '5319E7', description: 'Process improvement tracked by the weekly pulse' },
+              { name: 'docs:sweep',       color: 'C5DEF5', description: 'Rolling docs sweep issue' },
               { name: 'pulse:daily',       color: 'BFD4F2', description: 'Daily pulse rolling issue' },
               { name: 'pulse:weekly',      color: '6B8EB5', description: 'Weekly pulse issue' },
               { name: 'release',           color: '0E8A16', description: 'Release PR opened by the cadence workflow' },

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -15,13 +15,14 @@
 - `.squad/retro-log.md` — append-only per-PR metrics (workflow-written, never hand-edited)
 - Daily Pulse — the rolling `📊 Daily Pulse (rolling)` issue
 - Weekly Pulse — the weekly `Weekly Pulse · YYYY-MM-DD` issue
+- Docs Sweep — the rolling `📚 Docs Sweep (rolling)` issue
 - Release notes — curated from aggregated changesets on the daily Release PR
 - Session histories — `.squad/agents/*/history.md`
 - **Product and DX voice** — public docs (`docs-site/`), README, `CHANGELOG.md`, and the "will a newcomer understand this in ten minutes" check on DPs and PRs
 
 ## How I Work
 
-- My persistent artifacts are written by GitHub Actions workflows. I do not hand-edit `retro-log.md` or pulse issues. If the workflow is wrong, fix the workflow, not the artifact.
+- My persistent artifacts are written by GitHub Actions workflows. I do not hand-edit `retro-log.md`, pulse issues, or the docs-sweep issue. If the workflow is wrong, fix the workflow, not the artifact.
 - When @copilot is delegated a Scribe task from a workflow comment (`@copilot — work as Scribe`), it reads this charter and curates the artifact in my voice.
 - In-session, I merge `.squad/decisions/inbox/*.md` into `.squad/decisions.md` in chronological order, deduplicated.
 - I group release notes as Added / Changed / Fixed / Removed / Security. Breaking changes go at the top.
@@ -55,6 +56,7 @@ I am the persona for these workflows. When they fire, @copilot adopts this chart
 | `.github/workflows/squad-pr-retro.yml` | one line appended to `retro-log.md`, mirrored as a PR comment |
 | `.github/workflows/squad-daily-pulse.yml` | upserts the rolling daily-pulse issue |
 | `.github/workflows/squad-weekly-pulse.yml` | opens the weekly-pulse issue |
+| `.github/workflows/squad-monthly-docs-sweep.yml` | upserts the rolling docs-sweep issue |
 | `.github/workflows/squad-release-cadence.yml` | curates release notes as a comment on the Release PR |
 
 ## Model
@@ -72,4 +74,3 @@ Before starting work, read `.squad/decisions.md` and `.squad/ceremonies.md`.
 ## Voice
 
 Neutral and chronological. Records what happened, not what should have. Trusts the data, distrusts the vibes. Refuses to editorialise in historical artifacts. Happy to be opinionated in proposals when asked.
-

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -21,6 +21,7 @@ These run via GitHub Actions on schedule or events. Documented here for referenc
 | Per-PR Micro-Retro | PR closed | `.github/workflows/squad-pr-retro.yml` | Scribe | `.squad/retro-log.md` + PR comment |
 | Daily Pulse | cron `0 0 * * *` (17:00 PT) | `.github/workflows/squad-daily-pulse.yml` | Scribe | rolling issue `📊 Daily Pulse (rolling)` |
 | Weekly Pulse | cron `0 0 * * 2` (Mon 17:00 PT) | `.github/workflows/squad-weekly-pulse.yml` | Scribe | new issue `Weekly Pulse · YYYY-MM-DD` |
+| Monthly Docs Sweep | cron `0 0 2 * *` (~1st day 17:00 PT) | `.github/workflows/squad-monthly-docs-sweep.yml` | Scribe | rolling issue `📚 Docs Sweep (rolling)` |
 | Release Cadence | cron `0 0 * * *` (17:00 PT) | `.github/workflows/squad-release-cadence.yml` | Leela + Scribe | draft PR on `release/cadence` branch |
 
 All crons are UTC. `0 0 * * *` = 17:00 PDT / 16:00 PST.
@@ -166,7 +167,7 @@ This protocol applies to all agents (squad members AND @copilot). It is enforced
 4. Charter relevance: role boundaries and owned artifacts still match current workflows
 5. Skill accuracy: workflow-facing skills still match the real repo layout and ceremony gates
 
-**Output:** Scribe records findings in the current pulse issue or opens focused `process` issues when drift needs follow-up work.
+**Output:** Scribe records findings in the rolling `📚 Docs Sweep (rolling)` issue or opens focused `process` issues when drift needs follow-up work.
 
 ---
 

--- a/.squad/decisions/inbox/bender-monthly-docs-sweep-artifact.md
+++ b/.squad/decisions/inbox/bender-monthly-docs-sweep-artifact.md
@@ -1,0 +1,19 @@
+---
+title: Monthly docs sweep writes to a rolling Scribe issue
+date: 2026-04-20
+author: Bender
+---
+
+## Context
+
+#831 adds the deferred monthly Docs Sweep automation now that #811 and #813 have landed. The repo already has a weekly pulse issue and a rolling daily pulse issue, so the remaining question is where the monthly docs audit should live.
+
+## Decision
+
+Publish the monthly docs sweep to a dedicated rolling Scribe issue titled `📚 Docs Sweep (rolling)` and label it with `squad:scribe` plus `docs:sweep`.
+
+The workflow targets the canonical docs surface at `docs-site/docs/` and the canonical brief path `docs-site/docs/architecture/v2-implementation-brief.md`. The issue body carries automated docs-health signals and the standing manual checklist; any real drift discovered during the sweep should become focused `process` issues instead of more pulse artifacts.
+
+## Why
+
+This keeps the docs audit persistent and easy to update without creating another weekly-style issue stream. It also cleanly separates docs hygiene from Weekly Pulse, which stays the team’s time-boxed summary artifact.


### PR DESCRIPTION
Closes #831

Working as Bender (Backend Dev)

🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)

## Summary
- automate the monthly Docs Sweep now that `docs-site/docs/` is the canonical docs tree
- publish the sweep to a dedicated rolling Scribe artifact instead of duplicating Weekly Pulse

## Changes
- add `.github/workflows/squad-monthly-docs-sweep.yml` to upsert `📚 Docs Sweep (rolling)` with canonical docs checks and the standing sweep checklist
- add the `docs:sweep` label to custom label sync so the rolling artifact stays identifiable
- document the new monthly artifact in `.squad/ceremonies.md` and `.squad/agents/scribe/charter.md`
- record the rolling-issue artifact choice in `.squad/decisions/inbox/bender-monthly-docs-sweep-artifact.md`

## Testing
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/squad-monthly-docs-sweep.yml'); YAML.load_file('.github/workflows/sync-squad-custom-labels.yml')"`
- monthly docs-sweep Node smoke test (body generation against the checked-in repo)
- `CI=1 npm test -- --reporter=dot`

## Docs and changeset
- [x] Changeset added (or marked internal-only with reason) — internal-only workflow/docs automation; no changeset needed
- [x] docs-site/docs/ updated (or N/A) — N/A
- [x] docs-site/docs/architecture/v2-implementation-brief.md updated (or N/A) — N/A
- [x] docs-site/docs/extending/api-endpoints.md updated (or N/A) — N/A
- [x] Pack docs updated (or N/A) — N/A
- [x] Tests added or covered
