### PR TITLE
feat(web): Debug panel — surface agentName, skillsExecuted, toolsExecuted (#959)

### DIFF
--- a/.changeset/debug-end-fields-958.md
+++ b/.changeset/debug-end-fields-958.md
@@ -1,0 +1,6 @@
+---
+'@aks-kickstart/harness': patch
+'@aks-kickstart/web': patch
+---
+
+Debug panel: include `agentName`, `skillsExecuted`, and `toolsExecuted` in the SSE `end` event (#958). The runner now tracks tool call names/status and matched skill IDs per turn and surfaces them so the frontend debug panel can display which agent, skills, and tools were active.

--- a/.changeset/debug-panel-agent-skills-tools-959.md
+++ b/.changeset/debug-panel-agent-skills-tools-959.md
@@ -1,0 +1,5 @@
+---
+'@aks-kickstart/web': patch
+---
+
+Debug panel: surface `agentName`, `skillsExecuted`, and `toolsExecuted` from the SSE `end` event (#959). The main-chat Debug panel now includes three new sections — **Agent** (single label), **Skills** (list of skill IDs), and **Tools** (list of tool names with ok/error status dots) — fed from the fields added in #958. All fields are optional; when absent, each section renders a dimmed `—`.

--- a/packages/harness/src/runtime/runner.ts
+++ b/packages/harness/src/runtime/runner.ts
@@ -415,6 +415,11 @@ export class Runner {
     // Buffer all text chunks — output guardrails must pass before any chunk is sent to the client.
     const chunkBuffer: string[] = [];
 
+    // Debug telemetry — track tool calls and matched skills for the `end` event.
+    const toolsExecuted: Array<{ name: string; status: 'ok' | 'error' }> = [];
+    const pendingToolNames = new Map<string, number>(); // toolName → index in toolsExecuted
+    const skillsExecuted = skills.map((s) => s.id);
+
     try {
       const sdkRunner = getSdkRunner();
       const result = await sdkRunner.run(agent, guardedMessage, {
@@ -444,9 +449,14 @@ export class Runner {
           if (name === 'tool_called') {
             const toolName = (item as { rawItem?: { name?: string } }).rawItem?.name ?? 'unknown';
             sseWrite('tool_start', { toolName });
+            // Record a pending entry; will be updated to 'ok' on tool_output.
+            const idx = toolsExecuted.push({ name: toolName, status: 'ok' }) - 1;
+            pendingToolNames.set(toolName, idx);
           } else if (name === 'tool_output') {
             const toolName = (item as { rawItem?: { name?: string } }).rawItem?.name ?? 'unknown';
             sseWrite('tool_done', { toolName });
+            // Mark the matching pending entry as ok (already defaulted to 'ok').
+            pendingToolNames.delete(toolName);
           } else if (name === 'handoff_occurred') {
             const newAgentName = (item as { agent?: { name?: string } }).agent?.name;
             if (newAgentName) {
@@ -529,6 +539,9 @@ export class Runner {
         sessionId: session.sessionId,
         intent,
         model: modelName,
+        agentName,
+        skillsExecuted,
+        toolsExecuted,
       });
     } catch (err: unknown) {
       // AbortError: may be a UserAction interrupt OR a guardrail halt

--- a/packages/web/src/__tests__/sse-stream-end-model.test.ts
+++ b/packages/web/src/__tests__/sse-stream-end-model.test.ts
@@ -162,3 +162,82 @@ describe('_processSSEStream — error and phase events', () => {
     expect(onPhase).toHaveBeenCalledWith('design-agent');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #958 — end event carries agentName, skillsExecuted, toolsExecuted
+// ---------------------------------------------------------------------------
+
+describe('_processSSEStream — debug fields in end event (#958)', () => {
+  it('returns agentName, skillsExecuted, and toolsExecuted from the end event', async () => {
+    const stream = makeSSEStream([
+      sseFrame('start', { sessionId: 'sess-1' }),
+      sseFrame('chunk', { delta: 'Sure!' }),
+      sseFrame('end', {
+        sessionId: 'sess-1',
+        model: 'gpt-5.4-mini',
+        agentName: 'core.triage',
+        skillsExecuted: ['core/github-import'],
+        toolsExecuted: [{ name: 'core.emit_ui', status: 'ok' }],
+      }),
+    ]);
+
+    const result = await _processSSEStream(stream, {});
+
+    expect(result.agentName).toBe('core.triage');
+    expect(result.skillsExecuted).toEqual(['core/github-import']);
+    expect(result.toolsExecuted).toEqual([{ name: 'core.emit_ui', status: 'ok' }]);
+  });
+
+  it('returns undefined for debug fields when the end event omits them (backward compat)', async () => {
+    const stream = makeSSEStream([
+      sseFrame('end', { sessionId: 's', model: 'gpt-5.4-mini' }),
+    ]);
+
+    const result = await _processSSEStream(stream, {});
+
+    expect(result.agentName).toBeUndefined();
+    expect(result.skillsExecuted).toBeUndefined();
+    expect(result.toolsExecuted).toBeUndefined();
+  });
+
+  it('filters malformed toolsExecuted entries (type safety)', async () => {
+    const stream = makeSSEStream([
+      sseFrame('end', {
+        model: 'gpt-5.4-mini',
+        agentName: 'core.triage',
+        toolsExecuted: [
+          { name: 'core.emit_ui', status: 'ok' },
+          { name: 42, status: 'ok' },       // malformed — name not a string
+          { name: 'core.read_file' },        // malformed — missing status
+          null,                              // malformed — not an object
+        ],
+      }),
+    ]);
+
+    const result = await _processSSEStream(stream, {});
+
+    // Only the valid entry passes the type guard
+    expect(result.toolsExecuted).toEqual([{ name: 'core.emit_ui', status: 'ok' }]);
+  });
+
+  it('reports multiple tool calls including errors', async () => {
+    const stream = makeSSEStream([
+      sseFrame('end', {
+        model: 'gpt-5.4-mini',
+        agentName: 'core.codesmith',
+        skillsExecuted: [],
+        toolsExecuted: [
+          { name: 'core.fetch_webpage', status: 'ok' },
+          { name: 'core.write_file', status: 'error' },
+        ],
+      }),
+    ]);
+
+    const result = await _processSSEStream(stream, {});
+
+    expect(result.agentName).toBe('core.codesmith');
+    expect(result.skillsExecuted).toEqual([]);
+    expect(result.toolsExecuted).toHaveLength(2);
+    expect(result.toolsExecuted?.[1]).toEqual({ name: 'core.write_file', status: 'error' });
+  });
+});

--- a/packages/web/src/components/Chat/DebugPanel.tsx
+++ b/packages/web/src/components/Chat/DebugPanel.tsx
@@ -135,6 +135,39 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground4,
     fontStyle: 'italic',
   },
+  list: {
+    listStyleType: 'none',
+    paddingLeft: '0',
+    marginTop: '0',
+    marginBottom: '0',
+  },
+  listItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+    paddingTop: tokens.spacingVerticalXXS,
+    paddingBottom: tokens.spacingVerticalXXS,
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground1,
+  },
+  statusDot: {
+    display: 'inline-block',
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%',
+    flexShrink: 0,
+  },
+  statusOk: {
+    backgroundColor: tokens.colorPaletteGreenForeground1,
+  },
+  statusError: {
+    backgroundColor: tokens.colorPaletteRedForeground1,
+  },
+  statusLabel: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase100,
+  },
 });
 
 /** Simple JSON syntax highlighting via inline styles. */
@@ -261,6 +294,53 @@ export function DebugPanel({ debugInfo, a2uiMessages }: DebugPanelProps) {
               <Text font="monospace" size={200}>{debugInfo.model}</Text>
             ) : (
               <Text className={styles.notAvailable} size={200}>Not available</Text>
+            )}
+          </div>
+
+          {/* Agent */}
+          <div className={styles.section}>
+            <Text className={styles.sectionLabel}>Agent</Text>
+            {debugInfo?.agentName ? (
+              <Text font="monospace" size={200}>{debugInfo.agentName}</Text>
+            ) : (
+              <Text className={styles.notAvailable} size={200}>—</Text>
+            )}
+          </div>
+
+          {/* Skills */}
+          <div className={styles.section}>
+            <Text className={styles.sectionLabel}>Skills</Text>
+            {debugInfo?.skillsExecuted && debugInfo.skillsExecuted.length > 0 ? (
+              <ul className={styles.list}>
+                {debugInfo.skillsExecuted.map((skillId) => (
+                  <li key={skillId} className={styles.listItem}>
+                    <span>{skillId}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <Text className={styles.notAvailable} size={200}>—</Text>
+            )}
+          </div>
+
+          {/* Tools */}
+          <div className={styles.section}>
+            <Text className={styles.sectionLabel}>Tools</Text>
+            {debugInfo?.toolsExecuted && debugInfo.toolsExecuted.length > 0 ? (
+              <ul className={styles.list}>
+                {debugInfo.toolsExecuted.map((tool, idx) => (
+                  <li key={`${tool.name}-${idx}`} className={styles.listItem}>
+                    <span
+                      className={`${styles.statusDot} ${tool.status === 'ok' ? styles.statusOk : styles.statusError}`}
+                      aria-hidden="true"
+                    />
+                    <span>{tool.name}</span>
+                    <span className={styles.statusLabel}>{tool.status}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <Text className={styles.notAvailable} size={200}>—</Text>
             )}
           </div>
 

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -169,6 +169,9 @@ export interface SSEStreamResult {
   model: string | undefined;
   sessionId: string | undefined;
   intent: string | undefined;
+  agentName: string | undefined;
+  skillsExecuted: string[] | undefined;
+  toolsExecuted: Array<{ name: string; status: 'ok' | 'error' }> | undefined;
 }
 
 /**
@@ -198,6 +201,9 @@ export async function _processSSEStream(
     model: undefined,
     sessionId: undefined,
     intent: undefined,
+    agentName: undefined,
+    skillsExecuted: undefined,
+    toolsExecuted: undefined,
   };
 
   const reader = body.getReader();
@@ -250,6 +256,18 @@ export async function _processSSEStream(
                 callbacks.onIntent?.({ summary: parsed.intent });
               }
               if (parsed.model) state.model = String(parsed.model);
+              if (typeof parsed.agentName === 'string') state.agentName = parsed.agentName;
+              if (Array.isArray(parsed.skillsExecuted)) {
+                state.skillsExecuted = (parsed.skillsExecuted as unknown[]).filter((s): s is string => typeof s === 'string');
+              }
+              if (Array.isArray(parsed.toolsExecuted)) {
+                state.toolsExecuted = (parsed.toolsExecuted as unknown[]).filter(
+                  (t): t is { name: string; status: 'ok' | 'error' } =>
+                    typeof t === 'object' && t !== null &&
+                    typeof (t as Record<string, unknown>).name === 'string' &&
+                    ((t as Record<string, unknown>).status === 'ok' || (t as Record<string, unknown>).status === 'error'),
+                );
+              }
               break;
 
             case 'error': {

--- a/packages/web/src/hooks/useStreaming.ts
+++ b/packages/web/src/hooks/useStreaming.ts
@@ -374,6 +374,9 @@ export function useStreaming() {
     let lastModel: string | undefined;
     let lastSessionId: string | undefined;
     let lastUsage: TokenUsageSummary | undefined;
+    let lastAgentName: string | undefined;
+    let lastSkillsExecuted: string[] | undefined;
+    let lastToolsExecuted: Array<{ name: string; status: 'ok' | 'error' }> | undefined;
     const debugA2uiMessages: A2uiPayloadItem[] = [];
 
     // Build client messages for potential session rehydration
@@ -529,6 +532,23 @@ export function useStreaming() {
                   callbacks.onIntent?.({ summary: parsed.intent });
                 }
                 if (parsed.model) lastModel = parsed.model as string;
+                if (typeof parsed.agentName === 'string') {
+                  lastAgentName = parsed.agentName;
+                }
+                if (Array.isArray(parsed.skillsExecuted)) {
+                  lastSkillsExecuted = (parsed.skillsExecuted as unknown[]).filter(
+                    (s): s is string => typeof s === 'string',
+                  );
+                }
+                if (Array.isArray(parsed.toolsExecuted)) {
+                  lastToolsExecuted = (parsed.toolsExecuted as unknown[]).filter(
+                    (t): t is { name: string; status: 'ok' | 'error' } =>
+                      typeof t === 'object' && t !== null &&
+                      typeof (t as Record<string, unknown>).name === 'string' &&
+                      ((t as Record<string, unknown>).status === 'ok' ||
+                        (t as Record<string, unknown>).status === 'error'),
+                  );
+                }
                 break;
               }
 
@@ -591,11 +611,17 @@ export function useStreaming() {
         ? {
             model: lastModel,
             rawResponse: accumulated,
+            agentName: lastAgentName,
+            skillsExecuted: lastSkillsExecuted,
+            toolsExecuted: lastToolsExecuted,
             fullEnvelope: {
               message: accumulated,
               a2ui: debugA2uiMessages.length > 0 ? debugA2uiMessages : undefined,
               model: lastModel,
               usage: lastUsage,
+              agentName: lastAgentName,
+              skillsExecuted: lastSkillsExecuted,
+              toolsExecuted: lastToolsExecuted,
             },
           }
         : undefined;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -172,11 +172,23 @@ export interface TokenUsageSummary {
 // Debug
 // ---------------------------------------------------------------------------
 
+/** Per-turn tool execution record surfaced on the SSE `end` event (#958). */
+export interface DebugToolExecution {
+  name: string;
+  status: 'ok' | 'error';
+}
+
 export interface DebugMetadata {
   model?: string;
   systemPrompt?: string;
   rawResponse?: string;
   rawContent?: string;
+  /** Agent that owned this turn (e.g. `core.triage`). Populated from SSE `end` event. */
+  agentName?: string;
+  /** Skill IDs matched/executed during this turn. Populated from SSE `end` event. */
+  skillsExecuted?: string[];
+  /** Tool invocations attempted during this turn. Populated from SSE `end` event. */
+  toolsExecuted?: DebugToolExecution[];
   fullEnvelope?: {
     message?: string;
     model?: string;


### PR DESCRIPTION
Closes #959.
Depends on #961 (Bender's backend SSE `end` fields) — merged that branch in so CI passes locally; fields are all optional so behaviour degrades gracefully if #961 isn't in yet. Please land #961 first (or merge both together).

Working as **Fry (Frontend Dev)**. Tagging @Leela & @Zapp for review per Ahmed's request.

## What

Surfaces the three new SSE `end`-event fields from #958 in the main-chat **Debug** panel.

### 1. `DebugMetadata` (`packages/web/src/types.ts`)

Three new optional fields + a small `DebugToolExecution` helper type:

```ts
agentName?: string;
skillsExecuted?: string[];
toolsExecuted?: DebugToolExecution[]; // { name, status: 'ok' | 'error' }
```

### 2. `useStreaming.ts`

The inline SSE loop now captures `agentName` / `skillsExecuted` / `toolsExecuted` off the `end` event (same narrowing pattern Bender used in `_processSSEStream`), and the `debugInfo` object built before `onComplete` carries them through as top-level fields **and** inside `fullEnvelope` (so the JSON view + Copy button include them).

`onComplete` signature is unchanged — the fields ride on `debugInfo`.

### 3. `DebugPanel.tsx`

Three new sections styled to match the existing Model / Full LLM Response pattern (Fluent UI v9 tokens only, no new primitives):

- **Agent** — single monospace label. Empty → dimmed `—`.
- **Skills** — tokenless `<ul>` of skill IDs. Empty → dimmed `—`.
- **Tools** — `<ul>` of rows with an 8px status dot (green = `ok`, red = `error`), tool name, and a dimmed status label. Empty → dimmed `—`.

All use the existing `section` / `sectionLabel` / `notAvailable` classes plus three small additions (`list`, `listItem`, `statusDot`/`statusOk`/`statusError`, `statusLabel`) — no external icon/list components.

Visual preview (no live screenshot; backend wiring still pending on #961):

```
▼ Debug                                        [ Copy response ]

  Model
    gpt-4o

  Agent
    core.triage

  Skills
    • collaborator-voice
    • teach-then-ask

  Tools
    🟢 core.read_file        ok
    🟢 core.write_file       ok
    🔴 core.fetch_webpage    error

  ▼ Full LLM Response (JSON)   { …includes the three fields… }
```

## Quality gates

- `npm run lint` → 0 errors (warnings are pre-existing).
- `CI=1 npm test -- --reporter=dot` → **890 passed, 159 todo, 3 skipped**.
- `npm run build -w @aks-kickstart/web` → ✓ built in 4.25s.
- Changeset: `patch` on `@aks-kickstart/web`.

## Notes for reviewers

- No changes to `_processSSEStream` — the production hook uses an inline SSE loop. Bender's field-parsing there already has unit tests; I mirror the same narrowing in the inline loop (deliberate duplication, kept minimal).
- No new dependencies. No workflow changes.
- If `#961` merges first, this PR rebases cleanly (fast-forward on the harness/runner side).

🤖 Created by [sabbour-squad-frontend](https://github.com/apps/sabbour-squad-frontend)