### PR TITLE
fix: use local workspace references instead of npm for internal packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kickstart",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kickstart",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -15980,7 +15980,7 @@
     },
     "packages/harness": {
       "name": "@kickstart/harness",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@openai/agents": "0.8.4",
         "yaml": "^2.8.1",
@@ -15992,13 +15992,13 @@
     },
     "packages/mcp-server": {
       "name": "@kickstart/mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@kickstart/harness": "*",
-        "@kickstart/pack-aks-automatic": "*",
-        "@kickstart/pack-azure": "*",
-        "@kickstart/pack-core": "*",
-        "@kickstart/pack-github": "*",
+        "@kickstart/harness": "file:../harness",
+        "@kickstart/pack-aks-automatic": "file:../pack-aks-automatic",
+        "@kickstart/pack-azure": "file:../pack-azure",
+        "@kickstart/pack-core": "file:../pack-core",
+        "@kickstart/pack-github": "file:../pack-github",
         "@modelcontextprotocol/sdk": "^1.12.1"
       },
       "bin": {
@@ -16010,9 +16010,9 @@
     },
     "packages/pack-aks-automatic": {
       "name": "@kickstart/pack-aks-automatic",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@kickstart/harness": "*",
+        "@kickstart/harness": "file:../harness",
         "@openai/agents": "^0.8.4",
         "zod": "^4.1.12"
       },
@@ -16031,9 +16031,9 @@
     },
     "packages/pack-azure": {
       "name": "@kickstart/pack-azure",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@kickstart/harness": "*",
+        "@kickstart/harness": "file:../harness",
         "@openai/agents": "^0.8.4",
         "zod": "^4.1.12"
       },
@@ -16052,9 +16052,9 @@
     },
     "packages/pack-core": {
       "name": "@kickstart/pack-core",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@kickstart/harness": "*",
+        "@kickstart/harness": "file:../harness",
         "@openai/agents": "^0.8.4",
         "zod": "^3.0.0"
       },
@@ -16164,9 +16164,9 @@
     },
     "packages/pack-github": {
       "name": "@kickstart/pack-github",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@kickstart/harness": "*",
+        "@kickstart/harness": "file:../harness",
         "@openai/agents": "^0.8.4",
         "zod": "^4.1.12"
       },
@@ -16185,7 +16185,7 @@
     },
     "packages/web": {
       "name": "@kickstart/web",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-components": "^9.73.7",
@@ -16220,6 +16220,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@azure/functions": "^4.6.0",
+        "@kickstart/harness": "file:../../harness",
         "bicep-node": "^0.0.9",
         "vite": "^8.0.9"
       },
@@ -16235,6 +16236,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16251,6 +16253,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16267,6 +16270,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16283,6 +16287,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16299,6 +16304,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16315,6 +16321,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16331,6 +16338,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16347,6 +16355,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16363,6 +16372,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16379,6 +16389,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16395,6 +16406,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16411,6 +16423,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16427,6 +16440,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16443,6 +16457,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16459,6 +16474,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16475,6 +16491,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16491,6 +16508,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16507,6 +16525,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16523,6 +16542,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16539,6 +16559,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16555,6 +16576,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16571,6 +16593,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16587,6 +16610,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16603,6 +16627,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16619,6 +16644,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16635,6 +16661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -16,11 +16,11 @@
     "clean": "node -e \"const f=require('fs');f.rmSync('dist',{recursive:true,force:true});f.rmSync('tsconfig.tsbuildinfo',{force:true})\""
   },
   "dependencies": {
-    "@kickstart/harness": "*",
-    "@kickstart/pack-core": "*",
-    "@kickstart/pack-azure": "*",
-    "@kickstart/pack-aks-automatic": "*",
-    "@kickstart/pack-github": "*",
+    "@kickstart/harness": "file:../harness",
+    "@kickstart/pack-core": "file:../pack-core",
+    "@kickstart/pack-azure": "file:../pack-azure",
+    "@kickstart/pack-aks-automatic": "file:../pack-aks-automatic",
+    "@kickstart/pack-github": "file:../pack-github",
     "@modelcontextprotocol/sdk": "^1.12.1"
   },
   "devDependencies": {

--- a/packages/pack-aks-automatic/package.json
+++ b/packages/pack-aks-automatic/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@kickstart/harness": "*",
+    "@kickstart/harness": "file:../harness",
     "@openai/agents": "^0.8.4",
     "zod": "^4.1.12"
   },

--- a/packages/pack-azure/package.json
+++ b/packages/pack-azure/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@kickstart/harness": "*",
+    "@kickstart/harness": "file:../harness",
     "@openai/agents": "^0.8.4",
     "zod": "^4.1.12"
   },

--- a/packages/pack-core/package.json
+++ b/packages/pack-core/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@kickstart/harness": "*",
+    "@kickstart/harness": "file:../harness",
     "@openai/agents": "^0.8.4",
     "zod": "^3.0.0"
   },

--- a/packages/pack-github/package.json
+++ b/packages/pack-github/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@kickstart/harness": "*",
+    "@kickstart/harness": "file:../harness",
     "@openai/agents": "^0.8.4",
     "zod": "^4.1.12"
   },

--- a/packages/web/api/package.json
+++ b/packages/web/api/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@azure/functions": "^4.6.0",
-    "@kickstart/harness": "*",
+    "@kickstart/harness": "file:../../harness",
     "bicep-node": "^0.0.9",
     "vite": "^8.0.9"
   },


### PR DESCRIPTION
Resolves the SWA deployment blocker by changing @kickstart/* package dependencies to use file:// references instead of npm.

## Problem
The Azure Static Web Apps deployment was failing with:
```
npm error 404 Not Found - GET https://registry.npmjs.org/@kickstart%2fharness
```

The issue: these are internal workspace packages, not published to npm. But the API was configured with `workspaces=false` in .npmrc, causing npm to try fetching them from the public registry during `npm install --production`.

## Solution
Changed all internal package dependencies to use file:// references:
- packages/web/api: @kickstart/harness → file:../../harness
- packages/mcp-server: all pack dependencies → file: references  
- packages/pack-*: @kickstart/harness → file:../harness

This allows the packages to resolve from the local workspace even when workspaces=false.

## Testing
- ✅ npm install succeeds
- ✅ npm run build succeeds
- ✅ npm test passes (793 tests)
- ✅ npm run lint passes

Closes deployment blocker.