### PR TITLE
fix(web): use Fluent send icon in chat composer

### DIFF
--- a/.changeset/chat-go-icon-dark-mode.md
+++ b/.changeset/chat-go-icon-dark-mode.md
@@ -1,0 +1,8 @@
+---
+"@kickstart/web": patch
+---
+
+fix: use the Fluent go icon in the chat composer send button
+
+- replace the composer go.svg image with the same Fluent ArrowRight icon used in the landing input
+- inherit theme-aware icon color so the send button stays visible in dark mode

--- a/packages/web/css/components.css
+++ b/packages/web/css/components.css
@@ -348,6 +348,10 @@
   cursor: not-allowed;
 }
 
+.chat-send-icon {
+  font-size: 16px;
+}
+
 /* --- Demo badge (in phase bar) --- */
 .demo-badge {
   display: inline-flex;

--- a/packages/web/src/components/Chat/ChatInput.tsx
+++ b/packages/web/src/components/Chat/ChatInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { ArrowRight24Regular } from '@fluentui/react-icons';
 
 interface ChatInputProps {
   onSend: (text: string) => void;
@@ -57,7 +58,7 @@ export function ChatInput({ onSend, disabled, statusBar }: ChatInputProps) {
           aria-label="Send message"
           title="Send"
         >
-          <img src="assets/icons/commands/go.svg" width="16" height="16" alt="" />
+          <ArrowRight24Regular className="chat-send-icon" />
         </button>
       </div>
     </div>


### PR DESCRIPTION
No linked issue — direct user request.

Working as Fry (Frontend Dev)

## Summary
Use the same Fluent ArrowRight send icon from the landing input in the chat composer so the button remains visible in dark mode.

## Changes
- replace the composer `go.svg` image with `ArrowRight24Regular`
- size the Fluent icon to match the existing 16px send button affordance
- add a patch changeset for `@kickstart/web`

## Testing
- `npm run build -w @kickstart/web`
- `npx vitest run packages/web/src/__tests__/chat-ui.test.ts`
- `npx eslint packages/web/src/components/Chat/ChatInput.tsx`

## Docs and changeset
- [x] Changeset added
- [x] docs-site/docs/ updated (N/A)
- [x] docs-site/docs/architecture/v2-implementation-brief.md updated (N/A)
- [x] docs-site/docs/extending/api-endpoints.md updated (N/A)
- [x] Pack docs updated (N/A)
- [x] Tests added or covered (existing coverage/build validation)