### PR TITLE
ci: add publish-mcp workflow for npmjs publishing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,46 @@
+name: Publish MCP Server
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/mcp-server/**'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (do not actually publish)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write  # required for npm provenance attestation
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Security audit
+        run: npm audit --audit-level=high
+        working-directory: packages/mcp-server
+
+      - name: Build MCP server bundle
+        run: node esbuild.config.mjs
+        working-directory: packages/mcp-server
+
+      - name: Publish to npmjs.com
+        if: ${{ !inputs.dry_run }}
+        run: npm publish --access public --provenance
+        working-directory: packages/mcp-server
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds the missing `publish-mcp.yml` GitHub Actions workflow to the default branch (`main`) so GitHub indexes it for `workflow_dispatch`.

Workflow triggers:
- `push` to `main`  
- `workflow_dispatch`

**Note:** `NPM_TOKEN` secret must be configured in repo settings before the publish will succeed. Once merged and secret is set, run: `gh workflow run publish-mcp.yml -R sabbour/kickstart`

Closes: N/A (prerequisite for `@sabbour/kickstart-mcp` npmjs publish)