### PR TITLE
Fix: emit_ui tool schema strict-mode compliance (#1032)

### DIFF
--- a/.changeset/1032-emit-ui-strict-payload.md
+++ b/.changeset/1032-emit-ui-strict-payload.md
@@ -1,0 +1,58 @@
+---
+"@aks-kickstart/pack-core": patch
+---
+
+Fix `core.emit_ui` tool schema so the OpenAI Responses API accepts it in
+strict mode (#1032). The `action.event.payload` field was serialised by the
+`@openai/agents-core` Zod-to-JSON-Schema converter as
+`{ type: 'object', additionalProperties: <scalar> }` with no `properties`
+key (the `buildRecordSchema` path for `z.record(...)`), which OpenAI strict
+mode rejects with:
+
+    400 Invalid schema for function 'core_emit_ui': In context=(), object
+    schema missing properties.
+
+This broke every conversation that registers the `emit_ui` tool (i.e. every
+core-pack conversation in the Playground and the converse endpoint).
+
+### User-visible change — schema narrowing
+
+`payload` is now a **closed object** with a fixed key set:
+
+    {
+      confirmed: boolean | null,
+      id:        string  | null,
+      value:     string | number | boolean | null,
+      action:    string  | null,
+      target:    string  | null,
+    }
+
+Unused keys MUST be set to `null`; the tool's `stripNulls()` helper
+collapses `null` → absent before `A2UIMessageSchema.parse()` as before. The
+`a2ui-output-discipline` skill's `SKILL.md` example is updated to teach this
+shape.
+
+**Intentional narrowing:** `confirmed` is the only key with existing in-repo
+usage (the emit_ui confirm-dialog test fixture). `id` / `value` / `action` /
+`target` are added as forward-looking interaction keys; they are NOT present
+in current catalog, playground, or skill payloads. Skills or prompts that
+dispatch events with payload keys outside this set will have those keys
+silently stripped (OpenAI strict + Zod `.strip()` default). Adding new keys
+requires a code change plus a test update — if the list grows past ~8
+entries, prefer a JSON-string payload parsed in `execute()` instead.
+
+### Regression coverage
+
+Two new structural tests in `packages/pack-core/src/__tests__/`:
+
+- `tool-strict-mode-conformance.test.ts` — walks every pack-core tool
+  schema and asserts OpenAI's strict-mode object invariants #1
+  (`properties` present) and #3 (`additionalProperties: false`). Includes a
+  negative control that builds a transient tool with `z.record(...)` and
+  asserts the walker flags it. Also asserts the nullable wrapper on
+  `emit_ui.action.event.payload` survives the converter (`anyOf` with
+  `type: 'null'`).
+- `skill-a2ui-output-discipline.test.ts` — guards the shipped SKILL.md so
+  the retired `"payload": { /* optional */ }` placeholder cannot come back.
+
+Closes #1032.

--- a/packages/pack-core/src/__tests__/skill-a2ui-output-discipline.test.ts
+++ b/packages/pack-core/src/__tests__/skill-a2ui-output-discipline.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @file skill-a2ui-output-discipline.test.ts
+ * @suite a2ui-output-discipline SKILL.md shape guard (#1032 / T7)
+ *
+ * The `a2ui-output-discipline` skill is shipped to the model prompt. Prior
+ * to #1032 it documented the `payload` field as an open-keyed placeholder
+ * (`"payload": { /* optional *\/ }`), which teaches the model a shape that
+ * OpenAI strict mode now forbids. After #1032 `payload` is a closed object
+ * with a fixed key set (confirmed, id, value, action, target).
+ *
+ * This test locks two invariants on the source SKILL.md:
+ *
+ *   1. The old `"payload": { /* optional *\/ }` placeholder does NOT appear
+ *      (otherwise the shipped prompt still teaches the forbidden shape).
+ *   2. At least one key from the closed set appears in the file (so we know
+ *      the example is still teaching *something* concrete).
+ *
+ * Originally requested by Nibbler (QA) on DP Amendment #1 (N6).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SKILL_PATH = resolve(here, '../skills/a2ui-output-discipline/SKILL.md');
+
+describe('a2ui-output-discipline SKILL.md — closed payload contract (#1032)', () => {
+  const source = readFileSync(SKILL_PATH, 'utf8');
+
+  it('does not contain the stale open-keyed placeholder `payload: { /* optional */ }`', () => {
+    // Match either JSON comment-style or any variant with `optional` inside
+    // the payload braces. Keeps the guard permissive so trivial reshuffles
+    // don't break it, but the #1032-retired placeholder cannot return.
+    const stale = /"payload"\s*:\s*\{\s*\/\*\s*optional\s*\*\/\s*\}/;
+    expect(source, 'SKILL.md still contains the pre-#1032 `{ /* optional */ }` payload placeholder').not.toMatch(stale);
+  });
+
+  it('mentions at least one key from the closed payload key set', () => {
+    // confirmed | id | value | action | target — any mention inside the
+    // payload example section is enough to show the closed shape is
+    // being taught.
+    const keys = ['confirmed', 'id', 'value', 'action', 'target'];
+    const found = keys.filter((k) => source.includes(`"${k}"`));
+    expect(
+      found.length,
+      'SKILL.md should illustrate the closed payload key set with at least one of: ' +
+        keys.join(', '),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/pack-core/src/__tests__/tool-strict-mode-conformance.test.ts
+++ b/packages/pack-core/src/__tests__/tool-strict-mode-conformance.test.ts
@@ -1,0 +1,221 @@
+/**
+ * @file tool-strict-mode-conformance.test.ts
+ * @suite OpenAI strict-mode schema conformance — pack-core (#1032)
+ *
+ * Regression test for #1032 ("Invalid schema for function 'core_emit_ui': In
+ * context=(), object schema missing properties."). This happened because
+ * `z.record(z.string(), X)` is serialised by
+ * `@openai/agents-core/dist/utils/zodJsonSchemaCompat.mjs` (`buildRecordSchema`)
+ * as `{ type: 'object', additionalProperties: <X> }` with NO `properties` key,
+ * which OpenAI strict mode rejects.
+ *
+ * OpenAI strict mode (structured-outputs) enforces three invariants on every
+ * `{ type: 'object' }` node of a function-tool schema:
+ *
+ *   #1  `properties` is present (an object, possibly empty). Tested here (T3).
+ *   #2  every key in `properties` appears in `required`. Already covered by
+ *       `tool-strict-required-conformance.test.ts` (#998).
+ *   #3  `additionalProperties: false` is set explicitly. Tested here (T6).
+ *
+ * The third rule is the missing invariant that would also have caught #1032
+ * at CI time (a `z.record` converts to `additionalProperties: <schema>`, not
+ * `false`). This file walks every pack-core tool schema and asserts #1 + #3,
+ * plus #1032-specific anchors:
+ *
+ *   - T5: `emit_ui.action.event.payload` retains `anyOf: [..., {type:'null'}]`
+ *         after conversion (invariant check that the nullable wrapper
+ *         survives — not a regression catch; see DP Amendment #1, N3).
+ *   - T4: negative control — a freshly-built tool with `z.record(...)` in its
+ *         parameter tree is flagged by the walker (proves we catch the exact
+ *         shape that broke #1032).
+ *
+ * Originally requested by Nibbler (QA) on DP #1032 / Amendment #1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tool } from '@openai/agents';
+import { z } from 'zod';
+import type { FunctionTool } from '@openai/agents';
+import {
+  emitUiTool,
+  fetchWebpageTool,
+  readFileTool,
+  writeFileTool,
+  listFilesTool,
+  validateArtifactsTool,
+} from '../tools/index.js';
+import { createSearchComponentsTool } from '../tools/search_components.js';
+
+// ── Walker helpers ────────────────────────────────────────────────────────────
+
+type SchemaNode = Record<string, unknown>;
+
+function isPlainObject(v: unknown): v is SchemaNode {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Walk a JSON schema and invoke `visit` at every node. `path` names the
+ * nesting (e.g. `root.properties.message.anyOf[2].properties.action`).
+ */
+function walk(node: unknown, path: string, visit: (n: SchemaNode, p: string) => void): void {
+  if (!isPlainObject(node)) return;
+  visit(node, path);
+
+  if (isPlainObject(node.properties)) {
+    for (const [key, val] of Object.entries(node.properties as SchemaNode)) {
+      walk(val, `${path}.properties.${key}`, visit);
+    }
+  }
+  if (node.items !== undefined) walk(node.items, `${path}.items`, visit);
+  if (isPlainObject(node.additionalProperties)) {
+    walk(node.additionalProperties, `${path}.additionalProperties`, visit);
+  }
+  for (const kw of ['oneOf', 'anyOf', 'allOf'] as const) {
+    if (Array.isArray(node[kw])) {
+      (node[kw] as unknown[]).forEach((sub, i) => walk(sub, `${path}.${kw}[${i}]`, visit));
+    }
+  }
+}
+
+/** T3 — invariant #1: every `type: 'object'` node has a `properties` key. */
+function collectMissingProperties(schema: unknown, path = 'root'): string[] {
+  const issues: string[] = [];
+  walk(schema, path, (n, p) => {
+    if (n.type === 'object' && !('properties' in n)) {
+      issues.push(`${p} (type=object, no 'properties' key)`);
+    }
+  });
+  return issues;
+}
+
+/** T6 — invariant #3: every `type: 'object'` node has `additionalProperties: false`. */
+function collectAdditionalPropertiesViolations(schema: unknown, path = 'root'): string[] {
+  const issues: string[] = [];
+  walk(schema, path, (n, p) => {
+    if (n.type === 'object') {
+      if (n.additionalProperties !== false) {
+        issues.push(
+          `${p} (type=object, additionalProperties=${JSON.stringify(n.additionalProperties)}; expected false)`,
+        );
+      }
+    }
+  });
+  return issues;
+}
+
+function getToolSchema(contrib: { tool: unknown }): Record<string, unknown> | null {
+  const t = contrib.tool as FunctionTool;
+  if (t.type !== 'function') return null;
+  return t.parameters as Record<string, unknown>;
+}
+
+// ── Pack-core tool roster ─────────────────────────────────────────────────────
+
+const stubRegistry = {
+  components: [{ name: 'Button', description: 'A button', schema: {} }],
+};
+
+const tools = [
+  { name: 'core.emit_ui', contrib: emitUiTool },
+  { name: 'core.fetch_webpage', contrib: fetchWebpageTool },
+  { name: 'core.read_file', contrib: readFileTool },
+  { name: 'core.write_file', contrib: writeFileTool },
+  { name: 'core.list_files', contrib: listFilesTool },
+  { name: 'core.validate_artifacts', contrib: validateArtifactsTool },
+  { name: 'core.search_components', contrib: createSearchComponentsTool(stubRegistry) },
+] as const;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('pack-core tool OpenAI strict-mode conformance (#1032)', () => {
+  // T3 — every object node has `properties`.
+  describe('T3: invariant #1 — every object node declares properties', () => {
+    for (const { name, contrib } of tools) {
+      it(`${name}: no 'type: object' node is missing 'properties'`, () => {
+        const schema = getToolSchema(contrib);
+        if (!schema) return;
+        const issues = collectMissingProperties(schema);
+        expect(
+          issues,
+          `Missing 'properties' on object nodes in ${name}:\n  - ${issues.join('\n  - ')}`,
+        ).toHaveLength(0);
+      });
+    }
+  });
+
+  // T6 — every object node has additionalProperties: false.
+  describe('T6: invariant #3 — every object node has additionalProperties:false', () => {
+    for (const { name, contrib } of tools) {
+      it(`${name}: no 'type: object' node omits additionalProperties:false`, () => {
+        const schema = getToolSchema(contrib);
+        if (!schema) return;
+        const issues = collectAdditionalPropertiesViolations(schema);
+        expect(
+          issues,
+          `additionalProperties !== false on object nodes in ${name}:\n  - ${issues.join('\n  - ')}`,
+        ).toHaveLength(0);
+      });
+    }
+  });
+
+  // T5 — emit_ui.action.event.payload retains its nullable `anyOf` wrapper.
+  //
+  // Anchored to the converter's documented behaviour
+  // (@openai/agents-core/dist/utils/zodJsonSchemaCompat.mjs / buildNullableSchema:253-256
+  // unconditionally wraps inner in `anyOf: [inner, {type:'null'}]`). We walk
+  // the real emit_ui schema and assert at least one path to a `payload` key
+  // carries the nullable wrapper. This is an invariant lint, not a regression
+  // catch — the "nullable dropped" claim from the original DP was retracted
+  // in Amendment #1 (N3).
+  it('T5: emit_ui — action.event.payload keeps anyOf[..., {type:null}] after conversion', () => {
+    const schema = getToolSchema(emitUiTool) as SchemaNode;
+    expect(schema).toBeTruthy();
+
+    const nullableHits: string[] = [];
+    walk(schema, 'root', (n, p) => {
+      if (!p.endsWith('.payload')) return;
+      // Nullable fields appear as either `anyOf: [X, {type:'null'}]` or
+      // `type: ['object', 'null']`. We accept either form.
+      const anyOfHasNull =
+        Array.isArray(n.anyOf) &&
+        (n.anyOf as SchemaNode[]).some((b) => b.type === 'null');
+      const typeArrayHasNull =
+        Array.isArray(n.type) && (n.type as unknown[]).includes('null');
+      if (anyOfHasNull || typeArrayHasNull) {
+        nullableHits.push(p);
+      }
+    });
+
+    expect(
+      nullableHits.length,
+      'emit_ui payload should carry a nullable wrapper (anyOf with type:null, or type array including null) somewhere in the schema',
+    ).toBeGreaterThan(0);
+  });
+
+  // T4 — negative control. A tool with `z.record(...)` in its parameters
+  // must be flagged by the walker for invariant #1 AND #3.
+  it('T4: negative control — z.record(...) parameter tripwire is detected', () => {
+    const badTool = tool({
+      name: 'negative_control_record',
+      description: 'Intentionally bad shape — z.record does not satisfy strict mode.',
+      parameters: z.object({
+        // This is the exact shape that broke #1032: open-keyed record.
+        bag: z.record(z.string(), z.string()),
+      }),
+      // eslint-disable-next-line @typescript-eslint/require-await
+      execute: async () => 'noop',
+    });
+    const ft = badTool as FunctionTool;
+    const schema = ft.parameters as Record<string, unknown>;
+
+    const missingProps = collectMissingProperties(schema);
+    const apViolations = collectAdditionalPropertiesViolations(schema);
+    // Either missing properties OR a non-false additionalProperties counts
+    // as a tripwire hit; in practice buildRecordSchema yields both.
+    expect(
+      missingProps.length + apViolations.length,
+      'walker must flag z.record(...) as a strict-mode violation',
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/pack-core/src/__tests__/tools/emit_ui.test.ts
+++ b/packages/pack-core/src/__tests__/tools/emit_ui.test.ts
@@ -211,7 +211,9 @@ describe('core.emit_ui', () => {
               action: { event: { name: 'cancel', payload: null } } },
             { id: 'cancel-text', component: 'Text', text: 'Cancel' },
             { id: 'ok-btn', component: 'Button', child: 'ok-text',
-              action: { event: { name: 'ok', payload: { confirmed: true } } } },
+              action: { event: { name: 'ok', payload: {
+                confirmed: true, id: null, value: null, action: null, target: null,
+              } } } },
             { id: 'ok-text', component: 'Text', text: 'OK' },
           ],
         },
@@ -245,6 +247,52 @@ describe('core.emit_ui', () => {
         },
       });
       expect(String(result)).toContain('updateComponents');
+    });
+
+    // T2.5 (#1032 / DP Amendment #1, Nibbler N5) — closed-object payload:
+    // unknown keys sent by the LLM must be silently stripped by zod BEFORE
+    // the harness sees the message. OpenAI strict mode advertises
+    // `additionalProperties: false`, but zod's default strip behaviour is
+    // what enforces the contract at runtime. This locks in the stripping
+    // semantic so a future `.passthrough()` or schema widening can't
+    // regress it without a test failure.
+    it('emit_ui: strips unknown payload keys (additionalProperties: false contract)', async () => {
+      const result = await invoke({
+        version: A2UI_VERSION,
+        op: 'updateComponents' as const,
+        updateComponents: {
+          surfaceId: 's',
+          components: [
+            { id: 'btn', component: 'Button', child: 'lbl',
+              action: { event: { name: 'ok', payload: {
+                confirmed: true,
+                id: null, value: null, action: null, target: null,
+                // Unknown key — must be stripped, must NOT end up on the
+                // recorded emission or the harness message.
+                unknownKey: 'dropped',
+              } as unknown as {
+                confirmed: boolean | null;
+                id: string | null;
+                value: unknown;
+                action: string | null;
+                target: string | null;
+              } } } },
+            { id: 'lbl', component: 'Text', text: 'OK' },
+          ],
+        },
+      });
+      expect(String(result)).toContain('updateComponents');
+      expect(session.a2uiEmissions).toHaveLength(1);
+
+      const emitted = session.a2uiEmissions[0] as {
+        updateComponents: { components: Array<Record<string, unknown>> };
+      };
+      const btn = emitted.updateComponents.components[0] as {
+        action: { event: { name: string; payload: Record<string, unknown> } };
+      };
+      // stripNulls removes the null siblings, leaving only `confirmed`.
+      expect(btn.action.event.payload).toEqual({ confirmed: true });
+      expect(btn.action.event.payload).not.toHaveProperty('unknownKey');
     });
   });
 
@@ -391,7 +439,9 @@ describe('core.emit_ui', () => {
           surfaceId: 's',
           components: [
             { id: 'btn', component: 'Button', child: 'lbl',
-              action: { event: { name: 'submit', payload: { value: 'yes' } } } },
+              action: { event: { name: 'submit', payload: {
+                confirmed: null, id: null, value: 'yes', action: null, target: null,
+              } } } },
             { id: 'lbl', component: 'Text', text: 'Submit' },
           ],
         },

--- a/packages/pack-core/src/skills/a2ui-output-discipline/SKILL.md
+++ b/packages/pack-core/src/skills/a2ui-output-discipline/SKILL.md
@@ -33,7 +33,7 @@ emit for internal state transitions that have no user-visible effect.
   "child":    "<id>",            // optional — single-slot containers (Card, Button)
   "children": ["<id>", "<id>"],  // optional — multi-slot containers (Row, Column, List)
   "text":     "<literal>",       // optional — only on Text components
-  "action":   { "event": { "name": "<event>", "payload": { /* optional */ } } }
+  "action":   { "event": { "name": "<event>", "payload": { "confirmed": true, "id": null, "value": null, "action": null, "target": null } } }
 }
 ```
 

--- a/packages/pack-core/src/tools/emit_ui.ts
+++ b/packages/pack-core/src/tools/emit_ui.ts
@@ -31,15 +31,41 @@ const A2UIDynamicNumber = z.union([
 // Action schema for interactive components.
 // Uses a flat event envelope; `payload` is nullable so null is stripped by
 // stripNulls() before runtime validation (satisfies OpenAI strict-mode required).
+//
+// #1032 — The `payload` field WAS `z.record(z.string(), A2UIScalar).nullable()`.
+// OpenAI strict mode rejects records because the converter
+// (@openai/agents-core/dist/utils/zodJsonSchemaCompat.mjs:237-242 / buildRecordSchema)
+// emits `{ type: 'object', additionalProperties: <scalar> }` with NO `properties`
+// key, which violates OpenAI's rule that every object node must declare
+// `properties` (and `additionalProperties: false`). The fix narrows `payload`
+// to a closed object with a fixed key set. Unused keys MUST be set to null
+// and are stripped by `stripNulls()` before `A2UIMessageSchema.parse()`.
+//
+// Closed key set:
+//   - `confirmed` — evidence-backed (see
+//     packages/pack-core/src/__tests__/tools/emit_ui.test.ts, existing
+//     confirm-dialog fixture).
+//   - `id`, `value`, `action`, `target` — forward-looking interaction keys.
+//     Intentional narrowing per DP Amendment #1 / Nibbler N2: not present in
+//     current repo usage. Adding new keys requires a code change + test update.
+//     If this list ever needs to grow past ~8 entries, switch to
+//     Alternative 2 (JSON-string payload parsed in execute()).
 const A2UIActionSchema = z.object({
   event: z.object({
     name: z.string().describe('Event name dispatched when the component is activated.'),
     payload: z
-      .record(z.string(), A2UIScalar)
+      .object({
+        confirmed: z.boolean().nullable(),
+        id: z.string().nullable(),
+        value: A2UIScalar.nullable(),
+        action: z.string().nullable(),
+        target: z.string().nullable(),
+      })
       .nullable()
       .describe(
-        'Flat payload (string/number/boolean/null values) delivered with the event, ' +
-          'or null when no payload is needed.',
+        'Event payload with a closed key set (confirmed, id, value, action, target). ' +
+          'Unused keys MUST be set to null. Unknown keys are stripped by OpenAI strict ' +
+          'mode + zod. See .changeset for the narrowing contract.',
       ),
   }),
 }).describe(


### PR DESCRIPTION
Closes #1032.

## Summary

Fix: `core.emit_ui` tool schema is now OpenAI strict-mode compliant. The `action.event.payload` field was serialised by `@openai/agents-core`'s Zod-to-JSON-Schema converter (`buildRecordSchema`) as `{ type: 'object', additionalProperties: <scalar> }` with no `properties` key, which OpenAI strict mode rejects at tool registration time — breaking every conversation that exposes `emit_ui`.

Narrowing `payload` from `z.record(z.string(), A2UIScalar).nullable()` to a closed `z.object({ confirmed, id, value, action, target }).nullable()` generates a strict-mode-legal schema (`properties` present, `additionalProperties: false`). Runtime semantics are unchanged — `stripNulls()` still collapses `null` → absent before `A2UIMessageSchema.parse()`.

**Design proposal:** [DP](https://github.com/sabbour/kickstart/issues/1032#issuecomment-4292394291) · [Amendment #1](https://github.com/sabbour/kickstart/issues/1032#issuecomment-4292466164) (authoritative — supersedes DP on all resolved items).
Approvals: Leela ✅, Zapp ✅, Nibbler ✅ (re-review on this PR per DP process).

## Per-file changes

| File | Change |
|---|---|
| `packages/pack-core/src/tools/emit_ui.ts` | Replace open-keyed `z.record` payload with closed `z.object({ confirmed, id, value, action, target }).nullable()`. Update block comment with root-cause + key-set rationale. |
| `packages/pack-core/src/__tests__/tools/emit_ui.test.ts` | Update two existing fixtures (`payload: { confirmed: true }` and `payload: { value: 'yes' }`) to include the full closed key set with nulls; assertions on post-`stripNulls` recorded emissions are unchanged. Add **T2.5** — unknown-key stripping negative fixture. |
| `packages/pack-core/src/__tests__/tool-strict-mode-conformance.test.ts` **(new)** | T3 (missing-`properties` walker), T6 (`additionalProperties:false` walker), T5 (nullable-wrapper invariant), T4 (`z.record` negative control). |
| `packages/pack-core/src/__tests__/skill-a2ui-output-discipline.test.ts` **(new)** | T7 — SKILL.md shape guard. Fails if the retired `"payload": { /* optional */ }` placeholder returns, or if no closed-set key is illustrated. |
| `packages/pack-core/src/skills/a2ui-output-discipline/SKILL.md` | Payload example updated to show the closed key set with nulls (per DP Amendment #1, N6). |
| `.changeset/1032-emit-ui-strict-payload.md` **(new)** | Patch-level changeset. Calls out the user-visible schema narrowing explicitly. |

## Test status matrix (T1–T7, per DP Amendment #1)

| Test | Location | Status |
|---|---|---|
| **T1** — closed payload round-trip (`{ confirmed: true, id/value/action/target: null }`) | `emit_ui.test.ts` (existing confirm-dialog fixture, updated) | ✅ pass |
| **T2** — `payload: null` stripped to absent | `emit_ui.test.ts` (existing) | ✅ pass |
| **T2.5** — unknown-key stripping negative fixture | `emit_ui.test.ts` (new) | ✅ pass |
| **T3** — invariant #1 walker: every `type:'object'` has `properties` | `tool-strict-mode-conformance.test.ts` (new) | ✅ pass (7 tools) |
| **T4** — negative control: `z.record(...)` flagged by walker | `tool-strict-mode-conformance.test.ts` (new) | ✅ pass |
| **T5** — `emit_ui.action.event.payload` keeps `anyOf[..., {type:'null'}]` | `tool-strict-mode-conformance.test.ts` (new) | ✅ pass |
| **T6** — invariant #3 walker: every `type:'object'` has `additionalProperties:false` | `tool-strict-mode-conformance.test.ts` (new) | ✅ pass (7 tools) |
| **T7** — SKILL.md shape guard (no stale placeholder, at least one closed-set key illustrated) | `skill-a2ui-output-discipline.test.ts` (new) | ✅ pass |

Local run summary: `packages/pack-core` tests — **80/80 pass** across the four affected test files. Full `CI=1 npm test -- --reporter=dot` run: 1079 pass / 2 skipped / 159 todo / 1 failing suite pre-existing (`basic-components.test.tsx` imports `@testing-library/react` which is not installed — unrelated to this PR; file unchanged by this diff).

## Docs impact

- `packages/pack-core/src/skills/a2ui-output-discipline/SKILL.md` — payload example updated (N6).
- Inline comment in `packages/pack-core/src/tools/emit_ui.ts` documents the closed-key contract and the fallback (switch to JSON-string payload if the set needs to grow past ~8 entries).
- `.changeset/1032-emit-ui-strict-payload.md` — user-visible patch-level changeset; flags that skills/prompts dispatching payload keys outside the closed set will have those keys silently stripped.
- No ADR change — this is a bugfix within an existing architectural decision.

## Honest-state notes (from DP Amendment #1)

- The DP's "nullable dropped by converter" secondary root-cause claim was **retracted** in Amendment #1 (N3). `buildNullableSchema` wraps unconditionally; T5 is therefore an invariant lint, not a regression catch.
- The forward-looking keys (`id`, `value`, `action`, `target`) are **intentional narrowing**, not catalog-derived. Documented in the inline comment, SKILL.md, and changeset.
- `ensureStrictJsonSchema` is not exported by `@openai/agents-core`; T6 is a local structural walker, not an external-validator dependency (per Amendment #1, N4).

---
🤖 Created by [sabbour-squad-backend](https://github.com/apps/sabbour-squad-backend)
