### PR TITLE
docs: update local-setup env vars to KICKSTART_* and fix endpoint format

### DIFF
--- a/docs-site/docs/getting-started/local-setup.md
+++ b/docs-site/docs/getting-started/local-setup.md
@@ -36,13 +36,18 @@ Create `packages/web/api/local.settings.json`:
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AzureWebJobsStorage": "",
-    "AZURE_OPENAI_ENDPOINT": "https://your-resource.openai.azure.com/",
+    "AZURE_OPENAI_ENDPOINT": "https://your-resource.cognitiveservices.azure.com/",
     "AZURE_OPENAI_API_KEY": "your-api-key",
-    "AZURE_OPENAI_CHAT_DEPLOYMENT": "gpt-5.4-mini",
-    "AZURE_OPENAI_CODEX_DEPLOYMENT": "gpt-5.4"
+    "KICKSTART_CHAT_MODEL": "gpt-5.4-mini",
+    "KICKSTART_CODEX_MODEL": "gpt-5.4",
+    "KICKSTART_INSPIRE_MODEL": "gpt-5.4-nano"
   }
 }
 ```
+
+:::note Endpoint format
+For **Azure AI Services** (multi-service) resources, the endpoint uses `.cognitiveservices.azure.com/`. For legacy single-service Azure OpenAI resources, use `.openai.azure.com/`. Check your resource in the Azure Portal under **Keys and Endpoint**.
+:::
 
 :::caution
 Never commit `local.settings.json` files to source control. The repo already ignores them.


### PR DESCRIPTION
## What

- Replace `AZURE_OPENAI_CHAT_DEPLOYMENT` / `AZURE_OPENAI_CODEX_DEPLOYMENT` with `KICKSTART_CHAT_MODEL` / `KICKSTART_CODEX_MODEL` / `KICKSTART_INSPIRE_MODEL` to match the migration in PR #869
- Change example endpoint from `.openai.azure.com` to `.cognitiveservices.azure.com` (correct for Azure AI Services multi-service resources)
- Add callout explaining the two endpoint formats

## Why

The production 404 bug (issue #870) was caused by `AZURE_OPENAI_ENDPOINT` pointing to `asabbour-demo-resource.openai.azure.com` when the resource is an **AIServices** account whose real endpoint is `asabbour-demo-resource.cognitiveservices.azure.com`. Fixed the SWA setting directly; this PR prevents the same mistake for new dev setups.

Closes #870