### PR TITLE
feat(playground): unified A2UI renderer, JSON view, and fix component prop schemas

### DIFF
--- a/.changeset/playground-unified-renderer-967-968.md
+++ b/.changeset/playground-unified-renderer-967-968.md
@@ -1,0 +1,14 @@
+---
+"@aks-kickstart/web": patch
+---
+
+feat(playground): unify A2UI renderer with chat, add component JSON view, fix remaining error components
+
+- Extract `A2UIEnvelopePreview` component — the canonical "render these static A2UI descriptors" primitive. Uses the same `useA2UI` → `A2UISurfaceWrapper` pipeline as the Chat renderer. ComponentCard now delegates to this instead of duplicating the surface-creation lifecycle.
+- ComponentCard is now clickable and opens a detail dialog with Preview / JSON tabs (Fluent TabList). JSON tab shows the A2UI descriptor array with 2-space indent and a copy-to-clipboard button.
+- 401 error state in Gallery and Components tabs now shows a "Sign in to view components/scenarios" message instead of a generic error bar, with a reference to #955.
+- Regression guard added to `component-examples.test.ts`: `validateAndSanitizeComponents` must produce zero `_ErrorComponent` descriptors for every `COMPONENT_PREVIEWS` entry — the same path that fires at render time inside `A2UIEnvelopePreview`.
+
+Closes #967
+Closes #968
+References #955

--- a/packages/web/src/__tests__/component-examples.test.ts
+++ b/packages/web/src/__tests__/component-examples.test.ts
@@ -1,16 +1,21 @@
 /**
- * Regression test for #954.
+ * Regression tests for #954 and #967/#968 (playground renderer unification).
  *
  * Asserts every COMPONENT_PREVIEWS entry uses descriptor `component` values
  * that resolve through a registry seeded with the actual fluentOverrides +
  * rich components. Catches drift between `impl.name` (bare, e.g. "Text") and
  * the example map (which keys by pack-qualified id, e.g. "core/Text").
+ *
+ * Also guards the validateAndSanitizeComponents path — ensures that when the
+ * real sanitizer runs over the preview descriptors, NO descriptor is replaced
+ * with _ErrorComponent. This is the same code path that fires in A2UIEnvelopePreview
+ * at render time.
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { z } from 'zod';
 import { COMPONENT_PREVIEWS } from '../pages/component-examples';
-import { ClientComponentRegistry } from '../contexts/A2UIRegistryContext';
+import { ClientComponentRegistry, validateAndSanitizeComponents } from '../contexts/A2UIRegistryContext';
 import { fluentOverrides } from '../catalog/fluent-components/index';
 
 // Mirrors the rich-component list registered in main.tsx. We register stub
@@ -81,5 +86,26 @@ describe('COMPONENT_PREVIEWS', () => {
         }
       }
     }
+  });
+
+  it('validateAndSanitizeComponents produces NO _ErrorComponent for any COMPONENT_PREVIEWS entry (render-time guard)', () => {
+    // This is the exact code path that fires inside A2UIEnvelopePreview / useA2UI.
+    // If any descriptor would render as _ErrorComponent in the browser, this test fails.
+    const errorEntries: Array<{ key: string; id: unknown; component: unknown }> = [];
+    for (const [key, descriptors] of Object.entries(COMPONENT_PREVIEWS)) {
+      const sanitized = validateAndSanitizeComponents(
+        descriptors as Array<Record<string, unknown>>,
+        registry,
+      );
+      for (const d of sanitized) {
+        if (d.component === '_ErrorComponent') {
+          errorEntries.push({ key, id: d.id, component: d.component });
+        }
+      }
+    }
+    expect(
+      errorEntries,
+      'Some COMPONENT_PREVIEWS descriptors resolved to _ErrorComponent — check registry names vs descriptor values',
+    ).toEqual([]);
   });
 });

--- a/packages/web/src/components/A2UI/A2UIEnvelopePreview.tsx
+++ b/packages/web/src/components/A2UI/A2UIEnvelopePreview.tsx
@@ -1,0 +1,70 @@
+/**
+ * A2UIEnvelopePreview — renders a static set of A2UI component descriptors.
+ *
+ * This is the canonical "here are some descriptors, render them" component.
+ * It encapsulates the createSurface → updateComponents → A2UISurfaceWrapper
+ * lifecycle so every call site uses the same A2UI pipeline as the Chat renderer.
+ *
+ * Usage:
+ *   <A2UIEnvelopePreview
+ *     surfaceId="component-preview-core/Button"
+ *     components={[{ id: 'root', component: 'Button', text: 'Click me' }]}
+ *   />
+ */
+
+import React, { useEffect, useCallback, memo } from 'react';
+import { useA2UI } from '../../hooks/useA2UI';
+import { A2UISurfaceWrapper } from './A2UISurfaceWrapper';
+
+export interface A2UIEnvelopePreviewProps {
+  /** Unique ID for the surface created internally. */
+  surfaceId: string;
+  /** Flat A2UI component descriptor array. First element MUST have id="root". */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  components: Array<Record<string, any>>;
+  /** When false the surface is visually dimmed. Defaults to true. */
+  isActive?: boolean;
+  /** Slot rendered while the surface is being processed (defaults to nothing). */
+  loading?: React.ReactNode;
+}
+
+export const A2UIEnvelopePreview = memo(function A2UIEnvelopePreview({
+  surfaceId,
+  components,
+  isActive = true,
+  loading = null,
+}: A2UIEnvelopePreviewProps) {
+  // Stable no-op handler — previews are read-only, no actions wired.
+  const actionHandler = useCallback(() => {}, []);
+  const { surfaces, processMessages, processor } = useA2UI({ actionHandler });
+
+  useEffect(() => {
+    const msgs: unknown[] = [
+      { version: 'v0.9', createSurface: { surfaceId, catalogId: 'kickstart' } },
+      { version: 'v0.9', updateComponents: { surfaceId, components } },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const createdIds = processMessages(msgs as any);
+    return () => {
+      for (const id of createdIds) {
+        try { processor.model.deleteSurface(id); } catch { /* already gone */ }
+      }
+    };
+    // processMessages and processor are stable refs; re-run only when surfaceId changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [surfaceId]);
+
+  const surfaceEntries = Array.from(surfaces.entries());
+
+  if (surfaceEntries.length === 0) {
+    return <>{loading}</>;
+  }
+
+  return (
+    <>
+      {surfaceEntries.map(([id, surface]) => (
+        <A2UISurfaceWrapper key={id} surface={surface} isActive={isActive} />
+      ))}
+    </>
+  );
+});

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -20,7 +20,7 @@ import {
 import {
   Dismiss24Regular, Sparkle24Regular,
   Add24Regular, Lightbulb24Regular, Grid24Regular, Icons24Regular,
-  Navigation24Regular, FolderOpen24Regular,
+  Navigation24Regular, FolderOpen24Regular, Copy24Regular,
 } from '@fluentui/react-icons';
 import { useA2UI } from '../hooks/useA2UI';
 import type { ActionHandler } from '../hooks/useActionDispatch';
@@ -28,6 +28,7 @@ import { usePackRegistry } from '../hooks/usePackRegistry';
 import type { PlaygroundScenario, ComponentContribution } from '@aks-kickstart/harness';
 import { useDebug } from '../contexts/DebugContext';
 import { A2UISurfaceWrapper } from '../components/A2UI/A2UISurfaceWrapper';
+import { A2UIEnvelopePreview } from '../components/A2UI/A2UIEnvelopePreview';
 import { DebugPanel } from '../components/Chat/DebugPanel';
 import type { ChatMessage, DebugMetadata } from '../types';
 import type { SurfaceModel } from '../vendor/a2ui/web_core/index';
@@ -510,6 +511,21 @@ const useStyles = makeStyles({
   detailTabs: {
     marginBottom: tokens.spacingVerticalM,
   },
+  jsonCopyRow: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  compCardClickable: {
+    cursor: 'pointer',
+    ':hover': {
+      boxShadow: tokens.shadow8,
+    },
+    ':focus-visible': {
+      outline: `2px solid ${tokens.colorBrandStroke1}`,
+      outlineOffset: '2px',
+    },
+  },
   iconGrid: {
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
@@ -777,38 +793,28 @@ GalleryCard.displayName = 'GalleryCard';
 // Renders a live A2UI preview thumbnail for a single component entry.
 // Uses COMPONENT_PREVIEWS for example props; falls back to metadata-only
 // for components that have no registered example (e.g. complex rich components).
+// Click opens the component detail dialog (preview + JSON view).
 interface ComponentCardProps {
   comp: ComponentContribution;
+  onCardClick: (comp: ComponentContribution) => void;
 }
 
-const ComponentCard = memo(({ comp }: ComponentCardProps) => {
+const ComponentCard = memo(({ comp, onCardClick }: ComponentCardProps) => {
   const classes = useStyles();
-  const compActionHandler = useCallback<ActionHandler>(() => {}, []);
-  const { surfaces, processMessages, processor } = useA2UI({ actionHandler: compActionHandler });
-
   const exampleComponents = COMPONENT_PREVIEWS[comp.name];
-
-  useEffect(() => {
-    if (!exampleComponents) return;
-    const surfaceId = `component-preview-${comp.name}`;
-    const msgs: unknown[] = [
-      { version: 'v0.9', createSurface: { surfaceId, catalogId: 'kickstart' } },
-      { version: 'v0.9', updateComponents: { surfaceId, components: exampleComponents } },
-    ];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const createdIds = processMessages(msgs as any);
-    return () => {
-      for (const id of createdIds) {
-        try { processor.model.deleteSurface(id); } catch { /* already gone */ }
-      }
-    };
-  // processMessages and processor are stable refs; only re-run when component name changes
-  }, [comp.name]);
-
-  const surfaceEntries = Array.from(surfaces.entries());
+  const surfaceId = `component-preview-${comp.name}`;
 
   return (
-    <Card appearance="outline" style={{ padding: tokens.spacingVerticalM, cursor: 'default' }}>
+    <Card
+      appearance="outline"
+      style={{ padding: tokens.spacingVerticalM }}
+      className={classes.compCardClickable}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${comp.name} detail`}
+      onClick={() => onCardClick(comp)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCardClick(comp); } }}
+    >
       <Body1Strong style={{ fontFamily: tokens.fontFamilyMonospace, fontSize: tokens.fontSizeBase200 }}>
         {comp.name.split('/')[1] ?? comp.name}
       </Body1Strong>
@@ -817,17 +823,16 @@ const ComponentCard = memo(({ comp }: ComponentCardProps) => {
       </Caption1>
       {exampleComponents && (
         <div className={classes.cardBody} style={{ marginTop: tokens.spacingVerticalS, pointerEvents: 'none' }}>
-          {surfaceEntries.length === 0 ? (
-            <div style={{ padding: '8px 0', color: tokens.colorNeutralForeground4, fontSize: tokens.fontSizeBase200 }}>
-              Loading…
-            </div>
-          ) : (
-            surfaceEntries.map(([id, surface]) => (
-              <div key={id} className="a2ui-component">
-                <A2UISurfaceWrapper surface={surface} />
+          {/* A2UIEnvelopePreview — same render pipeline as Chat */}
+          <A2UIEnvelopePreview
+            surfaceId={surfaceId}
+            components={exampleComponents}
+            loading={
+              <div style={{ padding: '8px 0', color: tokens.colorNeutralForeground4, fontSize: tokens.fontSizeBase200 }}>
+                Loading…
               </div>
-            ))
-          )}
+            }
+          />
         </div>
       )}
     </Card>
@@ -879,6 +884,11 @@ function PlaygroundInner() {
   const [inspireLoading, setInspireLoading] = useState(false);
   const inspireAbortRef = useRef<AbortController | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  // Component detail dialog state
+  const [selectedComponent, setSelectedComponent] = useState<ComponentContribution | null>(null);
+  const [componentDialogOpen, setComponentDialogOpen] = useState(false);
+  const [componentDetailTab, setComponentDetailTab] = useState<'preview' | 'json'>('preview');
+  const [jsonCopied, setJsonCopied] = useState(false);
 
   // Registry-driven data — fetched live from /api/packs
   const { registry, loading: registryLoading, error: registryError } = usePackRegistry();
@@ -1192,6 +1202,29 @@ function PlaygroundInner() {
     if (!selectedScenario) return '';
     return JSON.stringify(selectedScenario.a2ui, null, 2);
   }, [selectedScenario]);
+
+  // Component detail dialog handlers
+  const handleComponentCardClick = useCallback((comp: ComponentContribution) => {
+    setSelectedComponent(comp);
+    setComponentDetailTab('preview');
+    setJsonCopied(false);
+    setComponentDialogOpen(true);
+  }, []);
+
+  // Memoize the JSON for the selected component
+  const componentJson = useMemo(() => {
+    if (!selectedComponent) return '';
+    const descriptors = COMPONENT_PREVIEWS[selectedComponent.name];
+    return descriptors ? JSON.stringify(descriptors, null, 2) : '';
+  }, [selectedComponent]);
+
+  const handleCopyComponentJson = useCallback(() => {
+    if (!componentJson) return;
+    navigator.clipboard.writeText(componentJson).then(() => {
+      setJsonCopied(true);
+      setTimeout(() => setJsonCopied(false), 2000);
+    }).catch(() => { /* clipboard unavailable */ });
+  }, [componentJson]);
 
   const customSurfaceEntries = Array.from(customA2ui.surfaces.entries());
 
@@ -1625,9 +1658,21 @@ function PlaygroundInner() {
       {activeTab === 'gallery' && (
         <div id="panel-gallery" role="tabpanel" aria-labelledby="tab-gallery" className="playground-gallery-scroll">
           {registryError ? (
-            <MessageBar intent="error" style={{ margin: tokens.spacingHorizontalL }}>
-              <MessageBarBody>Failed to load registry: {registryError}</MessageBarBody>
-            </MessageBar>
+            registryError.includes('401') ? (
+              <div className={classes.emptyState}>
+                <div className={classes.emptyIcon}>
+                  <img src="/assets/icons/fluent/sparkle.svg" alt="" width="32" height="32" style={{ opacity: 0.4 }} />
+                </div>
+                <Body1Strong>Sign in to view scenarios</Body1Strong>
+                <Caption1 style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}>
+                  The scenario registry requires authentication. See issue <a href="https://github.com/sabbour/kickstart/issues/955" target="_blank" rel="noopener noreferrer">#955</a>.
+                </Caption1>
+              </div>
+            ) : (
+              <MessageBar intent="error" style={{ margin: tokens.spacingHorizontalL }}>
+                <MessageBarBody>Failed to load registry: {registryError}</MessageBarBody>
+              </MessageBar>
+            )
           ) : filteredGalleryScenarios.length === 0 ? (
             <div className={classes.emptyState}>
               <div className={classes.emptyIcon}>
@@ -1661,9 +1706,21 @@ function PlaygroundInner() {
       {activeTab === 'components' && (
         <div id="panel-components" role="tabpanel" aria-labelledby="tab-components" className="playground-gallery-scroll">
           {registryError ? (
-            <MessageBar intent="error" style={{ margin: tokens.spacingHorizontalL }}>
-              <MessageBarBody>Failed to load registry: {registryError}</MessageBarBody>
-            </MessageBar>
+            registryError.includes('401') ? (
+              <div className={classes.emptyState}>
+                <div className={classes.emptyIcon}>
+                  <img src="/assets/icons/fluent/grid.svg" alt="" width="32" height="32" style={{ opacity: 0.4 }} />
+                </div>
+                <Body1Strong>Sign in to view components</Body1Strong>
+                <Caption1 style={{ color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalS }}>
+                  The component registry requires authentication. See issue <a href="https://github.com/sabbour/kickstart/issues/955" target="_blank" rel="noopener noreferrer">#955</a>.
+                </Caption1>
+              </div>
+            ) : (
+              <MessageBar intent="error" style={{ margin: tokens.spacingHorizontalL }}>
+                <MessageBarBody>Failed to load registry: {registryError}</MessageBarBody>
+              </MessageBar>
+            )
           ) : filteredComponents.length === 0 ? (
             <div className={classes.emptyState}>
               <div className={classes.emptyIcon}>
@@ -1683,7 +1740,7 @@ function PlaygroundInner() {
                 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: tokens.spacingVerticalM, padding: `0 ${tokens.spacingHorizontalL} ${tokens.spacingVerticalL}` }}>
                   {comps.map(comp => (
                     <GalleryCardErrorBoundary key={comp.name} label={comp.name}>
-                      <ComponentCard comp={comp} />
+                      <ComponentCard comp={comp} onCardClick={handleComponentCardClick} />
                     </GalleryCardErrorBoundary>
                   ))}
                 </div>
@@ -1834,6 +1891,86 @@ function PlaygroundInner() {
             </DialogContent>
             <DialogActions>
               <Button appearance="secondary" onClick={() => setDialogOpen(false)}>Close</Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      {/* ---- Component Detail Dialog ---- */}
+      <Dialog open={componentDialogOpen} onOpenChange={(_e, data) => setComponentDialogOpen(data.open)}>
+        <DialogSurface className={classes.dialogSurface}>
+          <DialogBody>
+            <DialogTitle
+              action={
+                <Button
+                  appearance="subtle"
+                  aria-label="Dismiss"
+                  icon={<Dismiss24Regular />}
+                  onClick={() => setComponentDialogOpen(false)}
+                />
+              }
+            >
+              {selectedComponent?.name}
+            </DialogTitle>
+            <DialogContent>
+              <div className={classes.dialogContent}>
+                {/* Detail Tabs */}
+                <TabList
+                  selectedValue={componentDetailTab}
+                  onTabSelect={(_e, data) => setComponentDetailTab(data.value as 'preview' | 'json')}
+                  size="small"
+                  className={classes.detailTabs}
+                >
+                  <Tab value="preview">Preview</Tab>
+                  <Tab value="json">JSON</Tab>
+                </TabList>
+
+                {componentDetailTab === 'preview' ? (
+                  <div>
+                    {selectedComponent && COMPONENT_PREVIEWS[selectedComponent.name] ? (
+                      /* A2UIEnvelopePreview — same render engine as Chat */
+                      <A2UIEnvelopePreview
+                        surfaceId={`comp-detail-${selectedComponent.name}`}
+                        components={COMPONENT_PREVIEWS[selectedComponent.name]}
+                        loading={
+                          <div style={{ padding: tokens.spacingVerticalL, color: tokens.colorNeutralForeground4, fontSize: tokens.fontSizeBase200 }}>
+                            Loading preview…
+                          </div>
+                        }
+                      />
+                    ) : (
+                      <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
+                        No preview available for this component.
+                      </Caption1>
+                    )}
+                  </div>
+                ) : (
+                  <div>
+                    <div className={classes.jsonCopyRow}>
+                      <Button
+                        appearance="subtle"
+                        size="small"
+                        icon={<Copy24Regular />}
+                        onClick={handleCopyComponentJson}
+                        disabled={!componentJson}
+                        aria-label="Copy JSON to clipboard"
+                      >
+                        {jsonCopied ? 'Copied!' : 'Copy'}
+                      </Button>
+                    </div>
+                    {componentJson ? (
+                      <pre className={classes.jsonCodeBlock}>{componentJson}</pre>
+                    ) : (
+                      <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
+                        No JSON preview registered for this component.
+                      </Caption1>
+                    )}
+                  </div>
+                )}
+              </div>
+            </DialogContent>
+            <DialogActions>
+              <Button appearance="secondary" onClick={() => setComponentDialogOpen(false)}>Close</Button>
             </DialogActions>
           </DialogBody>
         </DialogSurface>

--- a/packages/web/src/pages/component-examples.ts
+++ b/packages/web/src/pages/component-examples.ts
@@ -45,7 +45,7 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
   ],
 
   'core/Icon': [
-    { id: 'root', component: 'Icon', name: '/assets/icons/fluent/sparkle.svg' },
+    { id: 'root', component: 'Icon', name: { path: '/assets/icons/fluent/sparkle.svg' } },
   ],
 
   'core/Link': [
@@ -57,15 +57,15 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
   ],
 
   'core/Alert': [
-    { id: 'root', component: 'Alert', text: 'This is an alert message.', intent: 'info' },
+    { id: 'root', component: 'Alert', message: 'This is an alert message.', severity: 'info' },
   ],
 
   'core/TextField': [
-    { id: 'root', component: 'TextField', label: 'Name', placeholder: 'Enter your name' },
+    { id: 'root', component: 'TextField', label: 'Name' },
   ],
 
   'core/CheckBox': [
-    { id: 'root', component: 'CheckBox', label: 'Enable feature', checked: false },
+    { id: 'root', component: 'CheckBox', label: 'Enable feature', value: false },
   ],
 
   'core/Slider': [
@@ -73,7 +73,7 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
   ],
 
   'core/DateTimeInput': [
-    { id: 'root', component: 'DateTimeInput', label: 'Scheduled date' },
+    { id: 'root', component: 'DateTimeInput', label: 'Scheduled date', value: '' },
   ],
 
   'core/ChoicePicker': [
@@ -81,10 +81,11 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
       id: 'root',
       component: 'ChoicePicker',
       label: 'Region',
-      choices: [
+      options: [
         { label: 'East US', value: 'eastus' },
         { label: 'West Europe', value: 'westeurope' },
       ],
+      value: [],
     },
   ],
 
@@ -121,18 +122,21 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
     {
       id: 'root',
       component: 'List',
-      items: ['Item one', 'Item two', 'Item three'],
+      children: ['li1', 'li2', 'li3'],
     },
+    { id: 'li1', component: 'Text', text: 'Item one' },
+    { id: 'li2', component: 'Text', text: 'Item two' },
+    { id: 'li3', component: 'Text', text: 'Item three' },
   ],
 
   'core/Table': [
     {
       id: 'root',
       component: 'Table',
-      columns: [{ label: 'Name', key: 'name' }, { label: 'Status', key: 'status' }],
+      columns: ['Name', 'Status'],
       rows: [
-        { name: 'Alice', status: 'Active' },
-        { name: 'Bob', status: 'Inactive' },
+        ['Alice', 'Active'],
+        ['Bob', 'Inactive'],
       ],
     },
   ],
@@ -152,7 +156,11 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
       id: 'root',
       component: 'ComboBox',
       label: 'Framework',
-      options: ['React', 'Vue', 'Angular'],
+      options: [
+        { text: 'React', value: 'react' },
+        { text: 'Vue', value: 'vue' },
+        { text: 'Angular', value: 'angular' },
+      ],
     },
   ],
 
@@ -161,7 +169,11 @@ export const COMPONENT_PREVIEWS: Readonly<Record<string, ComponentPreviewEntry>>
       id: 'root',
       component: 'MultiSelect',
       label: 'Tags',
-      options: ['production', 'staging', 'dev'],
+      options: [
+        { text: 'production', value: 'production' },
+        { text: 'staging', value: 'staging' },
+        { text: 'dev', value: 'dev' },
+      ],
     },
   ],
 


### PR DESCRIPTION
## Summary

Working as **Fry** (Frontend Dev) 🤖

This PR implements three improvements to the Playground page:

### 1. Unified A2UI Renderer (Closes #967)

Extracts a reusable `A2UIEnvelopePreview` component that encapsulates the `useA2UI` + `createSurface` + `updateComponents` + `A2UISurfaceWrapper` lifecycle. The Playground `ComponentCard` was duplicating this plumbing inline; now both the Playground preview and the detail dialog use the same renderer as the Chat pipeline.

### 2. Fix Remaining `_ErrorComponent` Renders (Closes #968)

Root-caused and fixed 10 prop schema mismatches in `component-examples.ts` that caused components to fail Zod validation inside `validateAndSanitizeComponents`:

| Component | Problem | Fix |
|---|---|---|
| `Icon` | `name` was a string path | `name: { path: '...' }` object |
| `Alert` | `text`/`intent` fields | Renamed to `message`/`severity` |
| `TextField` | Unrecognised `placeholder` (strict schema) | Removed |
| `CheckBox` | `checked` field | Renamed to `value` |
| `DateTimeInput` | Missing required `value` field | Added `value: ''` |
| `ChoicePicker` | `choices` field + missing `value` | Renamed to `options`, added `value: []` |
| `List` | Used `items: string[]` — List is a layout component | Rewrote with `children` + `Text` nodes |
| `Table` | Column objects + row objects | `columns: string[]`, `rows: string[][]` |
| `ComboBox` | `options: string[]` | `options: [{text, value}]` objects |
| `MultiSelect` | Same as ComboBox | Same fix |

### 3. Component Detail Dialog with JSON View

Clicking a `ComponentCard` opens a detail dialog with two tabs:
- **Preview** — full live A2UI render via `A2UIEnvelopePreview`
- **JSON** — formatted descriptor with a copy-to-clipboard button

### 4. Auth Error Handling (related to #955)

401 responses from `/api/packs` now show a friendly "Sign in to view components" message in both Gallery and Components tabs, instead of a generic error.

### 5. Regression Test

Added test: *"validateAndSanitizeComponents produces NO \_ErrorComponent for any COMPONENT\_PREVIEWS entry"* — this test was failing before the fixes and now passes.

---

## Design Proposal

### Problem
The Playground's ComponentCard was duplicating A2UI surface-creation logic that already existed in the Chat pipeline, and 10 components were silently rendering `_ErrorComponent` due to prop mismatches introduced when the strict Zod schemas were added.

### Approach
1. **Single source of truth**: `A2UIEnvelopePreview` wraps the full `useA2UI` → `createSurface` → `updateComponents` → `A2UISurfaceWrapper` chain. Any future updates to the rendering pipeline only need to happen in one place.
2. **Schema-driven test**: Rather than manually auditing each example, we added a vitest regression that calls `validateAndSanitizeComponents` over every `COMPONENT_PREVIEWS` entry and asserts zero `_ErrorComponent` outputs. This will catch future regressions automatically.
3. **No auth bypass**: The `#955` auth gate on `/api/packs` is Bender/Zapp territory (SWA config). This PR only improves the graceful degradation UX.

### Trade-offs considered
- `A2UIEnvelopePreview` re-runs the full `useA2UI` hook per card (same as before — no regression). A future optimisation could share a single `MessageProcessor` across all cards, but that's out of scope.
- `ChoicePicker` requires a `value: []` in static previews because the schema marks it required. This is technically correct (the AI always provides a value) but looks odd in a preview. Acceptable for now.

---

⚠️ This task was flagged as "needs review" — please have a squad member review the dialog UX and the `A2UIEnvelopePreview` API surface before merging.