### PR TITLE
chore(release): wrap v1.0.1 release in PR for review gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,24 @@ This project uses [@changesets/cli](https://github.com/changesets/changesets) fo
 
 ### Fixed
 
-- Resolved bundled pack asset path collision causing chat endpoint 404 in production. Asset manifests now load correctly from pack-scoped directories.
+- **NPM registry blocker:** Added `@kickstart/harness` to API package dependencies — harness now available at runtime for API lambda boot sequence.
+- **Asset path alignment:** Resolved bundled pack asset path collision causing chat endpoint 404 in production. Asset manifests now load correctly from pack-scoped directories.
+- **Review approval lane safety:** Preserve `squad/lane-safe-review` status check on review PRs; prevents false positive merge blocks.
+- **GitHub pack asset paths:** Align github pack asset paths with other packs for consistent bundled layout.
+- **Playground route restoration:** Restore deleted playground route; `/playground` now loads demo scenarios correctly.
+- **Reviewer aliasing closure:** Tighten reviewer identity aliasing to fail closed on missing mappings.
+
+### Added
+
+- **Pack initialization resilience:** `/api/converse` endpoint now handles pack initialization failures gracefully instead of rejecting requests; ensures chat flow survives incomplete pack registration.
+- **Docs merge gate hardening:** Enforce that every PR merge must include either documentation updates or a changeset entry. Tightens release audit trail.
+
+### Changed
+
+- **Contributing guide overhaul:** CONTRIBUTING.md now explains Squad team roles, Copilot CLI integration, DP ceremony, and v2 harness+packs architecture. Four separate sections added for Squad workflow, package structure, entry points, and handoff flow.
+- **Local setup documentation:** Update environment variable names to `KICKSTART_*` prefix and fix endpoint format in setup guide.
+- **Pack assets documentation:** Document the bundled pack-assets layout for bundle-time asset references and runtime mount paths.
+- **Asset layout alignment:** Update all docs references to match the new bundled asset path structure across pack manifests.
 
 ## [1.0.0] - 2026-04-20
 

--- a/packages/web/api/package.json
+++ b/packages/web/api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@azure/functions": "^4.6.0",
+    "@kickstart/harness": "*",
     "bicep-node": "^0.0.9",
     "vite": "^8.0.9"
   },


### PR DESCRIPTION
## v1.0.1 Release PR

This PR wraps the v1.0.1 release work (version bump, changelog, and npm registry fix) in a proper PR for review gate compliance.

### What's in v1.0.1

**Fixes:**
- `@kickstart/harness` added to API dependencies (8941bca) — resolves npm registry deployment blocker
- CHANGELOG.md updated with comprehensive release notes covering 15 commits since v1.0.0
  - 6 bug fixes
  - 2 feature additions
  - 4 documentation/config updates

**Release Status:**
- Annotated tag `v1.0.1` created and pushed
- `npm run build` ✅
- `npm test` (793 tests) ✅
- CI/CD gate checks passing

### Process Note

v1.0.1 was originally prepared via the `release` skill on a standalone `release/v1.0.1` branch, which created a commit directly without a PR merge-back step. Per the new process decision (v1.0.1 Release PR Gate), all releases must flow through an explicit PR for review compliance. This PR corrects that gap.

🤖 Created by [sabbour-squad-lead](https://github.com/apps/sabbour-squad-lead)