### PR TITLE
fix: skip Oryx API build to use pre-resolved workspace packages

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Build web app (Vite)
         run: cd packages/web && npx vite build
 
+      - name: Pre-build API to resolve workspace packages
+        run: |
+          cd packages/web/api
+          npm install --production
+
       - name: Deploy to Azure Static Web Apps
         id: swa_deploy
         uses: Azure/static-web-apps-deploy@v1
@@ -55,6 +60,7 @@ jobs:
           api_location: "packages/web/api"
           output_location: ""
           skip_app_build: true
+          skip_api_build: true
 
       - name: Resolve production smoke target
         id: production_url


### PR DESCRIPTION
Fixes the SWA deployment failure caused by Oryx trying to resolve file:// symlinks in its isolated Docker container.

**Problem:**
- After PR #907 (workspace refs fix), the deployment fails during zipping
- Oryx runs npm install in a container where file:// paths don't resolve
- Error: 'Could not find file .../node_modules/@kickstart/harness'

**Solution:**
- Pre-build API packages in GitHub Actions environment (where file:// works)
- Skip Oryx's API build so it uses the pre-resolved node_modules
- Set skip_api_build: true

This ensures the actual resolved node_modules are uploaded, not broken symlinks.