### PR TITLE
fix: align github pack asset paths with other packs

### DIFF
--- a/docs-site/docs/architecture/v2-implementation-brief.md
+++ b/docs-site/docs/architecture/v2-implementation-brief.md
@@ -1051,7 +1051,7 @@ export function resolveAssetURL(metaUrl: string, sourceRelative: string, bundled
 }
 ```
 
-The API build copies every `.agent.md` and `SKILL.md` file into pack-scoped bundle folders, but the current output is not fully uniform:
+The API build copies every `.agent.md` and `SKILL.md` file into pack-scoped bundle folders under `dist/functions/pack-assets/`, even when a pack's authoring-time markdown lives outside `src/`:
 
 ```text
 dist/
@@ -1066,15 +1066,14 @@ dist/
       aks/
         agents/
         skills/
-  pack-assets/
-    github/
-      agents/
-      skills/
+      github/
+        agents/
+        skills/
 ```
 
-Core, Azure, and AKS server manifests resolve `./pack-assets/{pack}/...` from files emitted under `dist/functions/`, so their markdown lands under `dist/functions/pack-assets/...`. `pack-github` emits `dist/server-manifest.js`, resolves `../pack-assets/github/...`, and therefore reads from `dist/pack-assets/github/...` instead.
+Core, Azure, AKS, and GitHub server manifests all resolve `./pack-assets/{pack}/...` from files emitted under `dist/functions/`, so their markdown lands under `dist/functions/pack-assets/...`. `pack-github` still reads source markdown from its package-root `agents/` and `skills/` folders during local development, but its bundled fallback now matches the same Functions-relative layout as every other pack.
 
-The `{pack}` segment is still required. Different packs can reuse filenames like `SKILL.md` or `triage.agent.md`, so pack scoping prevents cross-pack collisions during the copy step even though the parent bundle directory differs today.
+The `{pack}` segment is still required. Different packs can reuse filenames like `SKILL.md` or `triage.agent.md`, so pack scoping prevents cross-pack collisions during the copy step.
 
 ---
 

--- a/docs-site/docs/extending/overview.md
+++ b/docs-site/docs/extending/overview.md
@@ -43,7 +43,7 @@ packages/
 - **New HTTP surface?** → [API Endpoints](./api-endpoints.md) covers the Azure Functions v4 pattern with SSE streaming.
 - **IDE integration?** → [MCP Tools](./mcp-tools.md) covers MCP tool authoring for VS Code Copilot and Claude Code.
 
-If you add `.agent.md` or `SKILL.md` files, the build copies them into pack-scoped `pack-assets/{pack}/{agents|skills}/` folders that the emitted server manifest resolves at runtime. Today most packs load from `dist/functions/pack-assets/...`, while `pack-github` loads from `dist/pack-assets/...`. See the [v2 implementation brief](../architecture/v2-implementation-brief.md#bundled-markdown-asset-layout).
+If you add `.agent.md` or `SKILL.md` files, the build copies them into pack-scoped `pack-assets/{pack}/{agents|skills}/` folders that the emitted server manifest resolves at runtime. All packs now load those bundled assets from `dist/functions/pack-assets/...`, including `pack-github` even though its source markdown lives at the package root. See the [v2 implementation brief](../architecture/v2-implementation-brief.md#bundled-markdown-asset-layout).
 
 ## Design Principles
 

--- a/packages/pack-github/src/server-manifest.ts
+++ b/packages/pack-github/src/server-manifest.ts
@@ -65,8 +65,8 @@ export const githubPackServer: Pack = {
 
   // pack-github keeps agents/skills at the package root (not under src/),
   // matching the live manifest in ./index.ts.
-  agentsDir: resolveAssetURL(import.meta.url, '../agents/', '../pack-assets/github/agents/'),
-  skillsDir: resolveAssetURL(import.meta.url, '../skills/', '../pack-assets/github/skills/'),
+  agentsDir: resolveAssetURL(import.meta.url, '../agents/', './pack-assets/github/agents/'),
+  skillsDir: resolveAssetURL(import.meta.url, '../skills/', './pack-assets/github/skills/'),
 
   tools: [apiGetTool],
 

--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -97,8 +97,8 @@ const bundleAssetCopies = [
   ["../../pack-azure/src/skills", "dist/functions/pack-assets/azure/skills"],
   ["../../pack-aks-automatic/src/agents", "dist/functions/pack-assets/aks/agents"],
   ["../../pack-aks-automatic/src/skills", "dist/functions/pack-assets/aks/skills"],
-  ["../../pack-github/agents", "dist/pack-assets/github/agents"],
-  ["../../pack-github/skills", "dist/pack-assets/github/skills"],
+  ["../../pack-github/agents", "dist/functions/pack-assets/github/agents"],
+  ["../../pack-github/skills", "dist/functions/pack-assets/github/skills"],
 ];
 
 const seenBundleTargets = new Map();


### PR DESCRIPTION
## Problem
The `/api/converse` endpoint returns HTTP 200 with SSE, but emits a 404 'resource not found' error when the github pack is enabled in production.

## Root Cause
The github pack's bundled agent/skill assets were copied to an incorrect location during the esbuild process:
- Other packs: `dist/functions/pack-assets/{pack}/agents|skills/`
- Github pack: `dist/pack-assets/github/agents|skills/` (wrong location)

Additionally, the github pack's server-manifest used a relative path (`../pack-assets/github/`) that didn't align with the bundled asset resolution strategy used by all other packs (`./pack-assets/{pack}/`).

## Solution
1. **esbuild.config.mjs**: Change line 100 to copy github pack assets to `dist/functions/pack-assets/github/` (was `dist/pack-assets/github/`)
2. **pack-github/src/server-manifest.ts**: Change bundled relative paths from `../pack-assets/github/` to `./pack-assets/github/` to match asset resolution convention

## Testing
✅ Local build and test passes:
- `npm run build -w @kickstart/api` succeeds
- `/api/converse` endpoint executes without asset loading errors
- Github pack agents/skills load correctly from bundled location

## Impact
- Fixes 404 errors in production when github pack is enabled
- Aligns github pack asset layout with other packs
- No breaking changes
