### PR TITLE
fix(api): bundle @azure/functions + bicep-node to fix SWA health 404

### DIFF
--- a/.changeset/fix-api-health-404.md
+++ b/.changeset/fix-api-health-404.md
@@ -1,0 +1,21 @@
+---
+'@kickstart/api': patch
+---
+
+Fix persistent HTTP 404 on `/api/health` after SWA deployment.
+
+Root cause: `packages/web/api/.npmrc` sets `workspaces=false` but npm v7+ silently
+ignores this when run inside a workspace root (CI log shows
+`npm warn config ignoring workspace config`). As a result, `@azure/functions` was
+never installed into `packages/web/api/node_modules` — it was hoisted to the repo root
+instead. The SWA action uploads only `packages/web/api`, so the Azure Functions worker
+could not resolve the import, no function handler registered, and every request
+returned 404.
+
+Fix: change `external` in `esbuild.config.mjs` from `["@azure/functions", "bicep-node"]`
+to `["@azure/functions-core"]`. Both `@azure/functions` and `bicep-node` are pure
+JavaScript; they are now bundled inline. `@azure/functions-core` is a virtual module
+injected by the Azure Functions Node.js worker host at runtime — it must remain external.
+
+Also removes the now-redundant "Resolve API workspace dependencies" workflow step and
+removes `continue-on-error: true` from the smoke check so failures surface properly.

--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -42,11 +42,6 @@ jobs:
       - name: Build all workspaces
         run: npm run build
 
-      - name: Resolve API workspace dependencies
-        run: |
-          cd packages/web/api
-          npm install --production --no-save
-
       - name: Verify API dist
         run: test -f packages/web/api/dist/functions/health.js || (echo "❌ API bundle not found at packages/web/api/dist/functions/" && exit 1)
 
@@ -77,7 +72,6 @@ jobs:
 
       - name: Smoke check live API health
         if: steps.production_url.outputs.base_url != ''
-        continue-on-error: true
         env:
           SWA_HEALTHCHECK_URL: ${{ steps.production_url.outputs.base_url }}/api/health
         run: node scripts/check-swa-health.mjs

--- a/packages/web/api/esbuild.config.mjs
+++ b/packages/web/api/esbuild.config.mjs
@@ -2,9 +2,11 @@
  * esbuild config for @kickstart/api
  *
  * Bundles each Azure Function entry point into a self-contained ESM file.
- * @kickstart/harness is inlined (not published to npm), while @azure/functions,
- * bicep-node, and Node.js built-ins stay external (resolved from node_modules
- * at runtime).
+ * All npm dependencies (including @azure/functions and bicep-node) are inlined;
+ * only Node.js built-ins stay external.  Making the bundles self-contained
+ * avoids a deployment-time issue where npm workspace hoisting keeps those
+ * packages in the repo root node_modules rather than packages/web/api/node_modules,
+ * causing the Functions worker to fail to resolve them in Azure SWA.
  */
 
 import * as esbuild from "esbuild";
@@ -75,7 +77,18 @@ await esbuild.build({
   format: "esm",
   platform: "node",
   target: "node22",
-  external: ["@azure/functions", "bicep-node"],
+  // @azure/functions-core is the only module that must stay external — it is a
+  // virtual module injected by the Azure Functions Node.js worker host at
+  // runtime and is never present in node_modules.  All other npm dependencies
+  // (including @azure/functions and bicep-node) are pure JavaScript and are
+  // bundled inline so that dist/functions/*.js files are self-contained.
+  //
+  // Background: npm workspace hoisting keeps these packages in the repo root
+  // node_modules rather than packages/web/api/node_modules, and the
+  // packages/web/api/.npmrc "workspaces=false" override is silently ignored in
+  // CI (npm warns "ignoring workspace config").  Bundling them removes the
+  // runtime dependency on node_modules entirely.
+  external: ["@azure/functions-core"],
   banner: {
     js: "import { createRequire as __kickstartCreateRequire } from 'node:module'; const require = __kickstartCreateRequire(import.meta.url);",
   },


### PR DESCRIPTION
## Problem

Persistent HTTP 404 on `/api/health` after PR #925 merged. All 8 smoke-check retries in CI fail with `HTTP 404 Not Found; body=(empty)`. The failure was masked as green by `continue-on-error: true` on the smoke-check step.

## Root Cause

`packages/web/api/.npmrc` sets `workspaces=false` to force local installation of deps — but **npm v7+ silently ignores this** when the working directory is inside a workspace root (CI log: `npm warn config ignoring workspace config at .../packages/web/api/.npmrc`).

So `npm install --production --no-save` hoisted `@azure/functions` and `bicep-node` to the repo root `node_modules` rather than `packages/web/api/node_modules`. The SWA action uploads only `packages/web/api`, so those packages were absent from the deployment artifact. The Azure Functions worker could not resolve the imports, no function handler registered, and every request returned 404.

## Fix

Change `external` in `packages/web/api/esbuild.config.mjs` from:
```js
external: ["@azure/functions", "bicep-node"]
```
to:
```js
external: ["@azure/functions-core"]
```

Both `@azure/functions` and `bicep-node` are pure JavaScript — no native bindings. Bundling them makes every `dist/functions/*.js` self-contained, eliminating the runtime dependency on `node_modules`.

`@azure/functions-core` **must stay external** — it is a virtual module injected by the Azure Functions Node.js worker host at runtime. It is never present in `node_modules` and cannot be bundled.

Also:
- **Remove** the now-dead "Resolve API workspace dependencies" step (`npm install --production --no-save` that was silently not working since PR #823)
- **Remove** `continue-on-error: true` from the smoke-check step so regressions surface as failures

Working as Bender (Backend Dev)

Closes #926