### PR TITLE
release: v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project uses [@changesets/cli](https://github.com/changesets/changesets) for versioning.
 
+## [1.0.2] - 2026-04-20
+
+### Fixed
+
+- **Package scope clarity:** Renamed package scope from `@kickstart` to `@aks-kickstart` to resolve npm registry resolution errors during Azure SWA deployment. Workspace packages are no longer confused with public npm packages.
+
 ## [1.0.1] - 2026-04-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kickstart",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AI-guided onboarding for deploying apps to AKS",
   "license": "MIT",
   "workspaces": [


### PR DESCRIPTION
Prepare v1.0.2 release with package scope rename.

## Changes
- Update version to 1.0.2
- Update CHANGELOG with package scope fix

## Details
This release includes the @kickstart → @aks-kickstart package scope rename that resolves npm registry resolution errors during Azure SWA deployment.

All tests passing (793 passed, 0 failed).