### PR TITLE
fix(emit_ui): use `component`+`id` fields and require catalogId="kickstart"

### DIFF
--- a/.changeset/fix-emit-ui-component-schema.md
+++ b/.changeset/fix-emit-ui-component-schema.md
@@ -1,0 +1,6 @@
+---
+"@aks-kickstart/pack-core": patch
+"@aks-kickstart/web": patch
+---
+
+Fix A2UI chat rendering: emit_ui tool schema now uses `component` field (not `type`) with required `id`, and `catalogId` is documented as `"kickstart"`. Previously emitted envelopes fell through to `_ErrorComponent` with "Missing component: root". DebugA2UITree resolves component types via the live client registry.

--- a/packages/pack-core/src/__tests__/tools/emit_ui.test.ts
+++ b/packages/pack-core/src/__tests__/tools/emit_ui.test.ts
@@ -35,7 +35,7 @@ const validUpdateComponents = {
   op: 'updateComponents' as const,
   updateComponents: {
     surfaceId: 'surface-001',
-    components: [{ type: 'Button', label: 'Click me' }],
+    components: [{ id: 'root', component: 'Button', label: 'Click me' }],
   },
 };
 

--- a/packages/pack-core/src/tools/emit_ui.ts
+++ b/packages/pack-core/src/tools/emit_ui.ts
@@ -9,12 +9,19 @@ import type { ToolContribution, SessionCtx } from '@aks-kickstart/harness';
 // Scalar values that can appear in data-model and component property fields.
 const A2UIScalar = z.union([z.string(), z.number(), z.boolean(), z.null()]);
 
-// Lightweight component schema — enforces `type` (required by A2UI) and the
-// most common optional rendering props. The runtime re-validates against the
-// full harness A2UIMessageSchema in execute(), so this schema only needs to be
-// strict enough for the OpenAI API to accept it without a 400.
+// Lightweight component schema — enforces `component` + `id` (both required by
+// the A2UI renderer) and the most common optional rendering props.
+// The runtime re-validates against the full harness A2UIMessageSchema in
+// execute(), so this schema only needs to be strict enough for the OpenAI API
+// to accept it without a 400.
+//
+// IMPORTANT: use `component` (not `type`) — the browser renderer destructures
+// `{ id, component, ...props }` from each entry. `id` must be unique within
+// the surface (e.g. "root" for the top-level component).
+// Use bare component names — no pack prefix (e.g. "Button", not "core/Button").
 const A2UIComponentSchema = z.object({
-  type: z.string().describe('Component type name from the A2UI catalog'),
+  id: z.string().describe('Unique component ID within this surface, e.g. "root"'),
+  component: z.string().describe('Bare component name, e.g. "Button", "Row", "Text" — no pack prefix'),
   label: z.string().nullable().optional(),
   placeholder: z.string().nullable().optional(),
   value: A2UIScalar.nullable().optional(),
@@ -39,7 +46,7 @@ const A2UIMessageInputSchema = z.discriminatedUnion('op', [
     op: z.literal('createSurface'),
     createSurface: z.object({
       surfaceId: z.string(),
-      catalogId: z.string(),
+      catalogId: z.string().describe('Must always be "kickstart"'),
       sendDataModel: z.boolean().nullable().optional(),
     }),
   }),
@@ -87,7 +94,10 @@ export const emitUiTool: ToolContribution = {
       'Validates and emits an A2UI v0.9 message. ' +
       'The message is validated against the A2UI schema and then recorded on the session context ' +
       'so the runner can stream it to the browser as an "a2ui" SSE event. ' +
-      'Use this any time you want to create, update, or remove a UI surface.',
+      'Use this any time you want to create, update, or remove a UI surface. ' +
+      'IMPORTANT: In createSurface messages, always set catalogId to "kickstart". ' +
+      'In updateComponents messages, use bare component names (e.g. "Button", not "core/Button") ' +
+      'and give every component a unique string id (e.g. "root" for the top-level component).',
     parameters: EmitUiInputSchema,
     execute: async (input, runCtx): Promise<string> => {
       const session = runCtx?.context as SessionCtx | undefined;

--- a/packages/web/src/components/Chat/DebugA2UITree.tsx
+++ b/packages/web/src/components/Chat/DebugA2UITree.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { makeStyles, tokens, Text } from '@fluentui/react-components';
-import { KNOWN_COMPONENT_TYPES } from '@aks-kickstart/harness';
+import { clientRegistry } from '../../contexts/A2UIRegistryContext';
 import type { A2uiPayloadItem, A2uiMsg, A2uiComponent } from '../../types';
 
 const KICKSTART_CATALOG_ID = 'kickstart';
@@ -147,7 +147,7 @@ function groupBySurface(messages: A2uiMsg[]): Map<string, SurfaceOps> {
 }
 
 function ComponentBadge({ componentType, styles }: { componentType: string; styles: ReturnType<typeof useStyles> }) {
-  const isKnown = KNOWN_COMPONENT_TYPES.includes(componentType);
+  const isKnown = clientRegistry.isSealed && clientRegistry.getNames().includes(componentType);
   return (
     <span className={`${styles.badge} ${isKnown ? styles.badgeOk : styles.badgeWarn}`}>
       {isKnown ? '✅ resolved' : '⚠️ unknown type'}


### PR DESCRIPTION
## Summary

Fixes three root causes of chat A2UI rendering failures ("⚠️ Missing component: root", all components showing as `_ErrorComponent`).

### Root causes

**1. Wrong component field name in `emit_ui` tool schema**
`A2UIComponentSchema` used `type` as the component identifier field, but the browser renderer (`message-processor.ts` + `validateAndSanitizeComponents`) destructures `{ id, component, ...props }`. LLM-emitted `type` values were silently ignored, every component resolved to `_ErrorComponent`, and the surface root was never populated.

**2. Missing `id` field in component schema**
`A2UIComponentSchema` had no `id` field. Since `id` is required by `ComponentModel`, components without it couldn't be added to the surface at all, causing "Missing component: root".

**3. No guidance on `catalogId` value**
The `createSurface.catalogId` field had no description, so the LLM guessed wrong values (e.g. `"core/Row"` — a component name), triggering the "🔴 bad catalog" error in the debug panel.

### Changes

| File | Change |
|------|--------|
| `packages/pack-core/src/tools/emit_ui.ts` | Rename `type`→`component`, add `id: string`, add `.describe('Must always be "kickstart"')` to catalogId, expand tool description |
| `packages/pack-core/src/__tests__/tools/emit_ui.test.ts` | Update fixture to match new schema (`component`+`id`) |
| `packages/web/src/components/Chat/DebugA2UITree.tsx` | Replace always-empty `KNOWN_COMPONENT_TYPES` with `clientRegistry.getNames()` so known types show ✅ resolved |

### Testing
- All 18 `emit_ui` tests pass
- All 203 web package tests pass
- Lint clean