### PR TITLE
docs: AppInsights SWA wiring + observability runbook

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1,3 +1,51 @@
+# Observability & AppInsights SWA Wiring — April 21, 2026
+
+**Date:** 2026-04-21T00:17:00Z  
+**Author:** Ahmed (Engineering), documented by Scribe  
+**Status:** Documented  
+**Related PR:** #976
+
+## Summary
+
+AppInsights connection-string plumbing on `kickstart-web-dev` (Static Web App) in `rg-kickstart-dev` (CloudNative subscription) was provisioned via `az staticwebapp appsettings set` on 2026-04-21. Deployment bypassed Bicep (`infra/main.bicep`) entirely due to pre-existing resources in a different subscription than `infra/parameters.dev.json` expects.
+
+### Key Facts
+
+- **SWA:** `kickstart-web-dev`
+- **Resource Group:** `rg-kickstart-dev`
+- **Subscription:** `CloudNative` (`4498459e-01d5-4a3f-b07e-8f1f36598c16`)
+- **Provisioning method:** `az staticwebapp appsettings set --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=..."`
+- **App setting:** Must be exactly `APPLICATIONINSIGHTS_CONNECTION_STRING` (case-sensitive)
+- **SWA restart:** Automatic on app-setting change (~30–60 seconds); telemetry auto-flows after restart
+- **Code-side wiring:** Already initialized in `packages/web/api/src/startup/*` via `@azure/monitor-opentelemetry` + `applicationinsights`
+
+### Known Divergence: Subscription & Parameters Mismatch
+
+`infra/parameters.dev.json` hardcodes:
+- `swaName: "kickstart-web-dev"`, `rg: "rg-kickstart-dev"`, AppInsights `ai-kickstart-dev`
+- Assumes resources are in the subscription specified in CLI context when Bicep runs
+
+**Actual state:** Resources pre-exist in `CloudNative` subscription (`4498459e-01d5-4a3f-b07e-8f1f36598c16`), which may differ from the subscription `parameters.dev.json` was designed for.
+
+### Impact & Mitigation
+
+**Future Bicep deployments via `az deployment group create`:**
+- Will conflict (resource exists) if run against the same RG, OR
+- Will create duplicates if run in a different subscription/RG
+
+**Mitigation:** Use `az staticwebapp appsettings set` for manual AppInsights wiring (documented in PR #976). Do not re-run Bicep unless:
+1. A new Bicep template is created with parameters for `CloudNative` subscription, OR
+2. Existing resources are destroyed and Bicep provisions from scratch, OR
+3. Parameter overrides are passed to `az deployment group create` to match actual subscription/RG
+
+### Documentation
+
+**PR #976** documents:
+1. `infra/README.md` → New section "Bring-your-own AppInsights (skip full bicep deploy)"
+2. `docs-site/docs/operations/observability.md` → Complete observability runbook (setup, verification, KQL, troubleshooting)
+
+---
+
 # Decision: DP Reviews — April 17, 2026
 
 ## Hypothesis log (process experiments)

--- a/docs-site/docs/operations/observability.md
+++ b/docs-site/docs/operations/observability.md
@@ -1,0 +1,162 @@
+---
+sidebar_position: 1
+---
+
+# Observability
+
+Application Insights is the observability backbone for Kickstart's deployed API. The Functions backend automatically exports traces, logs, and metrics to AppInsights via `@azure/monitor-opentelemetry`.
+
+## Overview
+
+The Kickstart API leverages Azure Application Insights for:
+- **Distributed tracing:** Request flows across the API, AI services, and third-party integrations.
+- **Logs:** Structured application logs and SDK logs.
+- **Metrics:** Request rates, response times, error rates, and custom business metrics.
+- **Live Metrics:** Real-time telemetry visualization (1–2 min latency).
+
+Telemetry is collected automatically by the `@azure/monitor-opentelemetry` SDK initialized in `packages/web/api/src/startup/appinsights.ts`.
+
+## Required Setup
+
+### AppInsights Connection String
+
+The telemetry SDK requires the **Application Insights connection string** to be set in the environment. The setting name is **case-sensitive**:
+
+- **Setting name:** `APPLICATIONINSIGHTS_CONNECTION_STRING` (exact spelling)
+- **Where to get it:** [Azure Portal](https://portal.azure.com) → Application Insights resource → **Overview** → copy the **Connection String**
+
+### On a Deployed Static Web App
+
+If AppInsights is already deployed (or available separately), set the app setting on your SWA:
+
+```bash
+az staticwebapp appsettings set \
+  --name <swa-name> \
+  --resource-group <rg> \
+  --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=<paste-from-ai-portal>"
+```
+
+The SWA's Functions backend will restart automatically (~30–60 seconds), and telemetry will flow to AppInsights.
+
+For more details, see `infra/README.md` → **Bring-your-own AppInsights**.
+
+### For Local Development
+
+Add the connection string to `packages/web/api/local.settings.json` (this file is `.gitignore`d):
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "<paste-from-ai-portal>"
+  }
+}
+```
+
+Restart your local Functions app (`npm run dev` in `packages/web/api`).
+
+## Verifying Telemetry
+
+### 1. Generate a request
+
+```bash
+curl https://<swa-host>/api/health
+```
+
+You should receive a 200 response.
+
+### 2. Check Live Metrics (1–2 min latency)
+
+1. Open [Azure Portal](https://portal.azure.com)
+2. Navigate to your **Application Insights** resource
+3. Click **Live Metrics** (left sidebar)
+4. Watch for incoming requests, dependencies, and exceptions
+
+### 3. Query historical data
+
+Click **Logs** in the AppInsights resource and run one of these KQL queries:
+
+**Last 5 minutes of traces:**
+```kql
+traces | where timestamp > ago(5m) | take 20
+```
+
+**Last 5 minutes of requests:**
+```kql
+requests | where timestamp > ago(5m) | take 20
+```
+
+**Request duration, by operation:**
+```kql
+requests
+| summarize avg_duration = avg(duration), count = count() by operation_Name
+| order by avg_duration desc
+```
+
+**Failed requests:**
+```kql
+requests | where success == false | take 20
+```
+
+## Troubleshooting
+
+### No telemetry appearing in AppInsights
+
+**Check 1: App setting is set correctly**
+- Name must be exactly `APPLICATIONINSIGHTS_CONNECTION_STRING` (case-sensitive)
+- Run: `az staticwebapp appsettings list --name <swa-name> --resource-group <rg>`
+- Look for the exact key and verify the value is not empty
+
+**Check 2: SWA has restarted**
+- Wait 60 seconds after setting the app setting
+- The SWA automatically restarts its Functions backend on app-setting changes
+
+**Check 3: Ingestion latency**
+- AppInsights can take up to 5 minutes to display newly ingested data
+- Check **Live Metrics** first (1–2 min latency)
+
+**Check 4: Connection string is valid**
+- Copy the connection string directly from [Azure Portal](https://portal.azure.com) → AppInsights resource → **Overview**
+- Do not modify or truncate the string; use the full value including `InstrumentationKey=...` and `IngestionEndpoint=...`
+
+**Check 5: AppInsights resource is accessible**
+- Verify the AppInsights resource exists in the Azure Portal
+- Verify the instrumentation key matches what you're setting (if you have multiple AppInsights resources, confirm you're using the correct one)
+
+### "Connection string not found" errors in Function logs
+
+- App setting `APPLICATIONINSIGHTS_CONNECTION_STRING` was not set before the SWA Functions host started
+- Set the app setting and wait for the SWA to restart (~60 seconds)
+- View Function app logs in [Azure Portal](https://portal.azure.com) → SWA resource → **Logs** or **Log stream**
+
+### Telemetry gaps or gaps in Live Metrics
+
+- The SWA may be idle and scaling down; generate a request to wake it up
+- Live Metrics has 1–2 min latency; querying **Logs** shows data with less latency once ingested
+- Check network connectivity between SWA and AppInsights ingestion endpoint (very rare; typically `dc.applicationinsights.azure.com`)
+
+## Structured Logging
+
+The SDK exports structured logs. To filter by custom properties:
+
+**By custom dimension:**
+```kql
+traces
+| where customDimensions.user_id == "12345"
+| order by timestamp desc
+```
+
+**By severity level:**
+```kql
+traces
+| where severityLevel >= 2  // Warning or higher
+| order by timestamp desc
+```
+
+## Performance Tuning
+
+- **Sampling:** By default, AppInsights ingests all telemetry. For high-volume deployments, configure adaptive sampling in the SDK.
+- **Retention:** Default retention is 30 days (configurable in AppInsights → **Usage and estimated costs** → **Data retention**).
+- **Costs:** Ingestion is charged per GB. Monitor your data volume in AppInsights → **Usage and estimated costs**.

--- a/infra/README.md
+++ b/infra/README.md
@@ -201,7 +201,7 @@ If you already have an Application Insights resource and a Static Web App deploy
    az staticwebapp appsettings set \
      --name kickstart-web-dev \
      --resource-group rg-kickstart-dev \
-     --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=2ffebd56-...;IngestionEndpoint=..."
+     --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=..."
    ```
 
 3. **Wait for restart:**

--- a/infra/README.md
+++ b/infra/README.md
@@ -168,3 +168,52 @@ The script will:
 | Future | `kickstart.aks.azure.com` |
 
 Custom domains are configured via Bicep (`customDomainHostname` parameter). Requires a CNAME record pointing to the SWA default hostname before deployment.
+
+## Bring-your-own AppInsights (skip full bicep deploy)
+
+If you already have an Application Insights resource and a Static Web App deployed (possibly in a different subscription than `parameters.dev.json`), you can wire in your AppInsights without running the full Bicep template.
+
+### Scenario
+
+- You've pre-created an AppInsights resource elsewhere (e.g., in a different subscription or resource group).
+- Your SWA is already deployed (e.g., `kickstart-web-dev` in `rg-kickstart-dev`).
+- You want to skip the Bicep deployment and directly set the AppInsights connection string on the SWA.
+
+### Steps
+
+1. **Find your AppInsights connection string:**
+   - Open [Azure Portal](https://portal.azure.com)
+   - Navigate to your Application Insights resource
+   - Click **Overview**
+   - Copy the **Connection String** (appears in the properties panel on the right)
+
+2. **Set the app setting on your SWA:**
+
+   ```bash
+   az staticwebapp appsettings set \
+     --name <swa-name> \
+     --resource-group <rg> \
+     --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=<paste-from-ai-portal>"
+   ```
+
+   Example:
+   ```bash
+   az staticwebapp appsettings set \
+     --name kickstart-web-dev \
+     --resource-group rg-kickstart-dev \
+     --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=2ffebd56-...;IngestionEndpoint=..."
+   ```
+
+3. **Wait for restart:**
+   - The SWA's managed Functions backend will restart automatically (~30–60 seconds).
+   - Once restarted, telemetry will begin flowing from the application to AppInsights.
+
+### Important Notes
+
+- **App setting name is case-sensitive:** Must be exactly `APPLICATIONINSIGHTS_CONNECTION_STRING`. Other names (e.g., `APPINSIGHTS_INSTRUMENTATION_KEY`) will not auto-bind to the telemetry SDK.
+- **Connection string format:** Use the full connection string from the AppInsights **Overview** page, not just the instrumentation key.
+- **Subscription mismatch:** The `parameters.dev.json` file hardcodes resource names (`swaName: kickstart-web-dev`, `rg: rg-kickstart-dev`) and assumes AppInsights is in the same subscription. If your resources exist in a different subscription, running `az deployment group create` will fail or create duplicates. **Use this app-setting approach instead of re-running Bicep.**
+
+### Verifying Telemetry
+
+See `docs-site/docs/operations/observability.md` for verification steps and troubleshooting.


### PR DESCRIPTION
## Summary

Document real-world AppInsights + SWA integration pattern and observability runbook for Kickstart.

### Changes

**1. infra/README.md**
- New section: **"Bring-your-own AppInsights (skip full bicep deploy)"**
- Copy-pasteable `az staticwebapp appsettings set` command
- Where to find the connection string (Azure Portal → AppInsights → Overview)
- Notes on SWA auto-restart (~30–60s) after app-setting change
- Warning: if resources pre-exist in a different subscription, parameter overrides or new parameters file needed; `az deployment group create` will conflict

**2. docs-site/docs/operations/observability.md** (new)
- Overview of AppInsights architecture and `@azure/monitor-opentelemetry` auto-instrumentation
- Required setup: connection string on SWA (`APPLICATIONINSIGHTS_CONNECTION_STRING` exactly) or `local.settings.json`
- Verification steps: curl health endpoint, Live Metrics, KQL queries
- Troubleshooting: common issues (app setting not set, SWA not restarted, ingestion latency, typos, wrong resource)
- Structured logging examples and performance tuning

### Real-World Context

**Concrete deployment:** `kickstart-web-dev` in `rg-kickstart-dev` (`CloudNative` subscription, `4498459e-01d5-4a3f-b07e-8f1f36598c16`) on 2026-04-21. AppInsights resource was provisioned separately and wired to SWA via:

```bash
az staticwebapp appsettings set \
  --name kickstart-web-dev \
  --resource-group rg-kickstart-dev \
  --setting-names "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
```

No Bicep deploy was used. Note: This differs from `infra/parameters.dev.json`, which hardcodes resource names and subscription expectations. Future deployments via Bicep may need parameter overrides or a new parameters file for the `CloudNative` subscription.

### Verification

- ✅ Docs build: `npm ci && npm run build` successful
- ✅ No connection string values in committed files (using placeholders)
- ✅ Sidebar auto-picks up new `operations/observability.md`

Closes #964