### PR TITLE
docs: restructure developer guide into four cohesive sections (#441)

### DIFF
--- a/.changeset/441-docs-restructure.md
+++ b/.changeset/441-docs-restructure.md
@@ -1,0 +1,5 @@
+---
+"kickstart": patch
+---
+
+docs: restructure developer guide into four cohesive sections (onboarding, architecture, pack authoring, ops)

--- a/docs-site/docs/agent-authoring/index.md
+++ b/docs-site/docs/agent-authoring/index.md
@@ -25,7 +25,7 @@ The main conversation loop is itself an agent. Specialist agents (e.g., a dedica
 
 ## Sections
 
-- [Conversation Phases](./conversation-phases) — how phase transitions are defined and enforced
-- [Agent as Tool](./agent-as-tool) — expose one agent as a callable tool for another
-- [Runner Chain](./runner-chain) — sequence multiple agents in a pipeline
-- [Session Tokens & Resume](./resume-and-session-token) — persist state across browser refreshes and long deployments
+- [Conversation Phases](/docs/agent-authoring/conversation-phases) — how phase transitions are defined and enforced
+- [Agent as Tool](/docs/agent-authoring/agent-as-tool) — expose one agent as a callable tool for another
+- [Runner Chain](/docs/agent-authoring/runner-chain) — sequence multiple agents in a pipeline
+- [Session Tokens & Resume](/docs/agent-authoring/resume-and-session-token) — persist state across browser refreshes and long deployments

--- a/docs-site/docs/architecture/a2ui-integration.md
+++ b/docs-site/docs/architecture/a2ui-integration.md
@@ -85,7 +85,7 @@ export interface ComponentContribution {
 }
 ```
 
-See [Components → Extending A2UI](../components/extending-a2ui.md) for the full add-a-component walkthrough.
+See [Components → Extending A2UI](../architecture/extending-a2ui.md) for the full add-a-component walkthrough.
 
 ---
 
@@ -102,7 +102,7 @@ export type ConversationPhaseComponent = {
 };
 ```
 
-The phase enum (`Phase` in the same file) — `Discover → Design → Generate → Review → Handoff → Deploy` — drives the visible phase tracker. See [Conversation phases](../extending/conversation-phases.md).
+The phase enum (`Phase` in the same file) — `Discover → Design → Generate → Review → Handoff → Deploy` — drives the visible phase tracker. See [Conversation phases](../agent-authoring/conversation-phases.md).
 
 ---
 

--- a/docs-site/docs/architecture/agent-coordination.md
+++ b/docs-site/docs/architecture/agent-coordination.md
@@ -281,6 +281,6 @@ The handoff schema is enforced at CI time:
 
 ## Related
 
-- [Agent as Tool (`asTool`)](../extending/agent-as-tool.md) — API reference and detailed usage.
-- [Runner Chain](../extending/runner-chain.md) — for stateful multi-turn specialist interaction.
-- [Conversation Phases](../extending/conversation-phases.md) — lifecycle of a multi-agent conversation.
+- [Agent as Tool (`asTool`)](../agent-authoring/agent-as-tool.md) — API reference and detailed usage.
+- [Runner Chain](../agent-authoring/runner-chain.md) — for stateful multi-turn specialist interaction.
+- [Conversation Phases](../agent-authoring/conversation-phases.md) — lifecycle of a multi-agent conversation.

--- a/docs-site/docs/architecture/arm-call-flow.md
+++ b/docs-site/docs/architecture/arm-call-flow.md
@@ -182,5 +182,5 @@ body pointing callers at `armFetch` + `/api/azure/token`.
 
 ## See also
 
-- [API Endpoints — Azure integration](../extending/api-endpoints.md#azure-integration) — full HTTP surface for `/api/azure/token` and the retired `/api/arm-proxy` tombstone.
+- [API Endpoints — Azure integration](../pack-authoring/api-endpoints.md#azure-integration) — full HTTP surface for `/api/azure/token` and the retired `/api/arm-proxy` tombstone.
 - [Architecture overview](./overview.md) — how ARM calls fit the broader Five-Primitives request flow.

--- a/docs-site/docs/architecture/component-selection-framework.md
+++ b/docs-site/docs/architecture/component-selection-framework.md
@@ -265,7 +265,7 @@ Agents do not randomly pick components. The selection is guided by:
 3. Register the component in `packages/web/src/main.tsx` (add to the richComponents map or pack registration).
 4. Update the contract test in `packages/web/src/__tests__/a2ui-allow-list-registry.test.ts` to include the new component count.
 5. **If the component is intended for a new pattern**, add a recipe in `config/recipes.json` with intent, composition, and anti-patterns.
-6. Update the [Custom Catalog](../components/custom-catalog.md) documentation.
+6. Update the [Custom Catalog](../pack-authoring/custom-catalog.md) documentation.
 
 ---
 
@@ -327,7 +327,7 @@ Card[Text(h2) + Text(body) + List + Row[Button × 2]]
 
 ## Related
 
-- [Custom Kickstart Catalog](../components/custom-catalog.md) — full list of available components.
+- [Custom Kickstart Catalog](../pack-authoring/custom-catalog.md) — full list of available components.
 - [A2UI Integration](./a2ui-integration.md) — how the A2UI protocol connects to the component layer.
-- [Extending A2UI](../components/extending-a2ui.md) — building new component types.
+- [Extending A2UI](../architecture/extending-a2ui.md) — building new component types.
 - `config/recipes.json` — complete recipe database.

--- a/docs-site/docs/architecture/extending-a2ui.md
+++ b/docs-site/docs/architecture/extending-a2ui.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 This page is the end-to-end recipe for adding a new component to Kickstart's A2UI catalog: write the schema, register the renderer with the SPA, register the contribution with the harness, teach the LLM how to call it, and (optionally) wire a playground scenario.
 
-The protocol is **A2UI v0.9** — see [A2UI integration](../architecture/a2ui-integration.md) for the envelope shapes and ordering rules. The bundled catalog is documented in [Custom catalog](./custom-catalog.md).
+The protocol is **A2UI v0.9** — see [A2UI integration](./a2ui-integration.md) for the envelope shapes and ordering rules. The bundled catalog is documented in [Custom catalog](../pack-authoring/custom-catalog.md).
 
 ---
 
@@ -105,7 +105,7 @@ Register the pack in `packages/web/api/src/startup/packs.ts` and `packages/mcp-s
 
 The SPA boots a renderer registry; every component contribution's `renderer` is registered against `name`. The bundled set lives in `packages/pack-core/src/components/` and is wired during web bootstrap. Custom packs export their renderers from `packages/pack-<yourpack>/src/components/index.ts`; the SPA (`packages/web/src/main.tsx`) imports the bundle and registers them in one place.
 
-The browser learns which components exist via `GET /api/packs` (see [API endpoints](../extending/api-endpoints.md)) — the `ComponentDTO` carries the `name` and JSON-Schema-serialised `propertySchema` (no renderer code, no internal types).
+The browser learns which components exist via `GET /api/packs` (see [API endpoints](../pack-authoring/api-endpoints.md)) — the `ComponentDTO` carries the `name` and JSON-Schema-serialised `propertySchema` (no renderer code, no internal types).
 
 ---
 
@@ -142,19 +142,19 @@ export const showRegionPicker = tool({
 });
 ```
 
-The runner's post-tool a2ui drain handles ordering — the envelope is emitted *after* the LLM tool_call returns, never before. See [LLM tools](../extending/llm-tools.md).
+The runner's post-tool a2ui drain handles ordering — the envelope is emitted *after* the LLM tool_call returns, never before. See [LLM tools](../pack-authoring/llm-tools.md).
 
 ---
 
 ## Step 6 — Optional: a UserAction for confirm / cancel
 
-If your component needs a typed result (e.g. "selected region"), add a UserAction whose `confirmComponent: { component: 'mypack/RegionPicker' }` ties UI to result. See [User actions](../extending/actions.md). The runner pauses on `user_action_req`, the browser collects the result, and `/api/converse/resume` validates against `resultSchema` (the resume schema-validation gate).
+If your component needs a typed result (e.g. "selected region"), add a UserAction whose `confirmComponent: { component: 'mypack/RegionPicker' }` ties UI to result. See [User actions](../pack-authoring/actions.md). The runner pauses on `user_action_req`, the browser collects the result, and `/api/converse/resume` validates against `resultSchema` (the resume schema-validation gate).
 
 ---
 
 ## Step 7 — Optional: a playground scenario
 
-Add a `PlaygroundScenario` and a `playgroundStubs[wireName]` for any UserAction the scenario needs. Stubs only resolve when `KICKSTART_PLAYGROUND=true` and the registry's frozen stub map allows them. See [Playground scenarios](../extending/playground-scenarios.md).
+Add a `PlaygroundScenario` and a `playgroundStubs[wireName]` for any UserAction the scenario needs. Stubs only resolve when `KICKSTART_PLAYGROUND=true` and the registry's frozen stub map allows them. See [Playground scenarios](../pack-authoring/playground-scenarios.md).
 
 ---
 

--- a/docs-site/docs/architecture/harness-runtime.md
+++ b/docs-site/docs/architecture/harness-runtime.md
@@ -47,7 +47,7 @@ Defines the `Session` class plus the `sessionStore` (default in-memory) and help
 | `ANON_SESSION_TTL_MS = 10 * 60 * 1000` | 10-minute TTL on anonymous sessions. |
 | `hydrateColdSession`, `HYDRATION_DEFAULT_CAP = 20`, `HYDRATION_CONTENT_MAX_BYTES = 4096` | Cold-rehydration for sessions evicted from memory. |
 
-See [Resume & session token](../extending/resume-and-session-token.md) for the full flow.
+See [Resume & session token](../agent-authoring/resume-and-session-token.md) for the full flow.
 
 ---
 
@@ -60,7 +60,7 @@ Two abstractions:
 
 Pick the backend by setting `KICKSTART_SESSION_STORE=memory|azure-table`. `createSessionStore()` and `startEvictionScheduler()` are exported from the same module. Eviction polls `evictExpired()` every 5 minutes by default and `unref()`s the timer so the process can exit cleanly.
 
-See [Session store](../extending/session-store.md) for the full adapter contract.
+See [Session store](../pack-authoring/session-store.md) for the full adapter contract.
 
 ---
 
@@ -72,7 +72,7 @@ Exports `SSEEventType`, `SSE_EVENT_TYPES` (a `Set` so adding a new event without
 
 ## Guardrails — `runtime/guardrails.ts`
 
-The shared engine. See [Guardrails](../extending/guardrails.md) and [Safeguards](../extending/safeguards.md). Public surface:
+The shared engine. See [Guardrails](../pack-authoring/guardrails.md) and [Safeguards](../pack-authoring/safeguards.md). Public surface:
 
 - `runGuardrails(input, contributions, sseWrite?)` — sequential pipeline used at the tool stage.
 - `applyRedact(input, result)` — payload mutation for `redact` verdicts.
@@ -105,7 +105,7 @@ Companion modules: `redact.ts` (regex-based PII / secret redaction), `sanitize-e
 
 ## Resume — `runtime/resume.ts`
 
-Server-side handler shared by `web/api/src/functions/resume.ts`. Exports `ResumeHandlerInput`, `ResumeHandlerResult`, and `ClientPrincipal`. Performs three security gates in the call site: OID match against the session's user, payload schema validation, and the `KICKSTART_PLAYGROUND` gate. See [Resume & session token](../extending/resume-and-session-token.md).
+Server-side handler shared by `web/api/src/functions/resume.ts`. Exports `ResumeHandlerInput`, `ResumeHandlerResult`, and `ClientPrincipal`. Performs three security gates in the call site: OID match against the session's user, payload schema validation, and the `KICKSTART_PLAYGROUND` gate. See [Resume & session token](../agent-authoring/resume-and-session-token.md).
 
 ---
 
@@ -131,4 +131,4 @@ Server-side handler shared by `web/api/src/functions/resume.ts`. Exports `Resume
 
 ## Registry — `runtime/registry.ts`
 
-`PackRegistry` owns all contributions. Lifecycle: `register(pack)` → `enable(names)` → `seal()`. Post-seal mutations throw. `seal()` validates every handoff target across active packs (#1073), snapshots playground stubs, and reserves the `core/` namespace for the core pack. See [Packs, skills & actions](../guides/packs-and-skills.md) for usage.
+`PackRegistry` owns all contributions. Lifecycle: `register(pack)` → `enable(names)` → `seal()`. Post-seal mutations throw. `seal()` validates every handoff target across active packs (#1073), snapshots playground stubs, and reserves the `core/` namespace for the core pack. See [Packs, skills & actions](../pack-authoring/packs-and-skills.md) for usage.

--- a/docs-site/docs/architecture/mcp-server-internals.md
+++ b/docs-site/docs/architecture/mcp-server-internals.md
@@ -209,4 +209,4 @@ should not add them without an architectural review.
 ## Cross-references
 
 - [Architecture overview](./overview.md)
-- [Extending — MCP tools](../extending/mcp-tools.md)
+- [Extending — MCP tools](../pack-authoring/mcp-tools.md)

--- a/docs-site/docs/architecture/tool-usage-framework.md
+++ b/docs-site/docs/architecture/tool-usage-framework.md
@@ -249,6 +249,6 @@ export const myPackServer: Pack = {
 
 ## Related Documentation
 
-- [LLM Tools](../extending/llm-tools.md) — detailed tool interface and registry API
-- [Agent as Tool](../extending/agent-as-tool.md) — full `asTool()` API reference
-- [MCP Tools](../extending/mcp-tools.md) — exposing tools over MCP
+- [LLM Tools](../pack-authoring/llm-tools.md) — detailed tool interface and registry API
+- [Agent as Tool](../agent-authoring/agent-as-tool.md) — full `asTool()` API reference
+- [MCP Tools](../pack-authoring/mcp-tools.md) — exposing tools over MCP

--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -404,7 +404,7 @@ To add a component to the Kickstart catalog:
 
 ## Adding New Conversation Phases
 
-See [Conversation Phases](./extending/conversation-phases.md) for the full walkthrough.
+See [Conversation Phases](./agent-authoring/conversation-phases.md) for the full walkthrough.
 
 In brief:
 1. Add a new phase to the `Phase` enum in `packages/harness/src/types/`

--- a/docs-site/docs/getting-started/local-setup.md
+++ b/docs-site/docs/getting-started/local-setup.md
@@ -149,7 +149,7 @@ npm run build -w @kickstart/mcp-server
 node packages/mcp-server/dist/index.js
 ```
 
-See [MCP Tools](../extending/mcp-tools.md) for connecting to VS Code Copilot or Claude Code.
+See [MCP Tools](../pack-authoring/mcp-tools.md) for connecting to VS Code Copilot or Claude Code.
 
 ## Dev Container
 

--- a/docs-site/docs/operations/csp-enforcement.md
+++ b/docs-site/docs/operations/csp-enforcement.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 ## Canonical Enforcement Location
 
-CSP is enforced at **runtime** by **Azure Static Web Apps** via the `globalHeaders` section of [`packages/web/public/staticwebapp.config.json`](../../../../packages/web/public/staticwebapp.config.json).
+CSP is enforced at **runtime** by **Azure Static Web Apps** via the `globalHeaders` section of `packages/web/public/staticwebapp.config.json`.
 
 This is the single source of truth for the deployed CSP header. Every change to the CSP policy must be made in that file.
 
@@ -24,7 +24,7 @@ This is the single source of truth for the deployed CSP header. Every change to 
 
 A compile-time companion guard runs on every PR that touches CSP-owning files:
 
-- **Script:** [`packages/web/scripts/check-csp.mjs`](../../../../packages/web/scripts/check-csp.mjs)
+- **Script:** `packages/web/scripts/check-csp.mjs`
 - **Workflow:** `.github/workflows/csp-check.yml`
 
 The guard reads `staticwebapp.config.json`, extracts the `Content-Security-Policy` value, and validates that required directives (e.g. `connect-src https://management.azure.com`) are present. It exits non-zero on any violation, blocking the PR.
@@ -77,5 +77,5 @@ The current guard only scans `globalHeaders` in `staticwebapp.config.json`. If t
 - Parent tracking issue: #324
 - Runtime smoke check: #347
 - Scope guard extension: #348
-- CSP guard script: [`packages/web/scripts/check-csp.mjs`](../../../../packages/web/scripts/check-csp.mjs)
-- Static Web App config: [`packages/web/public/staticwebapp.config.json`](../../../../packages/web/public/staticwebapp.config.json)
+- CSP guard script: `packages/web/scripts/check-csp.mjs`
+- Static Web App config: `packages/web/public/staticwebapp.config.json`

--- a/docs-site/docs/operations/debugging.md
+++ b/docs-site/docs/operations/debugging.md
@@ -77,7 +77,7 @@ If a UserAction stalls because the browser tab closed before resuming, the sessi
 node -e "import('./packages/harness/dist/runtime/session.js').then(m => console.log(m.sessionStore.list().map(s=>({id:s.sessionId,pending:!!s.pendingUserAction}))))"
 ```
 
-Then `POST /api/converse/resume` with a synthetic result that satisfies the action's `resultSchema` (see [Resume & session token](../extending/resume-and-session-token.md)). The compare-and-swap on `pendingUserAction` means a duplicate replay safely returns `404`.
+Then `POST /api/converse/resume` with a synthetic result that satisfies the action's `resultSchema` (see [Resume & session token](../agent-authoring/resume-and-session-token.md)). The compare-and-swap on `pendingUserAction` means a duplicate replay safely returns `404`.
 
 ---
 

--- a/docs-site/docs/operations/troubleshooting.md
+++ b/docs-site/docs/operations/troubleshooting.md
@@ -12,9 +12,9 @@ Symptom-first table for the most common failures. Each row links to the underlyi
 
 | Symptom | Likely cause | Where to look |
 |---|---|---|
-| SSE stream returns `error: {code: "GUARDRAIL_BLOCK"}` | A guardrail at any stage returned `block`. SSE is opaque by design (no id, reason, or stage). | App Insights `guardrail.evaluate` span carries the rule id and (redacted) reason. See [Guardrails](../extending/guardrails.md). |
+| SSE stream returns `error: {code: "GUARDRAIL_BLOCK"}` | A guardrail at any stage returned `block`. SSE is opaque by design (no id, reason, or stage). | App Insights `guardrail.evaluate` span carries the rule id and (redacted) reason. See [Guardrails](../pack-authoring/guardrails.md). |
 | `403 Forbidden` from `/api/converse/resume` | OID from `X-MS-CLIENT-PRINCIPAL` did not match `session.user.oid` (resume principal-match gate). | `packages/web/api/src/functions/resume.ts`; verify the auth principal. |
-| `400` from `/api/converse/resume` with no useful body | `resultPayload` did not pass the action's `resultSchema` (resume schema-validation gate). | App Insights has the full sanitized parse error. See [Resume & session token](../extending/resume-and-session-token.md). |
+| `400` from `/api/converse/resume` with no useful body | `resultPayload` did not pass the action's `resultSchema` (resume schema-validation gate). | App Insights has the full sanitized parse error. See [Resume & session token](../agent-authoring/resume-and-session-token.md). |
 | `404 No pending UserAction on this session` | A prior resume already cleared `pendingUserAction` (compare-and-swap). | Concurrent retry — by-design rejection. |
 | Anon session "lost" after about 10 minutes | Anon TTL is `ANON_SESSION_TTL_MS = 10 * 60 * 1000`. | `runtime/session.ts`. Surface a fresh anon token via the `session_token` SSE event. |
 | Hydrated session is missing older turns | `HYDRATION_DEFAULT_CAP = 20` keeps the most-recent 20 turns. | Adjust before calling `hydrateColdSession`. |
@@ -28,7 +28,7 @@ Symptom-first table for the most common failures. Each row links to the underlyi
 |---|---|---|
 | API boot fails with `[mypack.foo] Zod field at … uses .optional() without .nullable()` | Strict-mode I2 violation. | Replace `.optional()` with `strictOptional()` and call `stripNulls` in the tool body. See [Schema conformance](../architecture/schema-conformance.md). |
 | Tool not visible to the LLM | Tool not in the agent's frontmatter `tools:` allowlist, or the agent is from another pack and `dependsOn` is missing. | Check the agent's `*.agent.md`; confirm `dependsOn` includes the providing pack. |
-| Tool not visible over MCP | `mcpExposed !== true` or `requiresSession === true`. | See [MCP tools](../extending/mcp-tools.md). |
+| Tool not visible over MCP | `mcpExposed !== true` or `requiresSession === true`. | See [MCP tools](../pack-authoring/mcp-tools.md). |
 | `Pack already registered: X` at boot | Duplicate `pack.name` in the bootstrap. | Remove the duplicate registration. |
 | `Cross-pack handoff rejected: agent "A" in pack "P1" declares handoff to "B" in pack "P2"` | Handoff target outside `dependsOn` and `handoffTargets`. | Add `P2` to `P1.handoffTargets` (narrow) or `P1.dependsOn` (full trust). |
 
@@ -71,7 +71,7 @@ Symptom-first table for the most common failures. Each row links to the underlyi
 |---|---|---|
 | Stuck UserAction over MCP | Interrupt TTL is `INTERRUPT_TTL_MS = 15 * 60 * 1000`. | Re-issue the request after replying or after the TTL expires. |
 | Out-of-order tool calls over MCP | Per-session mutex (`session-mutex.ts`) only orders within a session — different sessions race. | Pin the test client to one session. |
-| Tool missing from MCP manifest | `mcpExposed !== true` *or* `requiresSession === true`. | See [MCP tools](../extending/mcp-tools.md). |
+| Tool missing from MCP manifest | `mcpExposed !== true` *or* `requiresSession === true`. | See [MCP tools](../pack-authoring/mcp-tools.md). |
 
 ---
 

--- a/docs-site/docs/pack-authoring/api-endpoints.md
+++ b/docs-site/docs/pack-authoring/api-endpoints.md
@@ -122,7 +122,7 @@ For the per-turn data flow, see [Architecture overview](../architecture/overview
 > Critical 2: `resultPayload` validated against `UserAction.resultSchema` → 400.
 > Critical 3: Playground stub gate enforced in `runner.ts` (`KICKSTART_PLAYGROUND=true`).
 
-The handler also performs a **compare-and-swap** on `session.pendingUserAction` — clearing it before validation prevents a concurrent replay from re-firing the same action. See [Resume & session token](./resume-and-session-token.md) for the full flow.
+The handler also performs a **compare-and-swap** on `session.pendingUserAction` — clearing it before validation prevents a concurrent replay from re-firing the same action. See [Resume & session token](../agent-authoring/resume-and-session-token.md) for the full flow.
 
 ---
 

--- a/docs-site/docs/pack-authoring/custom-catalog.md
+++ b/docs-site/docs/pack-authoring/custom-catalog.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 The core pack contributes 27 basic Fluent overrides + 13 rich domain-neutral components. Pack-contributed catalogs add domain components (Azure resource pickers, AKS readiness cards, etc.). Every component is a `ComponentContribution` registered with the harness `PackRegistry` and rendered by the SPA's A2UI v0.9 adapter.
 
-For the protocol, see [A2UI integration](../architecture/a2ui-integration.md). For the recipe to add new ones, see [Extending the A2UI component system](./extending-a2ui.md).
+For the protocol, see [A2UI integration](../architecture/a2ui-integration.md). For the recipe to add new ones, see [Extending the A2UI component system](../architecture/extending-a2ui.md).
 
 ---
 
@@ -79,7 +79,7 @@ export type ConversationPhaseComponent = {
 };
 ```
 
-Any pack can update it via `core.emit_ui` (or via the chat-A2UI helpers in `packages/harness/src/a2ui/chat-a2ui.ts`). See [Conversation phases](../extending/conversation-phases.md).
+Any pack can update it via `core.emit_ui` (or via the chat-A2UI helpers in `packages/harness/src/a2ui/chat-a2ui.ts`). See [Conversation phases](../agent-authoring/conversation-phases.md).
 
 ---
 
@@ -107,4 +107,4 @@ The recommended pattern is:
 3. **Bind to a UserAction** when the component must produce a typed result the agent reads.
 4. **Wrap in a typed tool** when you want strict-mode validation on the entire envelope before the runner's a2ui drain emits it.
 
-See [Extending the A2UI component system](./extending-a2ui.md) for the full step-by-step.
+See [Extending the A2UI component system](../architecture/extending-a2ui.md) for the full step-by-step.

--- a/docs-site/docs/pack-authoring/llm-tools.md
+++ b/docs-site/docs/pack-authoring/llm-tools.md
@@ -81,7 +81,7 @@ tools:
 
 Tools that push UI emit A2UI envelopes. The harness queues them on `session.a2uiEmissions` during the tool call and drains the queue **after** each LLM tool_call returns (the post-tool A2UI drain rule documented at the top of `runtime/runner.ts`). This guarantees A2UI frames cannot overtake their producing tool.
 
-The canonical emission helper is `core.emit_ui`. See [Components → Extending A2UI](../components/extending-a2ui.md) for component-typed tool patterns.
+The canonical emission helper is `core.emit_ui`. See [Components → Extending A2UI](../architecture/extending-a2ui.md) for component-typed tool patterns.
 
 ---
 

--- a/docs-site/docs/pack-authoring/packs-and-skills.md
+++ b/docs-site/docs/pack-authoring/packs-and-skills.md
@@ -81,13 +81,13 @@ Resolution rules (`runtime/skill-resolver.ts`, `runtime/skill-matcher.ts`, `runt
 - `fitSkillsInBudget` is greedy with **skip-on-overshoot** semantics — a small high-priority skill ranked after a large one still gets included.
 - The per-turn skill-pull byte cap is configured via `KICKSTART_SKILL_READ_MAX_BYTES_PER_TURN` and enforced inside `core.read_skill`.
 
-Bundled core skills include `a2ui-media-discipline`, `a2ui-output-discipline`, `collaborator-voice`, `file-generation-batching`, `gen-gha-workflow`, `phase-acceleration`, `teach-then-ask`. The full inventory is the auto-generated [Skills reference](../extending/skills-reference.md).
+Bundled core skills include `a2ui-media-discipline`, `a2ui-output-discipline`, `collaborator-voice`, `file-generation-batching`, `gen-gha-workflow`, `phase-acceleration`, `teach-then-ask`. The full inventory is the auto-generated [Skills reference](./reference/skills.md).
 
 ---
 
 ## Tools
 
-`ToolContribution` (`packages/harness/src/types/tool.ts`) — full reference: [LLM tools](../extending/llm-tools.md).
+`ToolContribution` (`packages/harness/src/types/tool.ts`) — full reference: [LLM tools](./llm-tools.md).
 
 ```ts
 export interface ToolContribution {
@@ -100,13 +100,13 @@ export interface ToolContribution {
 
 Tools are *per-pack*, *per-agent-allowlist*. There is no global tool registry. Schema-strictness is enforced by `assertStrictlyConformant()` (see [Schema conformance](../architecture/schema-conformance.md)).
 
-The full inventory with MCP/session flags is the auto-generated [Tools reference](../extending/tools-reference.md).
+The full inventory with MCP/session flags is the auto-generated [Tools reference](./reference/tools.md).
 
 ---
 
 ## User actions
 
-`UserActionContribution` (`packages/harness/src/types/user-action.ts`) — full reference: [User actions](../extending/actions.md).
+`UserActionContribution` (`packages/harness/src/types/user-action.ts`) — full reference: [User actions](./actions.md).
 
 ```ts
 {
@@ -126,7 +126,7 @@ The runner pauses on `user_action_req`, the SPA / MCP client collects input, and
 
 ## Components
 
-`ComponentContribution` (`packages/harness/src/types/component.ts`) — full guide: [Custom catalog](../components/custom-catalog.md) and [Extending the A2UI component system](../components/extending-a2ui.md).
+`ComponentContribution` (`packages/harness/src/types/component.ts`) — full guide: [Custom catalog](./custom-catalog.md) and [Extending the A2UI component system](../architecture/extending-a2ui.md).
 
 ```ts
 {
@@ -141,7 +141,7 @@ The runner pauses on `user_action_req`, the SPA / MCP client collects input, and
 
 ## Guardrails
 
-`GuardrailContribution` (`packages/harness/src/types/guardrail.ts`) — full reference: [Guardrails](../extending/guardrails.md).
+`GuardrailContribution` (`packages/harness/src/types/guardrail.ts`) — full reference: [Guardrails](./guardrails.md).
 
 ```ts
 {
@@ -158,7 +158,7 @@ Engine invariants: fail-closed on throw, opaque SSE codes, `core/` always wins, 
 
 ## Playground scenarios
 
-Pack-contributed via `pack.playgroundScenarios[]` and `pack.playgroundStubs`. Surfaced to the SPA through `/api/packs` (`PlaygroundScenarioDTO`). Stubs only resolve when `KICKSTART_PLAYGROUND=true`. See [Playground scenarios](../extending/playground-scenarios.md).
+Pack-contributed via `pack.playgroundScenarios[]` and `pack.playgroundStubs`. Surfaced to the SPA through `/api/packs` (`PlaygroundScenarioDTO`). Stubs only resolve when `KICKSTART_PLAYGROUND=true`. See [Playground scenarios](./playground-scenarios.md).
 
 ---
 

--- a/docs-site/docs/pack-authoring/packs.md
+++ b/docs-site/docs/pack-authoring/packs.md
@@ -79,7 +79,7 @@ Handoffs to agents in another pack are rejected unless the source pack lists the
 2. Add agents under `src/agents/<name>.agent.md` (markdown front matter + body). See an example like `packages/pack-core/src/agents/triage.agent.md`.
 3. Add skills under `src/skills/<slug>/SKILL.md`.
 4. Add tools as `ToolContribution` objects — see [LLM tools](./llm-tools.md).
-5. Add user actions, components, and guardrails as needed — see [Actions](./actions.md), [Components → Custom catalog](../components/custom-catalog.md), and [Guardrails](./guardrails.md).
+5. Add user actions, components, and guardrails as needed — see [Actions](./actions.md), [Components → Custom catalog](./custom-catalog.md), and [Guardrails](./guardrails.md).
 6. Register the pack in the API and MCP bootstraps:
    - `packages/web/api/src/startup/packs.ts`
    - `packages/mcp-server/src/startup/packs.ts`
@@ -90,4 +90,4 @@ Handoffs to agents in another pack are rejected unless the source pack lists the
 
 ## What's auto-generated
 
-The reference pages [Tools reference](./tools-reference.md) and [Skills reference](./skills-reference.md) are produced by scripts in `docs-site/scripts/` by walking pack source files: `packages/pack-*/src/tools/*.ts` for tools and `packages/pack-*/src/skills/**/SKILL.md` (including `*.SKILL.md`) for skills. Update the source, run `npm --prefix docs-site run build`, and the docs reflect the change.
+The reference pages [Tools reference](./reference/tools.md) and [Skills reference](./reference/skills.md) are produced by scripts in `docs-site/scripts/` by walking pack source files: `packages/pack-*/src/tools/*.ts` for tools and `packages/pack-*/src/skills/**/SKILL.md` (including `*.SKILL.md`) for skills. Update the source, run `npm --prefix docs-site run build`, and the docs reflect the change.

--- a/docs-site/docs/pack-authoring/reference/skills.md
+++ b/docs-site/docs/pack-authoring/reference/skills.md
@@ -6,7 +6,7 @@ sidebar_position: 12
 
 > Auto-generated from each pack's `SKILL.md` files. Do not edit by hand — run `npm --prefix docs-site run build` (or invoke `node docs-site/scripts/generate-skills-reference.mjs` directly).
 
-See [Packs, skills & actions](../guides/packs-and-skills.md) for the resolution rules and [Prompt pipeline](../architecture/prompt-pipeline.md) for how skills are assembled into the per-turn system prompt.
+See [Packs, skills & actions](../packs-and-skills.md) for the resolution rules and [Prompt pipeline](../../architecture/prompt-pipeline.md) for how skills are assembled into the per-turn system prompt.
 
 ## core
 

--- a/docs-site/docs/pack-authoring/reference/tools.md
+++ b/docs-site/docs/pack-authoring/reference/tools.md
@@ -6,7 +6,7 @@ sidebar_position: 11
 
 > Auto-generated from each pack's `tools/*.ts` files. Do not edit by hand — run `npm --prefix docs-site run build` (or invoke `node docs-site/scripts/generate-tools-reference.mjs` directly).
 
-See [LLM tools](./llm-tools.md) for authoring guidance and [MCP tools](./mcp-tools.md) for exposure rules.
+See [LLM tools](../llm-tools.md) for authoring guidance and [MCP tools](../mcp-tools.md) for exposure rules.
 
 ## core
 

--- a/docs-site/scripts/generate-skills-reference.mjs
+++ b/docs-site/scripts/generate-skills-reference.mjs
@@ -82,7 +82,7 @@ function generate() {
   lines.push('');
   lines.push('> Auto-generated from each pack\'s `SKILL.md` files. Do not edit by hand — run `npm --prefix docs-site run build` (or invoke `node docs-site/scripts/generate-skills-reference.mjs` directly).');
   lines.push('');
-  lines.push('See [Packs, skills & actions](../guides/packs-and-skills.md) for the resolution rules and [Prompt pipeline](../architecture/prompt-pipeline.md) for how skills are assembled into the per-turn system prompt.');
+  lines.push('See [Packs, skills & actions](../packs-and-skills.md) for the resolution rules and [Prompt pipeline](../../architecture/prompt-pipeline.md) for how skills are assembled into the per-turn system prompt.');
   lines.push('');
   for (const pack of PACKS) {
     const abs = resolve(REPO_ROOT, pack.dir);

--- a/docs-site/scripts/generate-tools-reference.mjs
+++ b/docs-site/scripts/generate-tools-reference.mjs
@@ -227,7 +227,7 @@ function generate() {
   lines.push('');
   lines.push('> Auto-generated from each pack\'s `tools/*.ts` files. Do not edit by hand — run `npm --prefix docs-site run build` (or invoke `node docs-site/scripts/generate-tools-reference.mjs` directly).');
   lines.push('');
-  lines.push('See [LLM tools](./llm-tools.md) for authoring guidance and [MCP tools](./mcp-tools.md) for exposure rules.');
+  lines.push('See [LLM tools](../llm-tools.md) for authoring guidance and [MCP tools](../mcp-tools.md) for exposure rules.');
   lines.push('');
   const errors = [];
   for (const pack of PACKS) {


### PR DESCRIPTION
## Summary
Implements the approved 4-wave docs restructure from issue #441.

Closes #441

Working as Amy (Documentation)

## Changes
- **Wave 1 (Onboarding):** Rewrote intro.md as a newcomer-friendly welcome page; added Core Concepts page explaining phases, packs, harness, A2UI, and skills vs tools
- **Wave 2 (Architecture):** Reorganized architecture/* into narrative subcategories (Core Flow, Agent System, Frontend & Protocol); retired audit/; added extending-a2ui.md to the architecture section
- **Wave 3 (Extend):** Merged guides/* and extending/* into unified pack-authoring/ section; broke out agent-authoring/ for agent-specific content; updated build scripts to write generated references to new paths
- **Wave 4 (Ops):** Added missing csp-enforcement.md to operations sidebar; fixed all broken internal links across 24 files; added client-side redirects for all moved URLs

## URL Stability
Old paths redirect via Docusaurus `redirects` plugin — no dead links. Covers all moved pages from extending/, guides/, components/, and audit/.

## Build
`npm run build` passes cleanly with `[SUCCESS] Generated static files in build.`

⚠️ This task was flagged as docs restructure — please have Ahmed review the IA before merging.