### PR TITLE
docs: harden squad github write auth guidance

### DIFF
--- a/.copilot/skills/gh-auth-isolation/SKILL.md
+++ b/.copilot/skills/gh-auth-isolation/SKILL.md
@@ -1,183 +1,47 @@
 ---
 name: "gh-auth-isolation"
-description: "Safely manage multiple GitHub identities (EMU + personal) in agent workflows"
+description: "Kickstart override for GitHub auth isolation in agent workflows"
 domain: "security, github-integration, authentication, multi-account"
 confidence: "high"
-source: "earned (production usage across 50+ sessions with EMU corp + personal GitHub accounts)"
+source: "earned (repo-specific hardening guidance)"
 tools:
   - name: "gh"
     description: "GitHub CLI for authenticated operations"
     when: "When accessing GitHub resources requiring authentication"
 ---
 
-## Context
+## Kickstart override
 
-Many developers use GitHub through an Enterprise Managed User (EMU) account at work while maintaining a personal GitHub account for open-source contributions. AI agents spawned by Squad inherit the shell's default `gh` authentication — which is usually the EMU account. This causes failures when agents try to push to personal repos, create PRs on forks, or interact with resources outside the enterprise org.
+In `sabbour/kickstart`, agent-authored GitHub writes are **GitHub App writes**, not human-account writes.
 
-This skill teaches agents how to detect the active identity, switch contexts safely, and avoid mixing credentials across operations.
+Use this path for every agent-authored write:
 
-## Patterns
+```bash
+TOKEN=$(node "$TEAM_ROOT/.squad/scripts/resolve-token.mjs" --required "$ROLE_SLUG")
+export GH_TOKEN="$TOKEN"
+```
 
-### Detect Current Identity
+- Issue/PR comments, edits, GraphQL mutations, review-thread resolution, `gh pr ready`, and `gh pr merge` must run as `GH_TOKEN=$TOKEN gh ...`.
+- Pushes must use token-authenticated HTTPS: `git push https://x-access-token:${TOKEN}@github.com/<owner>/<repo>.git <branch>`.
+- If `resolve-token.mjs --required` fails, stop. Do **not** fall back to ambient `gh`, ambient `git`, `gh auth token --user`, `gh auth switch`, `ghp`, or `ghw`.
 
-Before any GitHub operation, check which account is active:
+## Human-only troubleshooting
+
+If a human is debugging local GitHub CLI setup outside the Squad write path, they may inspect accounts with:
 
 ```bash
 gh auth status
 ```
 
-Look for:
-- `Logged in to github.com as USERNAME` — the active account
-- `Token scopes: ...` — what permissions are available
-- Multiple accounts will show separate entries
-
-### Extract a Specific Account's Token
-
-When you need to operate as a specific user (not the default):
+Prefer config-directory isolation for separate personal/work accounts so one shell does not silently flip another shell's identity:
 
 ```bash
-# Get the personal account token (by username)
-gh auth token --user personaluser
-
-# Get the EMU account token
-gh auth token --user corpalias_enterprise
+GH_CONFIG_DIR=~/.config/gh-public gh auth status
 ```
 
-**Use case:** Push to a personal fork while the default `gh` auth is the EMU account.
+## Anti-patterns
 
-### Push to Personal Repos from EMU Shell
-
-The most common scenario: your shell defaults to the EMU account, but you need to push to a personal GitHub repo.
-
-```bash
-# 1. Extract the personal token
-$token = gh auth token --user personaluser
-
-# 2. Push using token-authenticated HTTPS
-git push https://personaluser:$token@github.com/personaluser/repo.git branch-name
-```
-
-**Why this works:** `gh auth token --user` reads from `gh`'s credential store without switching the active account. The token is used inline for a single operation and never persisted.
-
-### Create PRs on Personal Forks
-
-When the default `gh` context is EMU but you need to create a PR from a personal fork:
-
-```bash
-# Option 1: Use --repo flag (works if token has access)
-gh pr create --repo upstream/repo --head personaluser:branch --title "..." --body "..."
-
-# Option 2: Temporarily set GH_TOKEN for one command
-$env:GH_TOKEN = $(gh auth token --user personaluser)
-gh pr create --repo upstream/repo --head personaluser:branch --title "..."
-Remove-Item Env:\GH_TOKEN
-```
-
-### Config Directory Isolation (Advanced)
-
-For complete isolation between accounts, use separate `gh` config directories:
-
-```bash
-# Personal account operations
-$env:GH_CONFIG_DIR = "$HOME/.config/gh-public"
-gh auth login  # Login with personal account (one-time setup)
-gh repo clone personaluser/repo
-
-# EMU account operations (default)
-Remove-Item Env:\GH_CONFIG_DIR
-gh auth status  # Back to EMU account
-```
-
-**Setup (one-time):**
-```bash
-# Create isolated config for personal account
-mkdir ~/.config/gh-public
-$env:GH_CONFIG_DIR = "$HOME/.config/gh-public"
-gh auth login --web --git-protocol https
-```
-
-### Shell Aliases for Quick Switching
-
-Add to your shell profile for convenience:
-
-```powershell
-# PowerShell profile
-function ghp { $env:GH_CONFIG_DIR = "$HOME/.config/gh-public"; gh @args; Remove-Item Env:\GH_CONFIG_DIR }
-function ghe { gh @args }  # Default EMU
-
-# Usage:
-# ghp repo clone personaluser/repo   # Uses personal account
-# ghe issue list                       # Uses EMU account
-```
-
-```bash
-# Bash/Zsh profile
-alias ghp='GH_CONFIG_DIR=~/.config/gh-public gh'
-alias ghe='gh'
-
-# Usage:
-# ghp repo clone personaluser/repo
-# ghe issue list
-```
-
-## Examples
-
-### ✓ Correct: Agent pushes blog post to personal GitHub Pages
-
-```powershell
-# Agent needs to push to personaluser.github.io (personal repo)
-# Default gh auth is corpalias_enterprise (EMU)
-
-$token = gh auth token --user personaluser
-git remote set-url origin https://personaluser:$token@github.com/personaluser/personaluser.github.io.git
-git push origin main
-
-# Clean up — don't leave token in remote URL
-git remote set-url origin https://github.com/personaluser/personaluser.github.io.git
-```
-
-### ✓ Correct: Agent creates a PR from personal fork to upstream
-
-```powershell
-# Fork: personaluser/squad, Upstream: bradygaster/squad
-# Agent is on branch contrib/fix-docs in the fork clone
-
-git push origin contrib/fix-docs  # Pushes to fork (may need token auth)
-
-# Create PR targeting upstream
-gh pr create --repo bradygaster/squad --head personaluser:contrib/fix-docs `
-  --title "docs: fix installation guide" `
-  --body "Fixes #123"
-```
-
-### ✗ Incorrect: Blindly pushing with wrong account
-
-```bash
-# BAD: Agent assumes default gh auth works for personal repos
-git push origin main
-# ERROR: Permission denied — EMU account has no access to personal repo
-
-# BAD: Hardcoding tokens in scripts
-git push https://personaluser:ghp_xxxxxxxxxxxx@github.com/personaluser/repo.git main
-# SECURITY RISK: Token exposed in command history and process list
-```
-
-### ✓ Correct: Check before you push
-
-```bash
-# Always verify which account has access before operations
-gh auth status
-# If wrong account, use token extraction:
-$token = gh auth token --user personaluser
-git push https://personaluser:$token@github.com/personaluser/repo.git main
-```
-
-## Anti-Patterns
-
-- ❌ **Hardcoding tokens** in scripts, environment variables, or committed files. Use `gh auth token --user` to extract at runtime.
-- ❌ **Assuming the default `gh` auth works** for all repos. EMU accounts can't access personal repos and vice versa.
-- ❌ **Switching `gh auth login`** globally mid-session. This changes the default for ALL processes and can break parallel agents.
-- ❌ **Storing personal tokens in `.env`** or `.squad/` files. These get committed by Scribe. Use `gh`'s credential store.
-- ❌ **Ignoring token cleanup** after inline HTTPS pushes. Always reset the remote URL to avoid persisting tokens.
-- ❌ **Using `gh auth switch`** in multi-agent sessions. One agent switching affects all others sharing the shell.
-- ❌ **Mixing EMU and personal operations** in the same git clone. Use separate clones or explicit remote URLs per operation.
+- ❌ Using `gh auth token --user` for agent-authored writes in this repo.
+- ❌ Using `gh auth switch` in a shared multi-agent shell.
+- ❌ Teaching agents to `git push origin` or run bare `gh pr create` in this repo.
+- ❌ Persisting human-account tokens in remotes, env files, or committed scripts.

--- a/.copilot/skills/github-multi-account/SKILL.md
+++ b/.copilot/skills/github-multi-account/SKILL.md
@@ -1,95 +1,38 @@
 ---
 name: github-multi-account
-description: Detect and set up account-locked gh aliases for multi-account GitHub. The AI reads this skill, detects accounts, asks the user which is personal/work, and runs the setup automatically.
+description: Repo-specific override for multi-account GitHub guidance in Kickstart.
 confidence: high
-source: https://github.com/tamirdresher/squad-skills/tree/main/plugins/github-multi-account
-author: tamirdresher
+source: sabbour/kickstart auth hardening
+author: kickstart
 ---
 
-# GitHub Multi-Account — AI-Driven Setup
+# GitHub Multi-Account — Kickstart Override
 
-## When to Activate
-When the user has multiple GitHub accounts (check with `gh auth status`). If you see 2+ accounts listed, this skill applies.
+This repo does **not** use account-switching aliases for agent-authored writes.
 
-## What to Do (as the AI agent)
+## Rule for `sabbour/kickstart`
 
-### Step 1: Detect accounts
-Run: `gh auth status`
-Look for multiple accounts. Note which usernames are listed.
+For Squad agents, every GitHub write must resolve the role app token first:
 
-### Step 2: Ask the user
-Ask: "I see you have multiple GitHub accounts: {list them}. Which one is your personal account and which is your work/EMU account?"
-
-### Step 3: Run the setup automatically
-Once the user confirms, do ALL of this for them:
-
-```powershell
-# 1. Define the functions
-$personal = "THEIR_PERSONAL_USERNAME"
-$work = "THEIR_WORK_USERNAME"
-
-# 2. Add to PowerShell profile
-$profilePath = $PROFILE.CurrentUserAllHosts
-if (!(Test-Path $profilePath)) { New-Item -Path $profilePath -Force | Out-Null }
-$existing = Get-Content $profilePath -Raw -ErrorAction SilentlyContinue
-if ($existing -notmatch "gh-personal") {
-    $block = @"
-
-# === GitHub Multi-Account Aliases ===
-function gh-personal { gh auth switch --user $personal 2>`$null | Out-Null; gh @args }
-function gh-work { gh auth switch --user $work 2>`$null | Out-Null; gh @args }
-Set-Alias ghp gh-personal
-Set-Alias ghw gh-work
-"@
-    Add-Content -Path $profilePath -Value $block
-}
-
-# 3. Create CMD wrappers
-$binDir = Join-Path $env:USERPROFILE ".squad\bin"
-if (!(Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
-"@echo off`ngh auth switch --user $personal >nul 2>&1`ngh %*" | Out-File "$binDir\ghp.cmd" -Encoding ascii
-"@echo off`ngh auth switch --user $work >nul 2>&1`ngh %*" | Out-File "$binDir\ghw.cmd" -Encoding ascii
-
-# 4. Add to PATH
-$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($userPath -notmatch [regex]::Escape($binDir)) {
-    [Environment]::SetEnvironmentVariable("PATH", "$binDir;$userPath", "User")
-    $env:PATH = "$binDir;$env:PATH"
-}
-
-# 5. Load in current session
-function gh-personal { gh auth switch --user $personal 2>$null | Out-Null; gh @args }
-function gh-work { gh auth switch --user $work 2>$null | Out-Null; gh @args }
-Set-Alias ghp gh-personal
-Set-Alias ghw gh-work
+```bash
+TOKEN=$(node "$TEAM_ROOT/.squad/scripts/resolve-token.mjs" --required "$ROLE_SLUG")
+export GH_TOKEN="$TOKEN"
 ```
 
-### Step 4: Verify for the user
-Run these and show the results:
-```powershell
-ghp api user --jq '.login'   # should show personal username
-ghw api user --jq '.login'   # should show work username
-```
+Then:
 
-### Step 5: Tell the user
-"All set! From now on use `ghp` for personal repos and `ghw` for work repos. I'll use them too."
+- use `GH_TOKEN=$TOKEN gh ...` for issue/PR comments, edits, GraphQL mutations, `gh pr create`, `gh pr ready`, and `gh pr merge`
+- use `git push https://x-access-token:${TOKEN}@github.com/<owner>/<repo>.git <branch>` for pushes
+- stop immediately if token resolution fails
 
-## After Setup — Usage Rules
+## Forbidden for agent-authored writes here
 
-1. **NEVER** use bare `gh` for repo operations — always `ghp` or `ghw`
-2. **NEVER** manually `gh auth switch` — the aliases handle it
-3. Determine alias by repo owner:
-   - Personal account repos → `ghp` / `gh-personal`
-   - Work/EMU account repos → `ghw` / `gh-work`
+- `gh auth switch`
+- `gh auth token --user ...`
+- `ghp` / `ghw` alias flows
+- bare `gh` write commands
+- `git push origin`
 
-## Repo-Specific Account Binding
+## Human note
 
-This repo (`bradygaster/squad`) is bound to the **bradygaster** (personal) account.
-All `gh` operations in this repo MUST use `ghp` / `gh-personal`.
-
-## For Squad Agents
-At the TOP of any script touching GitHub, define:
-```powershell
-function gh-personal { gh auth switch --user bradygaster 2>$null | Out-Null; gh @args }
-function gh-work { gh auth switch --user bradyg_microsoft 2>$null | Out-Null; gh @args }
-```
+If a human wants personal/work aliases for other repos, keep that setup outside the Squad automation path. Do not teach Kickstart agents to depend on those aliases.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -341,7 +341,7 @@ prompt: |
   {% endif %}
 
   {only if identity configured:}
-  GIT IDENTITY: Commit as `{app_slug}[bot]`. Resolve the token with `TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")`. For write actions, fail closed unless either the bot token resolved or `SQUAD_ALLOW_WRITE_FALLBACK=1` is explicitly set as an auditable escape hatch. PR body: `🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})`.
+  GIT IDENTITY: Commit as `{app_slug}[bot]`. Resolve the token with `TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")` and `export GH_TOKEN="$TOKEN"`. If resolution fails, stop; agent-authored writes do not fall back to ambient auth. PR body: `🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})`.
   {end identity block}
 
   TASK: {specific task description}
@@ -718,7 +718,7 @@ When spawning an agent that may do git operations (commit, push, PR), resolve th
 
 5. **Include the identity block** in the spawn prompt with the resolved values.
 
-**If config exists but role/app resolution fails for a write-capable agent, stop and fix the mapping.** Do not silently drop into ambient auth; the only escape hatch is an explicit `SQUAD_ALLOW_WRITE_FALLBACK=1` decision.
+**If config exists but role/app resolution fails for a write-capable agent, stop and fix the mapping.** Do not silently drop into ambient auth.
 
 ### Pre-Spawn: Worktree Setup
 
@@ -841,25 +841,21 @@ prompt: |
   ## GIT IDENTITY — Bot Authentication
   This project uses GitHub App identity for git operations. When pushing code or creating PRs, authenticate as the bot.
   
-  **Resolve token at runtime:**
+  **Resolve token at runtime (fail closed for writes):**
   ```bash
-  TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
+  TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+  export GH_TOKEN="$TOKEN"
   ```
-  `resolve-token.mjs` only uses explicit config keys or explicit alias mappings; it does **not** guess another app. If token resolution fails, write actions must stop unless `SQUAD_ALLOW_WRITE_FALLBACK=1` is explicitly set.
+  `resolve-token.mjs` only uses explicit config keys or explicit alias mappings; it does **not** guess another app. `--required` prints a reason to stderr and exits non-zero when write auth is not explicitly configured.
   
   **Git commit identity:**
   - `git -c user.name="{app_slug}[bot]" -c user.email="{app_slug}[bot]@users.noreply.github.com" commit ...`
   
-  **Guard write actions first:**
-  ```bash
-  if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-    echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-    exit 1
-  fi
-  ```
-  **Push:** `if [ -n "$TOKEN" ]; then git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git {branch}; else git push origin {branch}; fi`
-  **PR create:** `if [ -n "$TOKEN" ]; then GH_TOKEN=$TOKEN gh pr create ...; else gh pr create ...; fi`
+  **Agent-authored writes must stay on app identity:**
+  - **Push:** `git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git {branch}`
+  - **PR create:** `GH_TOKEN=$TOKEN gh pr create ...`
   **PR body must include:** `🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})`
+  - **Do not use** ambient `gh`, ambient `git`, `gh auth token --user`, or `gh auth switch` for normal agent-authored writes.
   
   **Never log or echo the token value.**
   {end identity block}

--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -31,6 +31,7 @@ All open v2 issues should carry milestone **v2**.
 
 ## Learnings
 
+- (2026-04-20T02:48:20.359-07:00) GitHub write hardening wave 1: `sabbour/kickstart` agent-authored writes now document a fail-closed path via `resolve-token.mjs --required`, `GH_TOKEN`, and token-authenticated pushes. Coordinator, lifecycle, and workflow docs should not suggest ambient `gh`, PAT, or account-switching fallbacks for bot writes.
 - (2026-04-17T12:06:45.293Z) Sprint planning always required before backlog pickup when `.squad/identity/now.md` gate is active. Shortest v2 slice is harness spine, not pack work: `#474 → #475 → #476` must land before pack-core batch.
 - (2026-04-17T03:30:17Z) DP #329: runtime duplication is the blocking risk — PoC adds `runtime/` inside `packages/mcp-server` that parallels `packages/web/api/` LLM client + session store. Third fork risk with SDK migration. Implementation issue must define canonical client before code lands.
 - (2026-04-17T03:30:17Z) DP #330 closeout: Option B (hybrid route planner + manager agent) adopted. `phaseComplete`/`filesComplete` flags retired. Implementation sequence locked: Gate → arch spike → backend (#445, Bender) → UI (#446, Fry) → cleanup. Follow-ons #445 and #446 created.

--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -31,6 +31,7 @@ All open v2 issues should carry milestone **v2**.
 
 ## Learnings
 
+- (2026-04-20T02:48:20.359-07:00) Lifecycle template parity matters for auth hardening: fixing `.squad/issue-lifecycle.md` is insufficient if `.squad/templates/issue-lifecycle.md` still teaches ambient push, PR-ready, or merge commands. Wave-1 GitHub write guidance must stay fail-closed in both live docs and generators.
 - (2026-04-20T02:48:20.359-07:00) GitHub write hardening wave 1: `sabbour/kickstart` agent-authored writes now document a fail-closed path via `resolve-token.mjs --required`, `GH_TOKEN`, and token-authenticated pushes. Coordinator, lifecycle, and workflow docs should not suggest ambient `gh`, PAT, or account-switching fallbacks for bot writes.
 - (2026-04-17T12:06:45.293Z) Sprint planning always required before backlog pickup when `.squad/identity/now.md` gate is active. Shortest v2 slice is harness spine, not pack work: `#474 → #475 → #476` must land before pack-core batch.
 - (2026-04-17T03:30:17Z) DP #329: runtime duplication is the blocking risk — PoC adds `runtime/` inside `packages/mcp-server` that parallels `packages/web/api/` LLM client + session store. Third fork risk with SDK migration. Implementation issue must define canonical client before code lands.

--- a/.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md
@@ -6,13 +6,26 @@
 
 Kickstart uses a structured issue → Design Proposal → PR → review → merge lifecycle. Design discussion happens on the **issue** (via a Design Proposal comment), not on the PR. PRs are for code review only.
 
+## Write identity
+
+For agent-authored GitHub writes, resolve the role app token first and reuse it for every write:
+
+```bash
+TOKEN=$(node "$TEAM_ROOT/.squad/scripts/resolve-token.mjs" --required "$ROLE_SLUG")
+export GH_TOKEN="$TOKEN"
+```
+
+Normal agent writes in this repo do **not** use ambient `gh` auth.
+They also do **not** use `gh auth token --user`, `gh auth switch`, `ghp`, or `ghw` for agent-authored writes in `sabbour/kickstart`.
+
 ## Steps
 
 ### 1. Pick up an issue
 
+Do not auto-assign a human via the agent app token. If a human assignee is intentionally needed for visibility, do that as a separate explicit human-owned step outside the agent-authored write path.
+
 ```bash
-gh issue edit <N> --add-assignee "$(gh api user -q .login)"
-gh issue edit <N> --milestone "<milestone-name>"
+GH_TOKEN=$TOKEN gh issue edit <N> --milestone "<milestone-name>"
 ```
 
 Move the project board status to **In progress**.
@@ -48,26 +61,12 @@ git worktree add .worktrees/<slug-or-issue-number> \
 cd .worktrees/<slug-or-issue-number>
 ```
 
-Rules:
-
-- Worktree path lives under `.worktrees/` (gitignored). Name it after the issue or a short slug.
-- Branch off `origin/main`, not the local `main`.
-- Never run `git checkout -b` in the top-level working tree.
-- One worktree per in-flight PR. Reuse, don't duplicate.
-- When the PR merges or closes, run from any other checkout:
-  ```bash
-  git worktree remove .worktrees/<name>
-  git worktree prune
-  ```
-
-All subsequent commands in this skill run from inside the worktree.
-
 ### 4. Open a draft PR
 
 Always draft, never ready on first push.
 
 ```bash
-gh pr create --draft \
+GH_TOKEN=$TOKEN gh pr create --draft \
   --title "<title>" \
   --body "Closes #<issue-number>
 
@@ -95,11 +94,11 @@ gh pr create --draft \
 
 ### 5. Keep the branch current
 
-Rebase, never merge.
+Rebase, never merge. Push with the app token, not ambient auth.
 
 ```bash
 git fetch origin && git rebase origin/main
-git push --force-with-lease
+git push https://x-access-token:${TOKEN}@github.com/<owner>/<repo>.git squad/<issue-number>-<slug> --force-with-lease
 ```
 
 ### 6. Mark ready for review
@@ -110,7 +109,7 @@ Only after:
 - Docs and changeset are in place.
 
 ```bash
-gh pr ready <N>
+GH_TOKEN=$TOKEN gh pr ready <N>
 ```
 
 ### 7. Review gates

--- a/.squad/issue-lifecycle.md
+++ b/.squad/issue-lifecycle.md
@@ -307,6 +307,7 @@ Ready for re-review."
 ```bash
 # Make changes
 # ⚠️ NEVER use `git add .` or `git add -A` — only stage files you intentionally changed
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
 git add -- {specific files you modified}
 git commit -m "fix: address review feedback"
 git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git squad/{issue-number}-{slug}
@@ -315,6 +316,7 @@ git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git squad/{is
 **Re-request review (GitHub):**
 ```bash
 TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 GH_TOKEN=$TOKEN gh pr ready {pr-number}
 ```
 
@@ -327,12 +329,14 @@ GH_TOKEN=$TOKEN gh pr ready {pr-number}
 **GitHub (merge commit):**
 ```bash
 TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 GH_TOKEN=$TOKEN gh pr merge {pr-number} --merge --delete-branch
 ```
 
 **GitHub (squash):**
 ```bash
 TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 GH_TOKEN=$TOKEN gh pr merge {pr-number} --squash --delete-branch
 ```
 

--- a/.squad/issue-lifecycle.md
+++ b/.squad/issue-lifecycle.md
@@ -132,55 +132,31 @@ Agents MUST use their GitHub App token for these calls so the comment appears as
 
 ```bash
 # Resolve bot token (see GIT IDENTITY in spawn prompt)
-TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
-if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-  echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-  exit 1
-fi
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 
 # Post start comment on the issue
-if [ -n "$TOKEN" ]; then
-  GH_TOKEN=$TOKEN gh issue comment {number} --repo {owner}/{repo} \
-    --body "🚀 **{AgentName}** ({Role}) is starting work on this issue.
+GH_TOKEN=$TOKEN gh issue comment {number} --repo {owner}/{repo} \
+  --body "🚀 **{AgentName}** ({Role}) is starting work on this issue.
 ⏱️ Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 🌿 Branch: \`squad/{issue-number}-{slug}\`"
-else
-  gh issue comment {number} --repo {owner}/{repo} \
-    --body "🚀 **{AgentName}** ({Role}) is starting work on this issue.
-⏱️ Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-🌿 Branch: \`squad/{issue-number}-{slug}\`"
-fi
 
 # Move issue to "In Progress" on the project board
 # Use the GitHub Projects GraphQL API to update the status field
-if [ -n "$TOKEN" ]; then
-  GH_TOKEN=$TOKEN gh api graphql -f query='
-    mutation {
-      updateProjectV2ItemFieldValue(
-        input: {
-          projectId: "{project-node-id}"
-          itemId: "{item-node-id}"
-          fieldId: "{status-field-id}"
-          value: { singleSelectOptionId: "{in-progress-option-id}" }
-        }
-      ) { projectV2Item { id } }
-    }'
-else
-  gh api graphql -f query='
-    mutation {
-      updateProjectV2ItemFieldValue(
-        input: {
-          projectId: "{project-node-id}"
-          itemId: "{item-node-id}"
-          fieldId: "{status-field-id}"
-          value: { singleSelectOptionId: "{in-progress-option-id}" }
-        }
-      ) { projectV2Item { id } }
-    }'
-fi
+GH_TOKEN=$TOKEN gh api graphql -f query='
+  mutation {
+    updateProjectV2ItemFieldValue(
+      input: {
+        projectId: "{project-node-id}"
+        itemId: "{item-node-id}"
+        fieldId: "{status-field-id}"
+        value: { singleSelectOptionId: "{in-progress-option-id}" }
+      }
+    ) { projectV2Item { id } }
+  }'
 ```
 
-> **Write-auth escape hatch:** Write actions fail closed by default. Set `SQUAD_ALLOW_WRITE_FALLBACK=1` only when you intentionally want to use ambient `gh`/`git` auth and can audit that choice.
+> **Fail-closed rule:** Agent-authored writes must resolve an explicit app token first. If `resolve-token.mjs --required` fails, stop; do not fall back to ambient `gh` or `git` auth.
 
 > **Board IDs:** The coordinator resolves project/item/field/option IDs before spawning and passes them in the ISSUE CONTEXT block. See spawn prompt additions below.
 
@@ -220,17 +196,8 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 
 **Push command:**
 ```bash
-TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
-if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-  echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-  exit 1
-fi
-
-if [ -n "$TOKEN" ]; then
-  git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git squad/{issue-number}-{slug}
-else
-  git push -u origin squad/{issue-number}-{slug}
-fi
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git squad/{issue-number}-{slug}
 ```
 
 ### 4. PR Creation
@@ -247,11 +214,8 @@ fi
 
 **GitHub:**
 ```bash
-TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
-if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-  echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-  exit 1
-fi
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 
 cat > pr-body.txt <<'EOF'
 🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})
@@ -261,17 +225,10 @@ Closes #{issue-number}
 {description}
 EOF
 
-if [ -n "$TOKEN" ]; then
-  GH_TOKEN=$TOKEN gh pr create --title "{title}" \
-    --body-file pr-body.txt \
-    --head squad/{issue-number}-{slug} \
-    --base main
-else
-  gh pr create --title "{title}" \
-    --body-file pr-body.txt \
-    --head squad/{issue-number}-{slug} \
-    --base main
-fi
+GH_TOKEN=$TOKEN gh pr create --draft --title "{title}" \
+  --body-file pr-body.txt \
+  --head squad/{issue-number}-{slug} \
+  --base main
 ```
 
 **Azure DevOps:**
@@ -328,40 +285,23 @@ Working as {member} ({role})
 **Feedback acknowledgment (GitHub — using bot identity):**
 
 ```bash
-TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
-if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-  echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-  exit 1
-fi
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 
 # Before making changes
-if [ -n "$TOKEN" ]; then
-  GH_TOKEN=$TOKEN gh pr comment {pr-number} --repo {owner}/{repo} \
-    --body "🔧 **{AgentName}** ({Role}) is addressing review feedback.
+GH_TOKEN=$TOKEN gh pr comment {pr-number} --repo {owner}/{repo} \
+  --body "🔧 **{AgentName}** ({Role}) is addressing review feedback.
 ⏱️ Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-else
-  gh pr comment {pr-number} --repo {owner}/{repo} \
-    --body "🔧 **{AgentName}** ({Role}) is addressing review feedback.
-⏱️ Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-fi
 
 # After pushing changes
-if [ -n "$TOKEN" ]; then
-  GH_TOKEN=$TOKEN gh pr comment {pr-number} --repo {owner}/{repo} \
-    --body "✅ **{AgentName}** addressed the feedback.
+GH_TOKEN=$TOKEN gh pr comment {pr-number} --repo {owner}/{repo} \
+  --body "✅ **{AgentName}** addressed the feedback.
 ⏱️ Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 **Changes:** {summary}
 Ready for re-review."
-else
-  gh pr comment {pr-number} --repo {owner}/{repo} \
-    --body "✅ **{AgentName}** addressed the feedback.
-⏱️ Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-**Changes:** {summary}
-Ready for re-review."
-fi
 ```
 
-> Write actions fail closed by default. Use `SQUAD_ALLOW_WRITE_FALLBACK=1` only as an explicit, auditable escape hatch for ambient auth.
+> Agent-authored feedback, review, and merge writes must use the explicit app token path above. Do not fall back to ambient auth.
 
 **Update workflow:**
 ```bash
@@ -369,12 +309,13 @@ fi
 # ⚠️ NEVER use `git add .` or `git add -A` — only stage files you intentionally changed
 git add -- {specific files you modified}
 git commit -m "fix: address review feedback"
-git push
+git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git squad/{issue-number}-{slug}
 ```
 
 **Re-request review (GitHub):**
 ```bash
-gh pr ready {pr-number}
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+GH_TOKEN=$TOKEN gh pr ready {pr-number}
 ```
 
 ### 6. PR Merge
@@ -385,12 +326,14 @@ gh pr ready {pr-number}
 
 **GitHub (merge commit):**
 ```bash
-gh pr merge {pr-number} --merge --delete-branch
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+GH_TOKEN=$TOKEN gh pr merge {pr-number} --merge --delete-branch
 ```
 
 **GitHub (squash):**
 ```bash
-gh pr merge {pr-number} --squash --delete-branch
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+GH_TOKEN=$TOKEN gh pr merge {pr-number} --squash --delete-branch
 ```
 
 **Azure DevOps:**
@@ -454,44 +397,25 @@ When spawning an agent to work on an issue, include this context block:
 
 1. **Post a start comment on the issue** using your bot identity:
    ```bash
-   TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
-   if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-     echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-     exit 1
-   fi
-   if [ -n "$TOKEN" ]; then
-     GH_TOKEN=$TOKEN gh issue comment {number} --repo {owner}/{repo} \
-       --body "🚀 **{AgentName}** ({Role}) is starting work on this issue.
+   TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+   export GH_TOKEN="$TOKEN"
+   GH_TOKEN=$TOKEN gh issue comment {number} --repo {owner}/{repo} \
+     --body "🚀 **{AgentName}** ({Role}) is starting work on this issue.
    ⏱️ Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
    🌿 Branch: \`squad/{issue-number}-{slug}\`"
-   else
-     gh issue comment {number} --repo {owner}/{repo} \
-       --body "🚀 **{AgentName}** ({Role}) is starting work on this issue.
-   ⏱️ Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-   🌿 Branch: \`squad/{issue-number}-{slug}\`"
-   fi
    ```
 
 2. **Move the issue to "In Progress" on the project board:**
    ```bash
-   if [ -n "$TOKEN" ]; then
-     GH_TOKEN=$TOKEN gh api graphql -f query='
-       mutation { updateProjectV2ItemFieldValue(input: {
-         projectId: "{project-node-id}", itemId: "{item-node-id}",
-         fieldId: "{status-field-id}",
-         value: { singleSelectOptionId: "{in-progress-option-id}" }
-       }) { projectV2Item { id } } }'
-   else
-     gh api graphql -f query='
-       mutation { updateProjectV2ItemFieldValue(input: {
-         projectId: "{project-node-id}", itemId: "{item-node-id}",
-         fieldId: "{status-field-id}",
-         value: { singleSelectOptionId: "{in-progress-option-id}" }
-       }) { projectV2Item { id } } }'
-   fi
+   GH_TOKEN=$TOKEN gh api graphql -f query='
+     mutation { updateProjectV2ItemFieldValue(input: {
+       projectId: "{project-node-id}", itemId: "{item-node-id}",
+       fieldId: "{status-field-id}",
+       value: { singleSelectOptionId: "{in-progress-option-id}" }
+     }) { projectV2Item { id } } }'
    ```
 
-> Write actions fail closed by default. Use `SQUAD_ALLOW_WRITE_FALLBACK=1` only as an explicit, auditable escape hatch for ambient auth.
+> Agent-authored writes in this lifecycle are fail-closed and must use an explicit app token.
 
 ## FEEDBACK ACKNOWLEDGMENT PROTOCOL
 
@@ -524,11 +448,8 @@ This data feeds Sprint Retro velocity analysis and Sprint Planning estimation.
 2. Push branch
 3. Open PR using:
    ```
-   TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
-   if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-     echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-     exit 1
-   fi
+   TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+   export GH_TOKEN="$TOKEN"
    cat > pr-body.txt <<'EOF'
    🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})
 
@@ -536,11 +457,7 @@ This data feeds Sprint Retro velocity analysis and Sprint Planning estimation.
 
    {description}
    EOF
-   if [ -n "$TOKEN" ]; then
-     GH_TOKEN=$TOKEN gh pr create --title "{title}" --body-file pr-body.txt --head squad/{issue-number}-{slug} --base {base-branch}
-   else
-     gh pr create --title "{title}" --body-file pr-body.txt --head squad/{issue-number}-{slug} --base {base-branch}
-   fi
+   GH_TOKEN=$TOKEN gh pr create --draft --title "{title}" --body-file pr-body.txt --head squad/{issue-number}-{slug} --base {base-branch}
    ```
 4. Report PR URL and time spent to coordinator
 ```

--- a/.squad/skills/pr-workflow/SKILL.md
+++ b/.squad/skills/pr-workflow/SKILL.md
@@ -18,29 +18,19 @@
 
 ---
 
-## GitHub Account Selection
+## GitHub Write Identity
 
-Before running any `gh` commands, ensure you are authenticated with the correct GitHub account.
+For agent-authored GitHub writes in this repo, do **not** rely on ambient `gh` auth. Resolve the explicit app token once per shell and reuse it for every write command:
 
-1. **Determine the repo owner** from the git remote:
-   ```bash
-   REPO_OWNER=$(gh repo view --json owner -q .owner.login)
-   ```
+```bash
+TOKEN=$(node "$TEAM_ROOT/.squad/scripts/resolve-token.mjs" --required "$ROLE_SLUG")
+export GH_TOKEN="$TOKEN"
+```
 
-2. **Check if this is a personal (non-EMU) repo.** EMU accounts typically have an `_` suffix (e.g., `user_microsoft`). If the repo owner is a personal account, switch `gh` to the personal account:
-   ```bash
-   # List authenticated accounts
-   gh auth status
-   # If the active account is an EMU account and the repo owner is personal, switch:
-   gh auth switch  # interactive — pick the matching account
-   ```
-
-3. **Verify** the active account matches the repo context:
-   ```bash
-   gh api user -q .login
-   ```
-
-> **Rule of thumb:** if `REPO_OWNER` does NOT contain `_` (i.e., it's not an EMU slug), use your personal GitHub account. Otherwise, use the EMU account.
+- `TEAM_ROOT` and `ROLE_SLUG` come from the coordinator prompt.
+- `--required` fails closed and prints the reason when the role/app mapping is missing or broken.
+- Read-only `gh` commands can still use normal auth, but issue/PR comments, edits, GraphQL mutations, pushes, and PR creation must use `GH_TOKEN=$TOKEN` or token-authenticated HTTPS.
+- Do **not** use `gh auth token --user`, `gh auth switch`, `ghp`, or `ghw` for agent-authored writes in `sabbour/kickstart`; those human-account paths bypass the bot identity contract.
 
 ---
 
@@ -48,19 +38,16 @@ Before running any `gh` commands, ensure you are authenticated with the correct 
 
 ### Picking Up an Issue
 
-1. **Assign to the current user** so the human owner has visibility:
-   ```bash
-   gh issue edit <N> --add-assignee "$(gh api user -q .login)"
-   ```
+1. **Do not auto-assign a human via the agent app token.** If a human assignee is intentionally needed for visibility, do that as a separate explicit human-owned step outside the agent-authored write path.
 
 2. **Post major findings as comments** on the issue as work progresses:
    ```bash
-   gh issue comment <N> --body "🔍 Finding: ..."
+   GH_TOKEN=$TOKEN gh issue comment <N> --body "🔍 Finding: ..."
    ```
 
 3. **Set the milestone** on the issue to tie it to the current sprint/release:
    ```bash
-   gh issue edit <N> --milestone "<milestone-name>"
+   GH_TOKEN=$TOKEN gh issue edit <N> --milestone "<milestone-name>"
    ```
 
 4. **Update project board fields** (Priority, Size, Estimate, Status).
@@ -71,7 +58,7 @@ Before running any `gh` commands, ensure you are authenticated with the correct 
    ```bash
    REPO_OWNER=$(gh repo view --json owner -q .owner.login)
    PROJECT_NUM=$(grep -oP 'projects/\K[0-9]+' .squad/team.md)
-   gh api graphql -f query='
+   GH_TOKEN=$TOKEN gh api graphql -f query='
      query {
        user(login: "'"$REPO_OWNER"'") {
          projectV2(number: '"$PROJECT_NUM"') {
@@ -90,7 +77,7 @@ Before running any `gh` commands, ensure you are authenticated with the correct 
 
    Then update a field on an item:
    ```bash
-   gh api graphql -f query='
+   GH_TOKEN=$TOKEN gh api graphql -f query='
      mutation {
        updateProjectV2ItemFieldValue(input: {
          projectId: "<PROJECT_ID>"
@@ -144,7 +131,7 @@ Before running any `gh` commands, ensure you are authenticated with the correct 
 
 1. **Always open as draft** — never open a ready PR directly:
    ```bash
-   gh pr create --draft \
+   GH_TOKEN=$TOKEN gh pr create --draft \
      --title "<title>" \
      --body "Closes #<issue-number>
 
@@ -163,7 +150,7 @@ Before running any `gh` commands, ensure you are authenticated with the correct 
 
 2. **Post findings as PR comments** as work progresses:
    ```bash
-   gh pr comment <N> --body "📝 Progress: ..."
+   GH_TOKEN=$TOKEN gh pr comment <N> --body "📝 Progress: ..."
    ```
 
 ### Keeping the Branch Current
@@ -173,14 +160,14 @@ When the branch is behind `main`, **always rebase** — never merge:
 git fetch origin
 git rebase origin/main
 # Resolve any conflicts
-git push --force-with-lease
+git push https://x-access-token:${TOKEN}@github.com/sabbour/kickstart.git squad/<issue-number>-<slug> --force-with-lease
 ```
 
 ### Marking Ready for Review
 
 Only after work is complete AND CI passes:
 ```bash
-gh pr ready <N>
+GH_TOKEN=$TOKEN gh pr ready <N>
 ```
 
 ### Review Gates
@@ -195,11 +182,11 @@ Zapp's review is a **pre-merge gate** for foundational patterns. Do not merge wi
 **How approvals work (label-based):**
 - **Leela** approves by adding the `leela:approved` label:
   ```bash
-  gh pr edit {number} --add-label "leela:approved" --repo sabbour/kickstart
+  GH_TOKEN=$TOKEN gh pr edit {number} --add-label "leela:approved" --repo sabbour/kickstart
   ```
 - **Zapp** approves by adding the `zapp:approved` label:
   ```bash
-  gh pr edit {number} --add-label "zapp:approved" --repo sabbour/kickstart
+  GH_TOKEN=$TOKEN gh pr edit {number} --add-label "zapp:approved" --repo sabbour/kickstart
   ```
 
 No GitHub formal PR review approval is required — squad agents share a single GitHub account with the repo owner, making self-approval impossible. The `squad/review-gate` status check (`.github/workflows/squad-review-gate.yml`) normally turns green when both labels are present. For explicitly low-risk PRs labeled `squad:chore-auto`, the gate accepts `leela:approved` alone unless the PR looks security-sensitive (`security`, `GHSA`, `CVE`, `vulnerability`) or touches sensitive paths (`.github/workflows/**`, auth, guardrail, security code), in which case `zapp:approved` is still required. `Squad Auto Merge` clears approval labels on every `synchronize` so new commits always need fresh approval labels.
@@ -209,7 +196,7 @@ No GitHub formal PR review approval is required — squad agents share a single 
 Use the REST API (not comment mentions):
 ```bash
 REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-gh api "repos/${REPO_NWO}/pulls/<N>/requested_reviewers" \
+GH_TOKEN=$TOKEN gh api "repos/${REPO_NWO}/pulls/<N>/requested_reviewers" \
   --method POST \
   -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
@@ -221,13 +208,13 @@ When a PR has review comments or formal review threads, the full feedback loop i
 1. **Read ALL feedback** — check both formal review threads AND top-level comments:
    ```bash
    # Formal review threads (these must all be resolved before merge)
-   gh pr view <N> --json reviewThreads --jq '.reviewThreads[] | {id: .id, isResolved: .isResolved, path: .path, body: (.comments[0].body // ""), line: .line}'
+   GH_TOKEN=$TOKEN gh pr view <N> --json reviewThreads --jq '.reviewThreads[] | {id: .id, isResolved: .isResolved, path: .path, body: (.comments[0].body // ""), line: .line}'
    
    # Top-level PR comments (Copilot often posts here)
-   gh pr view <N> --json comments --jq '.comments[] | {id: .id, author: .author.login, body: .body}'
+   GH_TOKEN=$TOKEN gh pr view <N> --json comments --jq '.comments[] | {id: .id, author: .author.login, body: .body}'
    
    # Formal review decisions
-   gh pr view <N> --json reviews --jq '.reviews[] | {author: .author.login, state: .state, body: .body}'
+   GH_TOKEN=$TOKEN gh pr view <N> --json reviews --jq '.reviews[] | {author: .author.login, state: .state, body: .body}'
    ```
 
 2. **For each piece of feedback, decide:**
@@ -237,18 +224,18 @@ When a PR has review comments or formal review threads, the full feedback loop i
 3. **After fixing (or deciding not to fix), ALWAYS reply to the specific comment:**
    ```bash
    # Reply to a review thread comment (get comment ID from reviewThreads query above)
-   gh api "repos/sabbour/kickstart/pulls/<PR>/comments/<comment_id>/replies" \
+   GH_TOKEN=$TOKEN gh api "repos/sabbour/kickstart/pulls/<PR>/comments/<comment_id>/replies" \
      --method POST \
      -f body="Addressed in <commit_sha>: <what you changed and why, 1-2 sentences>. Resolving thread."
    
    # OR for a top-level PR comment, reply inline:
-   gh pr comment <N> --body "Re: <quote the feedback briefly> — <what you did to address it, or why not>."
+   GH_TOKEN=$TOKEN gh pr comment <N> --body "Re: <quote the feedback briefly> — <what you did to address it, or why not>."
    ```
 
 4. **Resolve the thread after replying:**
    ```bash
    # Get thread node ID
-   THREAD_ID=$(gh api graphql -f query='{
+   THREAD_ID=$(GH_TOKEN=$TOKEN gh api graphql -f query='{
      repository(owner: "sabbour", name: "kickstart") {
        pullRequest(number: <N>) {
          reviewThreads(first: 50) {
@@ -259,12 +246,12 @@ When a PR has review comments or formal review threads, the full feedback loop i
    }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id')
    
    # Resolve it
-   gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_ID>"}) { thread { isResolved } } }'
+   GH_TOKEN=$TOKEN gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_ID>"}) { thread { isResolved } } }'
    ```
 
 5. **Verify all threads are resolved before attempting merge:**
    ```bash
-   UNRESOLVED=$(gh pr view <N> --json reviewThreads --jq '[.reviewThreads[] | select(.isResolved == false)] | length')
+   UNRESOLVED=$(GH_TOKEN=$TOKEN gh pr view <N> --json reviewThreads --jq '[.reviewThreads[] | select(.isResolved == false)] | length')
    # Must be 0 before proceeding
    ```
 
@@ -281,7 +268,7 @@ All CI checks must pass, including Playwright E2E tests. If checks fail:
 
 ### Merge Gate
 
-**Rule:** Never call `gh pr merge` without first verifying ALL of the following:
+**Rule:** Never call `GH_TOKEN=$TOKEN gh pr merge` without first verifying ALL of the following:
 
 1. **Squad label gate** — verify the PR satisfies one of the allowed approval paths on the current head:
     - standard path: `leela:approved` + `zapp:approved`
@@ -289,8 +276,8 @@ All CI checks must pass, including Playwright E2E tests. If checks fail:
     - low-risk sensitive path: `squad:chore-auto` + `leela:approved` + `zapp:approved` when the PR text looks security-sensitive or it touches `.github/workflows/**`, auth, guardrail, or security code
 
     ```bash
-    PR_JSON=$(gh pr view {number} --json number,title,body,headRefName,labels)
-    FILES_JSON=$(gh api repos/sabbour/kickstart/pulls/{number}/files --paginate)
+    PR_JSON=$(GH_TOKEN=$TOKEN gh pr view {number} --json number,title,body,headRefName,labels)
+    FILES_JSON=$(GH_TOKEN=$TOKEN gh api repos/sabbour/kickstart/pulls/{number}/files --paginate)
     jq -n --argjson pr "$PR_JSON" --argjson files "$FILES_JSON" '
       ($pr.labels | map(.name)) as $labels
       | ([ $pr.title, $pr.body, $pr.headRefName ] + $labels | map(select(. != null)) | join(" ")) as $signals
@@ -304,7 +291,7 @@ All CI checks must pass, including Playwright E2E tests. If checks fail:
 
 2. **Conversation resolution** — all review threads resolved:
    ```bash
-   gh pr view {number} --json reviewThreads --jq '[.reviewThreads[] | select(.isResolved == false)] | length'
+   GH_TOKEN=$TOKEN gh pr view {number} --json reviewThreads --jq '[.reviewThreads[] | select(.isResolved == false)] | length'
    ```
    Must return `0`.
 
@@ -318,7 +305,7 @@ If either check fails — STOP. Do not merge. Comment on the PR requesting the m
 
 Once merge gate checks pass, all reviews are addressed, threads resolved, and CI is green:
 ```bash
-gh pr merge <N> --squash --delete-branch
+GH_TOKEN=$TOKEN gh pr merge <N> --squash --delete-branch
 ```
 
 Qualifying GitHub PRs can now skip the manual merge command: the `Squad Auto Merge` workflow arms squash auto-merge when trusted merge signals are green (`CI Gate` from workflow `CI` plus `squad/review-gate` from `Squad Review Gate`), the PR is neither XL (>1000 changed lines) nor titled `refactor`, and one of these approval paths is satisfied on the current head:
@@ -376,7 +363,7 @@ Example: `squad/42-fix-login-validation`
 ## Quick Reference Checklist
 
 ```
-□ Assign issue to current user (gh api user -q .login)
+□ Assign issue to current user (GH_TOKEN=$TOKEN gh api user -q .login)
 □ Set milestone
 □ Update board → In progress
 □ Issue has exactly one `estimate:*` label
@@ -385,17 +372,17 @@ Example: `squad/42-fix-login-validation`
 □ Zapp approves DP (security)
 □ Create branch: squad/{N}-{slug}
 □ Implement (design already approved)
-□ Open draft PR: gh pr create --draft
+□ Open draft PR: GH_TOKEN=$TOKEN gh pr create --draft
 □ Post progress comments on PR
 □ Rebase if behind main (never merge)
 □ All CI green
-□ gh pr ready
+□ GH_TOKEN=$TOKEN gh pr ready
 □ Request @copilot review via API
 □ Leela reviews code quality
 □ Zapp reviews security
 □ Address all review comments
 □ Resolve all threads
 □ Update board → In review
-□ gh pr merge --squash --delete-branch
+□ GH_TOKEN=$TOKEN gh pr merge --squash --delete-branch
 □ Update board → Done
 ```

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -261,18 +261,24 @@ Working as {member} ({role})
 3. Pushes updates
 4. Requests re-review
 
+> **Fail-closed rule:** Agent-authored push / review / merge writes must resolve an explicit app token first. Do not use ambient `git` or `gh` auth in this lifecycle.
+
 **Update workflow:**
 ```bash
 # Make changes
 # ⚠️ NEVER use `git add .` or `git add -A` — only stage files you intentionally changed
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
 git add -- {specific files you modified}
 git commit -m "fix: address review feedback"
-git push
+git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git squad/{issue-number}-{slug}
 ```
 
 **Re-request review (GitHub):**
 ```bash
-gh pr ready {pr-number}
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
+GH_TOKEN=$TOKEN gh pr ready {pr-number}
 ```
 
 ### 6. PR Merge
@@ -283,12 +289,16 @@ gh pr ready {pr-number}
 
 **GitHub (merge commit):**
 ```bash
-gh pr merge {pr-number} --merge --delete-branch
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
+GH_TOKEN=$TOKEN gh pr merge {pr-number} --merge --delete-branch
 ```
 
 **GitHub (squash):**
 ```bash
-gh pr merge {pr-number} --squash --delete-branch
+TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+export GH_TOKEN="$TOKEN"
+GH_TOKEN=$TOKEN gh pr merge {pr-number} --squash --delete-branch
 ```
 
 **Azure DevOps:**

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -341,7 +341,7 @@ prompt: |
   {% endif %}
 
   {only if identity configured:}
-  GIT IDENTITY: Commit as `{app_slug}[bot]`. Resolve the token with `TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")`. For write actions, fail closed unless either the bot token resolved or `SQUAD_ALLOW_WRITE_FALLBACK=1` is explicitly set as an auditable escape hatch. PR body: `🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})`.
+  GIT IDENTITY: Commit as `{app_slug}[bot]`. Resolve the token with `TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")` and `export GH_TOKEN="$TOKEN"`. If resolution fails, stop; agent-authored writes do not fall back to ambient auth. PR body: `🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})`.
   {end identity block}
 
   TASK: {specific task description}
@@ -718,7 +718,7 @@ When spawning an agent that may do git operations (commit, push, PR), resolve th
 
 5. **Include the identity block** in the spawn prompt with the resolved values.
 
-**If config exists but role/app resolution fails for a write-capable agent, stop and fix the mapping.** Do not silently drop into ambient auth; the only escape hatch is an explicit `SQUAD_ALLOW_WRITE_FALLBACK=1` decision.
+**If config exists but role/app resolution fails for a write-capable agent, stop and fix the mapping.** Do not silently drop into ambient auth.
 
 ### Pre-Spawn: Worktree Setup
 
@@ -841,25 +841,21 @@ prompt: |
   ## GIT IDENTITY — Bot Authentication
   This project uses GitHub App identity for git operations. When pushing code or creating PRs, authenticate as the bot.
   
-  **Resolve token at runtime:**
+  **Resolve token at runtime (fail closed for writes):**
   ```bash
-  TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" "{role_slug}")
+  TOKEN=$(node "{team_root}/.squad/scripts/resolve-token.mjs" --required "{role_slug}")
+  export GH_TOKEN="$TOKEN"
   ```
-  `resolve-token.mjs` only uses explicit config keys or explicit alias mappings; it does **not** guess another app. If token resolution fails, write actions must stop unless `SQUAD_ALLOW_WRITE_FALLBACK=1` is explicitly set.
+  `resolve-token.mjs` only uses explicit config keys or explicit alias mappings; it does **not** guess another app. `--required` prints a reason to stderr and exits non-zero when write auth is not explicitly configured.
   
   **Git commit identity:**
   - `git -c user.name="{app_slug}[bot]" -c user.email="{app_slug}[bot]@users.noreply.github.com" commit ...`
   
-  **Guard write actions first:**
-  ```bash
-  if [ -z "$TOKEN" ] && [ "${SQUAD_ALLOW_WRITE_FALLBACK:-0}" != "1" ]; then
-    echo "Bot token resolution failed; refusing write action without SQUAD_ALLOW_WRITE_FALLBACK=1" >&2
-    exit 1
-  fi
-  ```
-  **Push:** `if [ -n "$TOKEN" ]; then git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git {branch}; else git push origin {branch}; fi`
-  **PR create:** `if [ -n "$TOKEN" ]; then GH_TOKEN=$TOKEN gh pr create ...; else gh pr create ...; fi`
+  **Agent-authored writes must stay on app identity:**
+  - **Push:** `git push https://x-access-token:${TOKEN}@github.com/{owner}/{repo}.git {branch}`
+  - **PR create:** `GH_TOKEN=$TOKEN gh pr create ...`
   **PR body must include:** `🤖 Created by [{app_slug}](https://github.com/apps/{app_slug})`
+  - **Do not use** ambient `gh`, ambient `git`, `gh auth token --user`, or `gh auth switch` for normal agent-authored writes.
   
   **Never log or echo the token value.**
   {end identity block}


### PR DESCRIPTION
🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)

## Summary
- harden coordinator, lifecycle, and workflow guidance so agent-authored GitHub writes fail closed on missing app tokens
- remove ambient `gh` / PAT / account-switch fallback examples from the targeted docs and skills
- keep human multi-account guidance scoped away from Kickstart agent write paths

## Testing
- `python3` validation script over touched docs ✅
- `npm run lint` ✅ (warnings only)
- `npm run build` ❌ existing unrelated workspace failure: missing `@kickstart/harness/runtime/asset-url` in `pack-core`, `pack-azure`, `pack-aks-automatic`, and `pack-github`

## Notes
- Focused wave-1 docs hardening only
