### PR TITLE
fix(workflows): release-cadence uses changeset:version + Leela app token

### DIFF
--- a/.github/workflows/squad-release-cadence.yml
+++ b/.github/workflows/squad-release-cadence.yml
@@ -20,10 +20,18 @@ jobs:
   cadence:
     runs-on: ubuntu-latest
     steps:
+      - name: Create Leela app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 3340358
+          private-key: ${{ secrets.SQUAD_LEAD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -78,7 +86,7 @@ jobs:
           git config user.name "squad-leela[bot]"
           git config user.email "leela@squad.local"
           git checkout -B release/cadence
-          npm run version
+          npm run changeset:version
           git add -A
           git commit -m "chore(release): daily cadence [leela]" -m "Working as Leela — see .squad/agents/leela/charter.md"
           git push --force-with-lease origin release/cadence
@@ -87,6 +95,7 @@ jobs:
         if: steps.existing.outputs.exists == 'false'
         uses: actions/github-script@v8
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const body = [
               '**Working as Leela (Lead)** · see `.squad/agents/leela/charter.md`',

--- a/.squad/extensions/kickstart-aks-dev/skills/release-process.md
+++ b/.squad/extensions/kickstart-aks-dev/skills/release-process.md
@@ -31,7 +31,7 @@ If no PR opened and you expected one, check `.github/workflows/squad-release-cad
 ### 2. Review the version bump
 
 Verify:
-- `npm run version` consumed all pending changesets from `.changeset/`.
+- `npm run changeset:version` consumed all pending changesets from `.changeset/`.
 - Every package bumped in lockstep.
 - `CHANGELOG.md` entries match the changeset bodies.
 
@@ -88,5 +88,5 @@ Open a Discussion under **Announcements** only when the release changes the top-
 - **Cadence workflow didn't run:** check `.github/workflows/squad-release-cadence.yml` run history. Dispatch manually via `workflow_dispatch` if a scheduled run was missed.
 - **Release PR already open and stale:** rebase it. The workflow is idempotent and won't open a duplicate.
 - **Changeset missed on a merged PR:** open a follow-up PR that adds a changeset describing the historical impact. The next cadence run picks it up.
-- **CHANGELOG drift:** regenerate with `npm run version`. Do not hand-edit.
+- **CHANGELOG drift:** regenerate with `npm run changeset:version`. Do not hand-edit.
 - **Tag pushed by mistake:** delete the tag locally and remotely (`git push --delete origin vX.Y.Z`), then re-tag the correct commit. Never force-update an existing tag that's already in a published release.


### PR DESCRIPTION
Closes #953

## Why this PR uses human authorization
Bot apps (sabbour-squad-*) don't have the GitHub `workflows` permission. Ahmed authorized using his credentials for this narrow workflow-file change.

## Changes
- `.github/workflows/squad-release-cadence.yml`: `npm run version` → `npm run changeset:version` + Leela app token plumbing
- `.squad/extensions/kickstart-aks-dev/skills/release-process.md`: 2 ref updates

## Out of scope (vs. #952)
- Does NOT touch `squad-pr-retro.yml` (already correct on main)
- Does NOT touch anything else from #792