### PR TITLE
ci: Fix changeset status check in PR contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
 
       - name: Changeset status
         if: steps.docs_gate.outputs.requireChangeset == 'true'
-        run: npx changeset status
+        run: |
+          # Create a local main branch for changesets to compare against
+          git fetch origin main:main --no-tags || git fetch origin main:main
+          npx changeset status
 
   e2e:
     name: Playwright E2E Tests


### PR DESCRIPTION
## Problem
The 'npx changeset status' command fails in PR CI checks with:
```
Error: Failed to find where HEAD diverged from "main"
```

This happens because the PR checkout creates a detached HEAD, and changeset can't find a local 'main' branch ref to compare against.

## Solution
Explicitly create a local main branch ref by running:
```bash
git fetch origin main:main
```

before running changeset status. This ensures changesets can find the divergence point.

## Impact
- Fixes CI gate failures for PRs that modify user-facing code without docs updates
- No impact on other CI checks or main branch merges
- Allows changesets to correctly detect which packages have changed