### PR TITLE
fix(review-gate): preserve lane-safe approvals on synchronize

### DIFF
--- a/.github/workflows/squad-auto-merge.yml
+++ b/.github/workflows/squad-auto-merge.yml
@@ -89,6 +89,16 @@ jobs:
               return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(filename));
             }
 
+            function getPreservedApprovalLabels(labels) {
+              const hasLeelaRejection = labels.has('leela:rejected');
+              const hasZappRejection = labels.has('zapp:rejected');
+              if (hasLeelaRejection === hasZappRejection) {
+                return [];
+              }
+
+              return hasZappRejection ? ['leela:approved'] : ['zapp:approved'];
+            }
+
             function isTrustedRetroLogPr(pr, labels, changedFiles) {
               return (
                 labels.has(TRUSTED_RETRO_LABEL) &&
@@ -205,11 +215,16 @@ jobs:
 
             async function clearApprovalLabels(pr, labels) {
               if (context.eventName !== 'pull_request_target' || context.payload.action !== 'synchronize') {
-                return [];
+                return { removed: [], preserved: [] };
               }
 
+              const preserved = getPreservedApprovalLabels(labels);
+              const labelsToClear = APPROVAL_LABELS.filter((label) => !preserved.includes(label));
               const removed = [];
               for (const label of APPROVAL_LABELS) {
+                if (!labelsToClear.includes(label)) {
+                  continue;
+                }
                 if (!labels.has(label)) {
                   continue;
                 }
@@ -228,7 +243,7 @@ jobs:
                   }
                 }
               }
-              return removed;
+              return { removed, preserved };
             }
 
             async function getTrustedWorkflowRuns(headSha, prNumber) {
@@ -322,8 +337,11 @@ jobs:
             const trustedRetroLogPr = isTrustedRetroLogPr(pr, labels, changedFiles);
             const dependabotPr = isDependabotPr(pr);
             const zappRequirementReason = getZappRequirementReason(pr, labels, changedFiles);
-            const removedLabels = await clearApprovalLabels(pr, labels);
-            if (removedLabels.length > 0) {
+            const clearedApprovals = await clearApprovalLabels(pr, labels);
+            if (clearedApprovals.removed.length > 0) {
+              const preservedLabelsSummary = clearedApprovals.preserved
+                .map((label) => `\`${label}\``)
+                .join(', ');
               await disableAutoMerge(
                 pr,
                 'new commits require fresh approvals',
@@ -331,11 +349,13 @@ jobs:
                   AUTO_MERGE_MARKER,
                   '🤖 Auto-merge disarmed.',
                   '',
-                  `- removed stale approval labels: ${removedLabels.join(', ')}`,
-                  '- new commits require fresh approval labels before re-arming',
+                  `- removed stale approval labels: ${clearedApprovals.removed.join(', ')}`,
+                  clearedApprovals.preserved.length > 0
+                    ? `- preserved ${preservedLabelsSummary} because the opposite reviewer is already in a rejection loop`
+                    : '- new commits require fresh approval labels before re-arming',
                 ].join('\n'),
               );
-              core.info(`Cleared stale approval labels for PR #${pr.number}: ${removedLabels.join(', ')}`);
+              core.info(`Cleared stale approval labels for PR #${pr.number}: ${clearedApprovals.removed.join(', ')}`);
               return;
             }
 

--- a/.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md
@@ -120,7 +120,7 @@ GH_TOKEN=$TOKEN gh pr ready <N>
 | Zapp | Security, auth, secrets, tool schemas, guardrails |
 | Hermes | Test coverage across the layers the PR touches |
 
-Both Leela and Zapp must approve. The `.github/workflows/squad-review-gate.yml` workflow enforces this as a required status check, and `Squad Auto Merge` clears those approval labels on every `synchronize` so fresh approval is always tied to the current head commit.
+Both Leela and Zapp must approve. The `.github/workflows/squad-review-gate.yml` workflow enforces this as a required status check, and `Squad Auto Merge` clears approval labels on `synchronize` unless the PR is already in the opposite reviewer's rejection loop. Today that means a `zapp:rejected` fix cycle preserves `leela:approved`, and a `leela:rejected` fix cycle preserves `zapp:approved`.
 
 ### 8. Address review comments
 


### PR DESCRIPTION
## Root Cause

The `clearApprovalLabels()` function in `squad-auto-merge.yml` stripped **all** approval labels (`leela:approved`, `zapp:approved`) unconditionally on every `pull_request_target` `synchronize` event. This caused unnecessary re-review loops:

- Zapp rejects a security finding → Hermes pushes a fix commit → `leela:approved` is stripped even though Leela's concerns weren't related to the security fix → Leela must re-approve.

## Fix

Added `getPreservedApprovalLabels()`: when exactly one reviewer has a `rejected` label present on the PR, the **other** reviewer's approval is preserved across the synchronize event:

- `zapp:rejected` present (but not `leela:rejected`) → preserve `leela:approved`
- `leela:rejected` present (but not `zapp:rejected`) → preserve `zapp:approved`
- Both or neither rejected → clear all approvals (fail-safe default)

This is conservative: it only preserves when we have an explicit signal that the new commit is addressing a lane-specific rejection. Any ambiguous push still invalidates all approvals.

## Files changed

- `.github/workflows/squad-auto-merge.yml` — `clearApprovalLabels` now returns `{ removed, preserved }`; added `getPreservedApprovalLabels()`
- `.squad/extensions/kickstart-aks-dev/skills/pr-workflow.md` — behavior doc updated to match

## Impact on PR #897 / #898

Both PRs are blocked by the approval-churn this fix addresses. Once merged, Leela's approval will survive Zapp-only fix commits, unblocking the v1.0.1 deployment fix.

Working as Bender (Backend Dev)

Closes #875