### PR TITLE
chore(release): remove deprecated v* branch pattern from skill & docs

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2337,3 +2337,74 @@ Startup-only registry model is directionally sound and `seal()` is the right con
 ## Security consequence
 
 With conditions above, Step 3 remains acceptable as design foundation for Step 4. Without them, the registry becomes a trust-boundary weak point.
+
+---
+
+# Decision: Release Process — v1.0.1 Gap & Pattern Retirement
+
+**Date:** 2026-04-20T12:42:36-07:00  
+**Author:** Leela (Lead)  
+**Trigger:** Post-release audit of v1.0.1 (published 2026-04-20T16:46:55Z)  
+**Status:** DECISION: ACCEPTED
+
+---
+
+## Finding
+
+v1.0.1 was prepared via the `release` skill, which created a `release/v1.0.1` branch and applied a version-bump commit (`0df05df`, "chore(release): prepare v1.0.1 with asset path fix"). However, the `v1.0.1` git tag was applied to the **pre-bump commit** (`0dddcbb`, "chore: rename Fat components to Smart components") — a commit that IS on `main`. No PR was opened to merge `release/v1.0.1` → `main`.
+
+Result:
+- `main` is still at package.json `1.0.0`
+- The version-bump commit (1.0.1) and the "asset path fix" content it carries live only on the unmerged `release/v1.0.1` branch
+- The deploy-swa workflow **did** run on the `v1.0.1` tag push (at `2026-04-20T16:33:36Z`, result: success), but it deployed the pre-bump commit — not the asset path fix
+
+---
+
+## Issue
+
+The `release/v1.0.1` branch has one commit not on `main`:
+
+```
+0df05df  chore(release): prepare v1.0.1 with asset path fix
+         — bumps package.json to 1.0.1
+         — adds .github/scripts/squad-visible-trail.cjs + workflow
+         — adds agent inbox entries (bender/fry follow-up items)
+```
+
+This commit is stranded. `main` never received the version bump or the asset path fix. Any user loading the deployed SWA sees code from commit `0dddcbb`, not the release-prep content.
+
+---
+
+## Root Cause
+
+Two competing release workflows are in use:
+
+| Path | Branch name | Tag origin | PR back to main? |
+|------|-------------|------------|-----------------|
+| `squad-release-cadence.yml` (designed process) | `release/cadence` | Created by `squad-release.yml` on `main` push | Yes — the cadence workflow opens `release/cadence → main` PR |
+| `release` skill (used for v1.0.1) | `release/v1.0.x` | Created manually on the release branch | **No** — skill has no merge-back step |
+
+The `squad-release-cadence.yml` design is correct: it merges version-bump changes into `main` first, then the `squad-release.yml` tags from `main`. The `release` skill short-circuits this by operating on a standalone `release/v*` branch, tagging at the wrong point, and leaving no path back to `main`.
+
+This is a **process regression** — the versioned branch pattern (also used for v0.7.0 and earlier) predates the cadence workflow. The cadence workflow was never fully adopted; the old pattern persisted.
+
+---
+
+## Decision
+
+**Retire the `release/v*` versioned branch pattern entirely.** All future releases go through `release/cadence → main` only. The `squad-release.yml` on `main` push creates the tag. The `release` skill is updated to redirect to the cadence workflow or be retired in favor of the cadence automation.
+
+The cadence workflow already covers release management correctly. Running two competing release paths is the root cause of this gap. One canonical process is cleaner, more auditable, and eliminates merge conflicts and stranded commits.
+
+---
+
+## Action Items
+
+| Item | Owner | Priority | Status |
+|------|-------|----------|--------|
+| Open PR `release/v1.0.1 → main`, merge it | Leela / sabbour | **Immediate** | — |
+| Remove `release` skill or update it to use cadence workflow | Leela (workflow update) + Scribe (docs) | High | ✅ Done — skill updated to redirect to cadence workflow; `release/v*` pattern explicitly retired in skill docs |
+| Add deprecation note to release skill docs: `release/v*` branches are retired | Scribe | High | ✅ Done — deprecation warning added to `.squad/extensions/kickstart-aks-dev/skills/release-process.md` |
+| Audit v0.7.0 and earlier for same gap (stranded version bumps) | Hermes | Medium | — |
+
+---

--- a/.squad/extensions/kickstart-aks-dev/skills/release-process.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/release-process.md
@@ -1,5 +1,7 @@
 # Release Process
 
+> ⚠️ **Deprecated pattern removed.** The `release/v*` versioned branch pattern (e.g. `release/v1.0.1`) is **retired**. Do not create `release/v*` branches. All releases go through the cadence workflow only: `release/cadence → main`. See [decisions.md — Release Process v1.0.1 Gap & Pattern Retirement] for full context.
+
 **When to use:** you are reviewing the daily release PR, publishing release notes, or troubleshooting the cadence workflow.
 
 ## Context
@@ -79,6 +81,7 @@ Open a Discussion under **Announcements** only when the release changes the top-
 - **Main = pre-prod SWA.** Every merge deploys. Tags mark versioned releases but do not cut a separate production deploy today.
 - **Infra + docs** deploy on push to main, path-scoped (`.github/workflows/deploy-infra.yml`, `.github/workflows/deploy-docs.yml`).
 - **Release early, release often.** Small, frequent releases over big batches.
+- **No `release/v*` branches.** The versioned branch pattern (`release/v1.0.x`, `release/v0.7.0`, etc.) is retired. The cadence workflow is the only valid release path. Creating a `release/v*` branch bypasses merge-back to `main` and strands the version bump commit.
 
 ## Failure modes
 


### PR DESCRIPTION
## Summary

Closes the two open action items from the **Release Process — v1.0.1 Gap & Pattern Retirement** decision.

### Changes

**`.squad/extensions/kickstart-aks-dev/skills/release-process.md`**
- Added deprecation banner at the top: release/v* pattern is retired, all releases go through release/cadence -> main only
- Added explicit 'No release/v* branches' rule to the Rules section with rationale

**`.squad/decisions.md`**
- Included the uncommitted Release Process Gap decision block (drafted, not yet pushed to main)
- Marked two action items as Done: skill update and deprecation note

### Verification

Grepped all non-worktree, non-node_modules docs for release/v references. Only remaining occurrences are in the historical audit trail section of decisions.md (post-mortem analysis, not instructions).

Working as **Leela (Lead)**